### PR TITLE
Federated queries are not correctly resolved if one of subgraphs is unavailable

### DIFF
--- a/packages/federation/tests/unavailable-subgraph/fixtures/TestEnvironment.ts
+++ b/packages/federation/tests/unavailable-subgraph/fixtures/TestEnvironment.ts
@@ -1,0 +1,68 @@
+import { createServer, Server } from 'http';
+import { getStitchedSchemaFromSupergraphSdl } from '@graphql-tools/federation';
+import { createYoga, YogaServerInstance } from 'graphql-yoga';
+import { TestSubgraph1 } from './TestSubgraph1';
+import { TestSubgraph2 } from './TestSubgraph2';
+
+export class TestEnvironment {
+  public readonly subgraph1: TestSubgraph1 = new TestSubgraph1();
+  public readonly subgraph2: TestSubgraph2 = new TestSubgraph2();
+  private yogaGateway?: Server;
+  #yoga?: YogaServerInstance<Record<string, unknown>, Record<string, unknown>>;
+  public get yoga() {
+    if (!this.#yoga) {
+      throw Error('You have to start test environment first!');
+    }
+
+    return this.#yoga;
+  }
+
+  public async start(): Promise<void> {
+    // start subgraphs
+    await Promise.all([this.subgraph1.start(), this.subgraph2.start()]);
+
+    // dynamic import is used only due to incompatibility with graphql@15
+    const { IntrospectAndCompose, RemoteGraphQLDataSource } = await import(
+      '@apollo/gateway'
+    );
+    const { supergraphSdl } = await new IntrospectAndCompose({
+      subgraphs: [
+        {
+          name: 'subgraph1',
+          url: `http://localhost:${this.subgraph1.port}/graphql`,
+        },
+        {
+          name: 'subgraph2',
+          url: `http://localhost:${this.subgraph2.port}/graphql`,
+        },
+      ],
+    }).initialize({
+      healthCheck: async () => Promise.resolve(),
+      update: () => undefined,
+      getDataSource: ({ url }) => new RemoteGraphQLDataSource({ url }),
+    });
+
+    // compose stitched schema
+    const schema = getStitchedSchemaFromSupergraphSdl({ supergraphSdl });
+
+    // start yoga geteway
+    this.#yoga = createYoga({ schema, maskedErrors: false });
+    this.yogaGateway = createServer(this.yoga);
+    await new Promise<void>((resolve) =>
+      this.yogaGateway?.listen(this.getTestPort(), () => resolve()),
+    );
+  }
+
+  public async stop(): Promise<void> {
+    // stop yoga geteway
+    await new Promise<void>((resolve, reject) =>
+      this.yogaGateway?.close((error) => (error ? reject(error) : resolve())),
+    );
+    // stop subgraphs
+    await Promise.all([this.subgraph1.stop(), this.subgraph2.stop()]);
+  }
+
+  public getTestPort(): number {
+    return parseInt(process.env['VITEST_POOL_ID'] ?? '1') + 3000;
+  }
+}

