### PR TITLE
Generate UUID using Math as RNG keeping platform independency

### DIFF
--- a/.changeset/early-scissors-join.md
+++ b/.changeset/early-scissors-join.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Generate UUID using Math as RNG keeping platform independency

--- a/packages/runtime/src/plugins/useDelegationPlanDebug.ts
+++ b/packages/runtime/src/plugins/useDelegationPlanDebug.ts
@@ -1,8 +1,8 @@
 import type { Logger } from '@graphql-mesh/types';
 import { pathToArray } from '@graphql-tools/utils';
-import { crypto } from '@whatwg-node/fetch';
 import { print } from 'graphql';
 import type { GatewayPlugin } from '../types';
+import { generateUUID } from '../utils';
 
 export function useDelegationPlan<TContext extends Record<string, any>>(opts: {
   logger: Logger;
@@ -18,7 +18,7 @@ export function useDelegationPlan<TContext extends Record<string, any>>(opts: {
       logger = opts.logger,
     }) {
       logger = logger.child('delegation-plan');
-      const planId = crypto.randomUUID();
+      const planId = generateUUID();
       logger.debug('start', () => {
         const logObj: Record<string, any> = {
           planId,
@@ -71,7 +71,7 @@ export function useDelegationPlan<TContext extends Record<string, any>>(opts: {
       logger = opts.logger,
     }) {
       logger = logger.child('delegation-stage-execute');
-      const stageId = crypto.randomUUID();
+      const stageId = generateUUID();
       logger.debug('start', () => ({
         stageId,
         subgraph,

--- a/packages/runtime/src/plugins/useFetchDebug.ts
+++ b/packages/runtime/src/plugins/useFetchDebug.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '@graphql-mesh/types';
-import { crypto } from '@whatwg-node/fetch';
 import type { GatewayPlugin } from '../types';
+import { generateUUID } from '../utils';
 
 export function useFetchDebug<TContext extends Record<string, any>>(opts: {
   logger: Logger;
@@ -8,7 +8,7 @@ export function useFetchDebug<TContext extends Record<string, any>>(opts: {
   return {
     onFetch({ url, options, logger = opts.logger }) {
       logger = logger.child('fetch');
-      const fetchId = crypto.randomUUID();
+      const fetchId = generateUUID();
       logger.debug('request', () => ({
         fetchId,
         url,

--- a/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
+++ b/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
@@ -1,15 +1,15 @@
 import { defaultPrintFn } from '@graphql-mesh/transport-common';
 import type { Logger } from '@graphql-mesh/types';
-import { crypto } from '@whatwg-node/fetch';
 import { isAsyncIterable } from 'graphql-yoga';
 import type { GatewayPlugin } from '../types';
+import { generateUUID } from '../utils';
 
 export function useSubgraphExecuteDebug<
   TContext extends Record<string, any>,
 >(opts: { logger: Logger }): GatewayPlugin<TContext> {
   return {
     onSubgraphExecute({ executionRequest, logger = opts.logger }) {
-      const subgraphExecuteId = crypto.randomUUID();
+      const subgraphExecuteId = generateUUID();
       logger = logger.child('subgraph-execute');
       if (executionRequest) {
         logger.debug('start', () =>

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -61,3 +61,17 @@ export const defaultQueryText = /* GraphQL */ `
   #     }
   #
 `;
+
+/**
+ * Generates a v4 UUID to be used as the ID using `Math`
+ * as the random number generator.
+ *
+ * Reference: https://gist.github.com/jed/982883
+ */
+export function generateUUID() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0,
+      v = c == 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
Importing `crypto` from `@whatwg-node/fetch` adds a bunch of Node dependencies into the bundle.

Since we dont need true/secure randomness at location where we generate UUIDs, using Math as and RNG is ok.

### TODO

- [ ] Why?