### PR TITLE
fix(fusion-runtime) do not override existing merge config

### DIFF
--- a/.changeset/empty-mangos-kick.md
+++ b/.changeset/empty-mangos-kick.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/fusion-runtime': patch
+---
+
+Do not override existing merge configuration

--- a/packages/fusion-runtime/src/federation/subgraph.ts
+++ b/packages/fusion-runtime/src/federation/subgraph.ts
@@ -504,7 +504,7 @@ export function handleFederationSubschema({
   subschemaConfig.executor = function subschemaExecutor(req) {
     return onSubgraphExecute(subgraphName, req);
   };
-  
+
   return subschemaConfig;
 }
 

--- a/packages/fusion-runtime/src/federation/subgraph.ts
+++ b/packages/fusion-runtime/src/federation/subgraph.ts
@@ -455,7 +455,6 @@ export function handleFederationSubschema({
     );
   }
   if (mergeDirectiveUsed) {
-    subschemaConfig.merge = {};
     // Workaround because transformer needs the directive definition itself
     const subgraphSchemaConfig = subschemaConfig.schema.toConfig();
     subschemaConfig.schema = new GraphQLSchema({
@@ -505,7 +504,7 @@ export function handleFederationSubschema({
   subschemaConfig.executor = function subschemaExecutor(req) {
     return onSubgraphExecute(subgraphName, req);
   };
-
+  
   return subschemaConfig;
 }
 

--- a/packages/fusion-runtime/src/federation/subgraph.ts
+++ b/packages/fusion-runtime/src/federation/subgraph.ts
@@ -455,6 +455,8 @@ export function handleFederationSubschema({
     );
   }
   if (mergeDirectiveUsed) {
+    const existingMergeConfig = subschemaConfig.merge || {};
+    subschemaConfig.merge = {};
     // Workaround because transformer needs the directive definition itself
     const subgraphSchemaConfig = subschemaConfig.schema.toConfig();
     subschemaConfig.schema = new GraphQLSchema({
@@ -464,7 +466,7 @@ export function handleFederationSubschema({
     });
 
     subschemaConfig.merge =
-      stitchingDirectivesTransformer(subschemaConfig).merge;
+      Object.assign(existingMergeConfig, stitchingDirectivesTransformer(subschemaConfig).merge);
     const queryType = subschemaConfig.schema.getQueryType();
     if (!queryType) {
       throw new Error('Query type is required');

--- a/packages/fusion-runtime/src/federation/subgraph.ts
+++ b/packages/fusion-runtime/src/federation/subgraph.ts
@@ -465,8 +465,10 @@ export function handleFederationSubschema({
       assumeValid: true,
     });
 
-    subschemaConfig.merge =
-      Object.assign(existingMergeConfig, stitchingDirectivesTransformer(subschemaConfig).merge);
+    subschemaConfig.merge = Object.assign(
+      existingMergeConfig,
+      stitchingDirectivesTransformer(subschemaConfig).merge,
+    );
     const queryType = subschemaConfig.schema.getQueryType();
     if (!queryType) {
       throw new Error('Query type is required');

--- a/packages/fusion-runtime/tests/runtime.test.ts
+++ b/packages/fusion-runtime/tests/runtime.test.ts
@@ -1,144 +1,138 @@
-import { buildSubgraphSchema } from "@graphql-tools/federation";
-import { parse } from "graphql";
-import { describe, expect, it } from "vitest";
-import { composeAndGetExecutor } from "./utils";
+import { buildSubgraphSchema } from '@graphql-tools/federation';
+import { parse } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import { composeAndGetExecutor } from './utils';
 
 describe('handleFederationSubschema', () => {
-    it('combine federation merging and custom merging', async () => {
-        const users = buildSubgraphSchema({
-            typeDefs: parse(/* GraphQL */ `
+  it('combine federation merging and custom merging', async () => {
+    const users = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        directive @merge(keyField: String) on FIELD_DEFINITION
 
-                directive @merge(keyField: String) on FIELD_DEFINITION
+        type Query {
+          userById(id: ID!): User @merge(keyField: "id")
+        }
 
+        type User {
+          id: ID!
+          name: String
+          posts: [Post]
+        }
 
-                type Query {
-                    userById(id: ID!): User @merge(keyField: "id")
-                }
+        type Post @key(fields: "id") {
+          id: ID!
+          author: User
+        }
+      `),
+      resolvers: {
+        Query: {
+          userById(_root, { id }) {
+            return { id, name: `User ${id}` };
+          },
+        },
+        Post: {
+          __resolveReference(post) {
+            return { id: post.id };
+          },
+          author(post) {
+            return { id: post.id, name: `User ${post.id}` };
+          },
+        },
+        User: {
+          posts() {
+            return [{ id: '1' }];
+          },
+        },
+      },
+    });
+    const posts = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          posts: [Post]
+        }
 
-                type User {
-                    id: ID!
-                    name: String
-                    posts: [Post]
-                }
-
-                type Post @key(fields: "id") {
-                    id: ID!
-                    author: User
-                }
-
-            `),
-            resolvers: {
-                Query: {
-                    userById(_root, { id }) {
-                        return { id, name: `User ${id}` };
-                    },
-                },
-                Post: {
-                    __resolveReference(post) {
-                        return { id: post.id };
-                    },
-                    author(post) {
-                        return { id: post.id, name: `User ${post.id}` };
-                    }
-                },
-                User: {
-                    posts() {
-                        return [{ id: '1' }];
-                    }
-                },
+        type Post @key(fields: "id") {
+          id: ID!
+          title: String
+        }
+      `),
+      resolvers: {
+        Query: {
+          posts() {
+            return [{ id: '1', title: 'Post 1' }];
+          },
+        },
+        Post: {
+          __resolveReference(post) {
+            return { id: post.id };
+          },
+          title(post) {
+            return `Post ${post.id}`;
+          },
+        },
+      },
+    });
+    const executor = composeAndGetExecutor([
+      {
+        schema: users,
+        name: 'users',
+      },
+      {
+        schema: posts,
+        name: 'posts',
+      },
+    ]);
+    const result = await executor({
+      query: /* GraphQL */ `
+        query {
+          userById(id: "1") {
+            id
+            name
+            posts {
+              id
+              title
+              author {
+                id
+                name
+              }
             }
-        });
-        const posts = buildSubgraphSchema({
-            typeDefs: parse(/* GraphQL */ `
-
-                type Query {
-                    posts: [Post]
-                }
-
-                type Post @key(fields: "id") {
-                    id: ID!
-                    title: String
-                }
-
-             `),
-            resolvers: {
-                Query: {
-                    posts() {
-                        return [{ id: '1', title: 'Post 1' }];
-                    },
-                },
-                Post: {
-                    __resolveReference(post) {
-                        return { id: post.id };
-                    },
-                    title(post) {
-                        return `Post ${post.id}`;
-                    }
-                }
+          }
+          posts {
+            id
+            title
+            author {
+              id
+              name
             }
-        });
-        const executor = composeAndGetExecutor([
-            {
-                schema: users,
-                name: 'users',
+          }
+        }
+      `,
+    });
+    expect(result).toMatchObject({
+      userById: {
+        id: '1',
+        name: 'User 1',
+        posts: [
+          {
+            id: '1',
+            title: 'Post 1',
+            author: {
+              id: '1',
+              name: 'User 1',
             },
-            {
-                schema: posts,
-                name: 'posts',
-            }
-        ]);
-        const result = await executor({
-            query: /* GraphQL */ `
-                query {
-                    userById(id: "1") {
-                        id
-                        name
-                        posts {
-                            id
-                            title
-                            author {
-                                id
-                                name
-                            }
-                        }
-                    }
-                    posts {
-                        id
-                        title
-                        author {
-                            id
-                            name
-                        }
-                    }
-                }
-            `
-        });
-        expect(result).toMatchObject({
-            userById: {
-                id: '1',
-                name: 'User 1',
-                posts: [
-                    {
-                        id: '1',
-                        title: 'Post 1',
-                        author: {
-                            id: '1',
-                            name: 'User 1'
-                        },
-                    },
-                ],
-            },
-            posts: [
-                {
-                    id: '1',
-                    title: 'Post 1',
-                    author: {
-                        id: '1',
-                        name: 'User 1'
-                    },
-                },
-            ],
-        });
-
-    })
-})
+          },
+        ],
+      },
+      posts: [
+        {
+          id: '1',
+          title: 'Post 1',
+          author: {
+            id: '1',
+            name: 'User 1',
+          },
+        },
+      ],
+    });
+  });
+});

