### PR TITLE
Stringify less and at right positions when debugging subgraphs and fetch

### DIFF
--- a/packages/runtime/src/plugins/useDelegationPlanDebug.ts
+++ b/packages/runtime/src/plugins/useDelegationPlanDebug.ts
@@ -26,7 +26,7 @@ export function useDelegationPlan<TContext extends Record<string, any>>(opts: {
           typeName,
         };
         if (variables && Object.keys(variables).length) {
-          logObj['variables'] = JSON.stringify(variables, null, '  ');
+          logObj['variables'] = variables;
         }
         if (fragments && Object.keys(fragments).length) {
           logObj['fragments'] = Object.fromEntries(
@@ -44,7 +44,7 @@ export function useDelegationPlan<TContext extends Record<string, any>>(opts: {
         if (info?.path) {
           logObj['path'] = pathToArray(info.path).join(' | ');
         }
-        return logObj;
+        return JSON.stringify(logObj);
       });
       return ({ delegationPlan }) => {
         logger.debug('done', () => ({
@@ -72,20 +72,32 @@ export function useDelegationPlan<TContext extends Record<string, any>>(opts: {
     }) {
       logger = logger.child('delegation-stage-execute');
       const stageId = generateUUID();
-      logger.debug('start', () => ({
-        stageId,
-        subgraph,
-        typeName,
-        key: JSON.stringify(key),
-        object: JSON.stringify(object),
-        path: pathToArray(info.path).join(' | '),
-        selectionSet: print(selectionSet),
-      }));
+      logger.debug('start', () =>
+        JSON.stringify(
+          {
+            stageId,
+            subgraph,
+            typeName,
+            key,
+            object,
+            path: pathToArray(info.path).join(' | '),
+            selectionSet: print(selectionSet),
+          },
+          null,
+          '  ',
+        ),
+      );
       return ({ result }) => {
-        logger.debug('result', () => ({
-          stageId,
-          result: JSON.stringify(result, null, '  '),
-        }));
+        logger.debug('result', () =>
+          JSON.stringify(
+            {
+              stageId,
+              result,
+            },
+            null,
+            '  ',
+          ),
+        );
       };
     },
   };

--- a/packages/runtime/src/plugins/useFetchDebug.ts
+++ b/packages/runtime/src/plugins/useFetchDebug.ts
@@ -9,24 +9,31 @@ export function useFetchDebug<TContext extends Record<string, any>>(opts: {
     onFetch({ url, options, logger = opts.logger }) {
       logger = logger.child('fetch');
       const fetchId = generateUUID();
-      logger.debug('request', () => ({
-        fetchId,
-        url,
-        ...(options || {}),
-        body: options?.body && JSON.stringify(options.body, null, '  '),
-        headers:
-          options?.headers && JSON.stringify(options.headers, null, '  '),
-      }));
+      logger.debug('request', () =>
+        JSON.stringify(
+          {
+            fetchId,
+            url,
+            ...(options || {}),
+            body: options?.body,
+            headers: options?.headers,
+          },
+          null,
+          '  ',
+        ),
+      );
       return function onFetchDone({ response }) {
-        logger.debug('response', () => ({
-          fetchId,
-          status: response.status,
-          headers: JSON.stringify(
-            Object.fromEntries(response.headers.entries()),
+        logger.debug('response', () =>
+          JSON.stringify(
+            {
+              fetchId,
+              status: response.status,
+              headers: Object.fromEntries(response.headers.entries()),
+            },
             null,
             '  ',
           ),
-        }));
+        );
       };
     },
   };

--- a/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
+++ b/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
@@ -30,10 +30,16 @@ export function useSubgraphExecuteDebug<
         if (isAsyncIterable(result)) {
           return {
             onNext({ result }) {
-              logger.debug('next', () => ({
-                subgraphExecuteId,
-                result: JSON.stringify(result, null, '  '),
-              }));
+              logger.debug('next', () =>
+                JSON.stringify(
+                  {
+                    subgraphExecuteId,
+                    result,
+                  },
+                  null,
+                  '  ',
+                ),
+              );
             },
             onEnd() {
               logger.debug('end', () => ({
@@ -42,10 +48,16 @@ export function useSubgraphExecuteDebug<
             },
           };
         }
-        logger.debug('result', () => ({
-          subgraphExecuteId,
-          result: JSON.stringify(result, null, '  '),
-        }));
+        logger.debug('result', () =>
+          JSON.stringify(
+            {
+              subgraphExecuteId,
+              result,
+            },
+            null,
+            '  ',
+          ),
+        );
         return void 0;
       };
     },


### PR DESCRIPTION
Aside from the micro perf optimization of stringifying less, it looks better in logs.

👎 
<img width="1175" alt="Screenshot 2024-11-20 at 21 04 43" src="https://github.com/user-attachments/assets/33fbdfb6-6b43-4bf5-8d1a-4a669ee08250">

👍 
<img width="1174" alt="Screenshot 2024-11-20 at 21 03 53" src="https://github.com/user-attachments/assets/1780e2f3-d708-4712-aadb-958874619f9a">
