### PR TITLE
feat(gateway): support `additionalTypeDefs`

### DIFF
--- a/.changeset/selfish-poems-allow.md
+++ b/.changeset/selfish-poems-allow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': minor
+---
+
+Support \`additionalTypeDefs\` in the gateway configuration

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -661,6 +661,9 @@ export function createGatewayRuntime<
       onSubgraphExecuteHooks,
       onDelegationPlanHooks,
       onDelegationStageExecuteHooks,
+      ...(config.additionalTypeDefs
+        ? { additionalTypeDefs: config.additionalTypeDefs }
+        : {}),
       ...((config.additionalResolvers
         ? { additionalResolvers: config.additionalResolvers }
         : {}) as IResolvers),

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -17,7 +17,11 @@ import type {
 } from '@graphql-mesh/types';
 import type { LogLevel } from '@graphql-mesh/utils';
 import type { HTTPExecutorOptions } from '@graphql-tools/executor-http';
-import type { IResolvers, ValidationRule } from '@graphql-tools/utils';
+import type {
+  IResolvers,
+  TypeSource,
+  ValidationRule,
+} from '@graphql-tools/utils';
 import type { CSRFPreventionPluginOptions } from '@graphql-yoga/plugin-csrf-prevention';
 import type { UsePersistedOperationsOptions } from '@graphql-yoga/plugin-persisted-operations';
 import type { DocumentNode, GraphQLSchema, TypeInfo } from 'graphql';
@@ -116,6 +120,10 @@ export interface GatewayConfigSubgraph<
 
 interface GatewayConfigSchemaBase<TContext extends Record<string, any>>
   extends GatewayConfigBase<TContext> {
+  /**
+   * Additional GraphQL schema type definitions.
+   */
+  additionalTypeDefs?: TypeSource;
   /**
    * Additional GraphQL schema resolvers.
    */


### PR DESCRIPTION
Support schema extensions in the gateway level, so you can extend the schema with type definitions and resolvers;

```ts
export const gatewayConfig = defineConfig({
 // ...
 additionalTypeDefs,
 additionalResolvers,
})
```