--- a/packages/fusion-runtime/tests/runtime.test.ts
+++ b/packages/fusion-runtime/tests/runtime.test.ts
@@ -1,0 +1,144 @@
+import { buildSubgraphSchema } from "@graphql-tools/federation";
+import { parse } from "graphql";
+import { describe, expect, it } from "vitest";
+import { composeAndGetExecutor } from "./utils";
+
+describe('handleFederationSubschema', () => {
+    it('combine federation merging and custom merging', async () => {
+        const users = buildSubgraphSchema({
+            typeDefs: parse(/* GraphQL */ `
+
+                directive @merge(keyField: String) on FIELD_DEFINITION
+
+
+                type Query {
+                    userById(id: ID!): User @merge(keyField: "id")
+                }
+
+                type User {
+                    id: ID!
+                    name: String
+                    posts: [Post]
+                }
+
+                type Post @key(fields: "id") {
+                    id: ID!
+                    author: User
+                }
+
+            `),
+            resolvers: {
+                Query: {
+                    userById(_root, { id }) {
+                        return { id, name: `User ${id}` };
+                    },
+                },
+                Post: {
+                    __resolveReference(post) {
+                        return { id: post.id };
+                    },
+                    author(post) {
+                        return { id: post.id, name: `User ${post.id}` };
+                    }
+                },
+                User: {
+                    posts() {
+                        return [{ id: '1' }];
+                    }
+                },
+            }
+        });
+        const posts = buildSubgraphSchema({
+            typeDefs: parse(/* GraphQL */ `
+
+                type Query {
+                    posts: [Post]
+                }
+
+                type Post @key(fields: "id") {
+                    id: ID!
+                    title: String
+                }
+
+             `),
+            resolvers: {
+                Query: {
+                    posts() {
+                        return [{ id: '1', title: 'Post 1' }];
+                    },
+                },
+                Post: {
+                    __resolveReference(post) {
+                        return { id: post.id };
+                    },
+                    title(post) {
+                        return `Post ${post.id}`;
+                    }
+                }
+            }
+        });
+        const executor = composeAndGetExecutor([
+            {
+                schema: users,
+                name: 'users',
+            },
+            {
+                schema: posts,
+                name: 'posts',
+            }
+        ]);
+        const result = await executor({
+            query: /* GraphQL */ `
+                query {
+                    userById(id: "1") {
+                        id
+                        name
+                        posts {
+                            id
+                            title
+                            author {
+                                id
+                                name
+                            }
+                        }
+                    }
+                    posts {
+                        id
+                        title
+                        author {
+                            id
+                            name
+                        }
+                    }
+                }
+            `
+        });
+        expect(result).toMatchObject({
+            userById: {
+                id: '1',
+                name: 'User 1',
+                posts: [
+                    {
+                        id: '1',
+                        title: 'Post 1',
+                        author: {
+                            id: '1',
+                            name: 'User 1'
+                        },
+                    },
+                ],
+            },
+            posts: [
+                {
+                    id: '1',
+                    title: 'Post 1',
+                    author: {
+                        id: '1',
+                        name: 'User 1'
+                    },
+                },
+            ],
+        });
+
+    })
+})


### PR DESCRIPTION
When an existing Federation subgraph is extended by Mesh with extra type merging configuration, respect both configurations instead of overriding existing Federation annotations completely.