### PR TITLE
Re-export LogLevel and DefaultLogger for easier access and logging manipulation

### DIFF
--- a/.changeset/mighty-doors-guess.md
+++ b/.changeset/mighty-doors-guess.md
@@ -1,0 +1,6 @@
+---
+'@graphql-hive/gateway': patch
+'@graphql-hive/gateway-runtime': patch
+---
+
+Re-export LogLevel and DefaultLogger for easier access and logging manipulation

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,6 +1,6 @@
 export * from './cli';
 export * from '@graphql-hive/gateway-runtime';
-export { PubSub } from '@graphql-mesh/utils';
+export { PubSub, LogLevel, DefaultLogger } from '@graphql-mesh/utils';
 export * from '@graphql-mesh/plugin-jwt-auth';
 export * from '@graphql-mesh/plugin-opentelemetry';
 export * from '@graphql-mesh/plugin-prometheus';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,5 @@
 export * from './createGatewayRuntime';
+export { LogLevel, DefaultLogger } from '@graphql-mesh/utils';
 export type * from './types';
 export * from './plugins/useCustomFetch';
 export * from './plugins/useStaticFiles';


### PR DESCRIPTION
Previously users have to first find out @graphql-mesh/utils is where the logging LogLevel comes from, then install the lib (if using strict deps) and use the LogLevel export from it.

With this change, users can simply set the LogLevel directly from the gateway without any additional imports or deps.