--- a/packages/federation/tests/unavailable-subgraph/fixtures/TestSubgraph1.ts
+++ b/packages/federation/tests/unavailable-subgraph/fixtures/TestSubgraph1.ts
@@ -1,0 +1,92 @@
+import { createServer, Server } from 'http';
+import { parse } from 'graphql';
+import { createGraphQLError, createYoga } from 'graphql-yoga';
+
+const typeDefs = parse(/* GraphQL */ `
+  type Query {
+    testNestedField: TestNestedField!
+  }
+
+  type TestNestedField {
+    subgraph1_Nullable: TestSubgraph1Query
+    subgraph1_NonNullable: TestSubgraph1Query!
+  }
+
+  type TestSubgraph1Query {
+    testSuccessQuery: TestUser1
+    testErrorQuery: TestUser1
+  }
+
+  type TestUser1 {
+    id: String!
+    email: String!
+    sub1: Boolean!
+  }
+`);
+
+const resolvers = {
+  Query: {
+    testNestedField: () => ({
+      subgraph1_Nullable: () => ({
+        testSuccessQuery: () => {
+          return {
+            id: 'user1',
+            email: 'user1@example.com',
+            sub1: true,
+          };
+        },
+        testErrorQuery: () => {
+          throw createGraphQLError('My original subgraph1 error!', {
+            extensions: {
+              code: 'BAD_REQUEST',
+            },
+          });
+        },
+      }),
+      subgraph1_NonNullable: () => ({
+        testSuccessQuery: () => {
+          return {
+            id: 'user1',
+            email: 'user1@example.com',
+            sub1: true,
+          };
+        },
+        testErrorQuery: () => {
+          throw createGraphQLError('My original subgraph1 error!', {
+            extensions: {
+              code: 'BAD_REQUEST',
+            },
+          });
+        },
+      }),
+    }),
+  },
+};
+
+export class TestSubgraph1 {
+  public readonly port: number = this.getTestPort() + 1000;
+  private subgraph?: Server;
+
+  public async start(): Promise<void> {
+    // dynamic import is used only due to incompatibility with graphql@15
+    const { buildSubgraphSchema } = await import('@apollo/subgraph');
+    const yoga = createYoga({
+      schema: buildSubgraphSchema({ typeDefs, resolvers }),
+    });
+    this.subgraph = createServer(yoga);
+
+    return new Promise<void>((resolve) => {
+      this.subgraph?.listen(this.port, () => resolve());
+    });
+  }
+
+  public async stop(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.subgraph?.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+
+  private getTestPort(): number {
+    return parseInt(process.env['VITEST_POOL_ID'] ?? '1') + 3000;
+  }
+}

--- a/packages/federation/tests/unavailable-subgraph/fixtures/TestSubgraph2.ts
+++ b/packages/federation/tests/unavailable-subgraph/fixtures/TestSubgraph2.ts
@@ -1,0 +1,92 @@
+import { createServer, Server } from 'http';
+import { parse } from 'graphql';
+import { createGraphQLError, createYoga } from 'graphql-yoga';
+
+const typeDefs = parse(/* GraphQL */ `
+  type Query {
+    testNestedField: TestNestedField!
+  }
+
+  type TestNestedField {
+    subgraph2_Nullable: TestSubgraph2Query
+    subgraph2_NonNullable: TestSubgraph2Query!
+  }
+
+  type TestSubgraph2Query {
+    testSuccessQuery: TestUser2
+    testErrorQuery: TestUser2
+  }
+
+  type TestUser2 {
+    id: String!
+    email: String!
+    sub2: Boolean!
+  }
+`);
+
+const resolvers = {
+  Query: {
+    testNestedField: () => ({
+      subgraph2_Nullable: () => ({
+        testSuccessQuery: () => {
+          return {
+            id: 'user2',
+            email: 'user1@example.com',
+            sub2: true,
+          };
+        },
+        testErrorQuery: () => {
+          throw createGraphQLError('My original subgraph2 error!', {
+            extensions: {
+              code: 'BAD_REQUEST',
+            },
+          });
+        },
+      }),
+      subgraph2_NonNullable: () => ({
+        testSuccessQuery: () => {
+          return {
+            id: 'user2',
+            email: 'user1@example.com',
+            sub2: true,
+          };
+        },
+        testErrorQuery: () => {
+          throw createGraphQLError('My original subgraph2 error!', {
+            extensions: {
+              code: 'BAD_REQUEST',
+            },
+          });
+        },
+      }),
+    }),
+  },
+};
+
+export class TestSubgraph2 {
+  public readonly port: number = this.getTestPort() + 2000;
+  private subgraph?: Server;
+
+  public async start(): Promise<void> {
+    // dynamic import is used only due to incompatibility with graphql@15
+    const { buildSubgraphSchema } = await import('@apollo/subgraph');
+    const yoga = createYoga({
+      schema: buildSubgraphSchema({ typeDefs, resolvers }),
+    });
+    this.subgraph = createServer(yoga);
+
+    return new Promise<void>((resolve) => {
+      this.subgraph?.listen(this.port, () => resolve());
+    });
+  }
+
+  public async stop(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.subgraph?.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+
+  private getTestPort(): number {
+    return parseInt(process.env['VITEST_POOL_ID'] ?? '1') + 3000;
+  }
+}

--- a/packages/federation/tests/unavailable-subgraph/yoga.gateway.test.ts
+++ b/packages/federation/tests/unavailable-subgraph/yoga.gateway.test.ts
@@ -1,0 +1,289 @@
+import {
+  FormattedExecutionResult,
+  GraphQLFormattedError,
+  versionInfo,
+} from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { TestEnvironment } from './fixtures/TestEnvironment';
+
+const describeIf = (condition: boolean) =>
+  condition ? describe : describe.skip;
+
+describeIf(versionInfo.major >= 16)(
+  'Yoga gateway - subgraph unavailable',
+  () => {
+    let ctx: TestEnvironment;
+
+    beforeAll(async () => {
+      ctx = new TestEnvironment();
+      await ctx.start();
+    });
+
+    afterAll(async () => {
+      await ctx.stop();
+    });
+
+    const nullableQuery = /* GraphQL */ `
+      query {
+        testNestedField {
+          subgraph1_Nullable {
+            testSuccessQuery {
+              id
+              email
+              sub1
+            }
+          }
+          subgraph2_Nullable {
+            testErrorQuery {
+              id
+              email
+              sub2
+            }
+          }
+        }
+      }
+    `;
+
+    const expectedNullableData = {
+      testNestedField: {
+        subgraph1_Nullable: {
+          testSuccessQuery: {
+            id: 'user1',
+            email: 'user1@example.com',
+            sub1: true,
+          },
+        },
+        subgraph2_Nullable: {
+          testErrorQuery: null,
+        },
+      },
+    };
+
+    const nonNullableQuery = /* GraphQL */ `
+      query {
+        testNestedField {
+          subgraph1_NonNullable {
+            testSuccessQuery {
+              id
+              email
+              sub1
+            }
+          }
+          subgraph2_NonNullable {
+            testErrorQuery {
+              id
+              email
+              sub2
+            }
+          }
+        }
+      }
+    `;
+
+    const expectedNonNullableData = {
+      testNestedField: {
+        subgraph1_NonNullable: {
+          testSuccessQuery: {
+            id: 'user1',
+            email: 'user1@example.com',
+            sub1: true,
+          },
+        },
+        subgraph2_NonNullable: {
+          testErrorQuery: null,
+        },
+      },
+    };
+
+    const expectedUnavailableErrors: GraphQLFormattedError[] = [
+      {
+        message: expect.stringMatching(
+          /^connect ECONNREFUSED (127.0.0.1|::1):\d{4}$/,
+        ),
+        path: ['testNestedField'], // path should actually be ['testNestedField', 'subgraph2_Nullable | subgraph2_NonNullable', 'testErrorQuery'],
+      },
+    ];
+
+    describe('EXPECTED RESPONSE - EVERYTHING OK', () => {
+      it('subgraph2_Nullable.testErrorQuery - receive valid error if testErrorQuery throw an error', async () => {
+        const expectedErrors: GraphQLFormattedError[] = [
+          {
+            message: 'My original subgraph2 error!',
+            path: ['testNestedField', 'subgraph2_Nullable', 'testErrorQuery'],
+          },
+        ];
+
+        const response = await ctx.yoga.fetch('http://yoga/graphql', {
+          method: 'POST',
+          body: JSON.stringify({ query: nullableQuery }),
+          headers: { 'content-type': 'application/json' },
+        });
+
+        const result: FormattedExecutionResult = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(result.data).toMatchObject(expectedNullableData);
+        expect(result.errors).toMatchObject(expectedErrors);
+      });
+
+      it('subgraph2_NonNullable.testErrorQuery - receive valid error if testErrorQuery throw an error', async () => {
+        const expectedErrors: GraphQLFormattedError[] = [
+          {
+            message: 'My original subgraph2 error!',
+            path: [
+              'testNestedField',
+              'subgraph2_NonNullable',
+              'testErrorQuery',
+            ],
+          },
+        ];
+
+        const response = await ctx.yoga.fetch('http://yoga/graphql', {
+          method: 'POST',
+          body: JSON.stringify({ query: nonNullableQuery }),
+          headers: { 'content-type': 'application/json' },
+        });
+
+        const result: FormattedExecutionResult = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(result.data).toMatchObject(expectedNonNullableData);
+        expect(result.errors).toMatchObject(expectedErrors);
+      });
+    });
+
+    describe('UNEXPECTED RESPONSE - FAILING TESTS', () => {
+      beforeAll(async () => {
+        await ctx.subgraph2.stop();
+      });
+
+      afterAll(async () => {
+        await ctx.subgraph2.start();
+      });
+
+      it('subgraph2_Nullable.testErrorQuery - subgraph2 is unavailable', async () => {
+        // it should be "expectedNullableData"
+        const unexpectedData = {
+          testNestedField: {
+            ...expectedNullableData.testNestedField,
+            subgraph2_Nullable: null,
+          },
+        };
+
+        // the "ECONNREFUSED" error got completely lost somewhere along the way !!!
+        const unexpectedErrors = undefined; // it should be "expectedUnavailableErrors"
+
+        const response = await ctx.yoga.fetch('http://yoga/graphql', {
+          method: 'POST',
+          body: JSON.stringify({ query: nullableQuery }),
+          headers: { 'content-type': 'application/json' },
+        });
+
+        const result: FormattedExecutionResult = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(result.data).toMatchObject(unexpectedData);
+        expect(result.errors).toBe(unexpectedErrors);
+      });
+
+      it('subgraph2_NonNullable.testErrorQuery - subgraph2 is unavailable', async () => {
+        const unexpectedData = null; // it should be "expectedNonNullableData"
+
+        // it should be "expectedUnavailableErrors"
+        const unexpectedErrors: GraphQLFormattedError[] = [
+          {
+            message:
+              'Cannot return null for non-nullable field TestNestedField.subgraph2_NonNullable.',
+            path: ['testNestedField', 'subgraph2_NonNullable'],
+          },
+        ];
+
+        const response = await ctx.yoga.fetch('http://yoga/graphql', {
+          method: 'POST',
+          body: JSON.stringify({ query: nonNullableQuery }),
+          headers: { 'content-type': 'application/json' },
+        });
+
+        const result: FormattedExecutionResult = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(result.data).toBe(unexpectedData);
+        expect(result.errors).toMatchObject(unexpectedErrors);
+      });
+
+      it('subgraph2_Nullable.testErrorQuery only - subgraph2 is unavailable', async () => {
+        const query = /* GraphQL */ `
+          query {
+            testNestedField {
+              subgraph2_Nullable {
+                testErrorQuery {
+                  id
+                  email
+                  sub2
+                }
+              }
+            }
+          }
+        `;
+
+        const unexpectedData = null; // it should be:
+        // const expectedNullableData = {
+        //   testNestedField: {
+        //     subgraph2_Nullable: {
+        //       testErrorQuery: null,
+        //     },
+        //   },
+        // };
+
+        const response = await ctx.yoga.fetch('http://yoga/graphql', {
+          method: 'POST',
+          body: JSON.stringify({ query }),
+          headers: { 'content-type': 'application/json' },
+        });
+
+        const result: FormattedExecutionResult = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(result.data).toBe(unexpectedData);
+        expect(result.errors).toMatchObject(expectedUnavailableErrors);
+      });
+
+      it('subgraph2_NonNullable.testErrorQuery only - subgraph2 is unavailable', async () => {
+        const query = /* GraphQL */ `
+          query {
+            testNestedField {
+              subgraph2_NonNullable {
+                testErrorQuery {
+                  id
+                  email
+                  sub2
+                }
+              }
+            }
+          }
+        `;
+
+        const unexpectedData = null; // it should be:
+        // const expectedNonNullableData = {
+        //   testNestedField: {
+        //     subgraph2_NonNullable: {
+        //       testErrorQuery: null,
+        //     },
+        //   },
+        // };
+
+        const response = await ctx.yoga.fetch('http://yoga/graphql', {
+          method: 'POST',
+          body: JSON.stringify({ query }),
+          headers: { 'content-type': 'application/json' },
+        });
+
+        const result: FormattedExecutionResult = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(result.data).toBe(unexpectedData);
+        expect(result.errors).toMatchObject(expectedUnavailableErrors);
+      });
+    });
+  },
+);


### PR DESCRIPTION
Imagine a simple federated query:
```graphql
query {
  testNestedField {
    subgraph1 { # Everything inside this field is resolved by subgraph1
      testSuccessQuery {
        id
        email
        sub1
      }
    }
    subgraph2 { # Everything inside this field is resolved by subgraph2
      testSuccessQuery {
        id
        email
        sub2
      }
    }
  }
}
```

If subraph2 is unavailable, the query should be resolved as follows:
```ts
{
  testNestedField: {
    subgraph1: {
      testSuccessQuery: {
        id: 'user1',
        email: 'user1@example.com',
        sub1: true,
      },
    },
    subgraph2: {
      testSuccessQuery: null
    },
  },
}
```

In case of a subgrah2 outage, Apollo Gateway will resolve the above-mentioned query exactly as shown in the example. Unfortunately, GraphQL Yoga used as gateway does not work properly in this case and the result is also strangely affected by non/nullable **parent** fields even if the actual query **result has always nullable type**.

I didn't find the exact location where the problem occurs, but I would guess that it's somewhere in the `@graphql-tools/executor-http` package.

**Explanation of the tests which can be found in this PR.**
The first two test cases in `describe('EXPECTED RESPONSE - EVERYTHING OK')` when subgraph2 actually returns an error from its resolver return the expected response. These are just example tests of how it should work and result should be the same even if the subgrah2 is down.

The other 4 test cases in `describe('UNEXPECTED RESPONSE - FAILING TESTS')` when subgraph2 is actually unavailable always return a different and wrong response.

- test `subgraph2_Nullable.testErrorQuery - subgraph2 is unavailable`
  - unexpected response `data` and `errors` got completely lost somewhere along the way

- test `subgraph2_NonNullable.testErrorQuery - subgraph2 is unavailable`
  - unexpected response `data` and wrong error due to **NonNullable "parent"** field (GQL result type of `testErrorQuery` **is actually nullable**)

- test `subgraph2_Nullable.testErrorQuery only - subgraph2 is unavailable`
  - unexpected response `data`, but the error is **almost correct**. Only error `path` is incomplete and should be `['testNestedField', 'subgraph2_Nullable', 'testErrorQuery']`

- test `subgraph2_NonNullable.testErrorQuery only - subgraph2 is unavailable`
  - unexpected response `data`, but the error is **almost correct**. Only error `path` is incomplete and should be `['testNestedField', 'subgraph2_NonNullable', 'testErrorQuery']`