### PR TITLE
fix(batch-execute): prefix non-provided variables correctly

### DIFF
--- a/.changeset/unlucky-pillows-study.md
+++ b/.changeset/unlucky-pillows-study.md
@@ -1,0 +1,42 @@
+---
+'@graphql-tools/batch-execute': patch
+---
+
+Fix the issue that batched query generation when optional variables are not prefixed and sent correctly.
+
+See the use case below;
+
+When two batched queries are sent like below;
+
+```graphql
+query TestOne($someOptionalVar: String) {
+  foo(someOptionalArg: $someOptionalVar) {
+    id
+    name
+  }
+}
+```
+
+```graphql
+query TestTwo($someOptionalVar: String) {
+  foo(someOptionalArg: $someOptionalVar) {
+    id
+    name
+  }
+}
+```
+
+And then `someOptionalVar` is not prefixed if the value is not sent by the user. The batched queries will be sent as below, then it will cause issues.
+
+```graphql
+query TestOneTwo($someOptionalVar: String, $someOptionalVar: String) {
+  _0_foo: foo(someOptionalArg: $someOptionalVar) {
+    id
+    name
+  }
+  _1_foo: foo(someOptionalArg: $someOptionalVar) {
+    id
+    name
+  }
+}
+```

--- a/packages/batch-execute/src/mergeRequests.ts
+++ b/packages/batch-execute/src/mergeRequests.ts
@@ -174,14 +174,18 @@ function prefixRequest(
   if (executionVariables) {
     prefixedVariables = Object.create(null);
     for (const variableName in executionVariables) {
-      prefixedVariables[prefix + variableName] = executionVariables[variableName];
+      prefixedVariables[prefix + variableName] =
+        executionVariables[variableName];
     }
   }
 
   if (hasFragments) {
     prefixedDocument = {
       ...prefixedDocument,
-      definitions: prefixedDocument.definitions.filter((def) => !isFragmentDefinition(def) || fragmentSpreadImpl[def.name.value]),
+      definitions: prefixedDocument.definitions.filter(
+        (def) =>
+          !isFragmentDefinition(def) || fragmentSpreadImpl[def.name.value],
+      ),
     };
   }
 

--- a/packages/batch-execute/src/mergeRequests.ts
+++ b/packages/batch-execute/src/mergeRequests.ts
@@ -142,12 +142,19 @@ function prefixRequest(
   let prefixedDocument = aliasTopLevelFields(prefix, request.document);
 
   const executionVariableNames = Object.keys(executionVariables);
-  const hasFragmentDefinitions = request.document.definitions.some((def) =>
-    isFragmentDefinition(def),
-  );
+  let hasFragmentDefinitions = false;
+  let hasVariables = false;
+
+  for (const def of prefixedDocument.definitions) {
+    if (isFragmentDefinition(def)) {
+      hasFragmentDefinitions = true;
+    } else if (isOperationDefinition(def)) {
+      hasVariables = !!def.variableDefinitions?.length;
+    }
+  }
   const fragmentSpreadImpl: Record<string, boolean> = {};
 
-  if (executionVariableNames.length > 0 || hasFragmentDefinitions) {
+  if (hasVariables || hasFragmentDefinitions) {
     prefixedDocument = visit(prefixedDocument, {
       [Kind.VARIABLE]: prefixNode,
       [Kind.FRAGMENT_DEFINITION]: prefixNode,

--- a/packages/batch-execute/tests/batchExecute.test.ts
+++ b/packages/batch-execute/tests/batchExecute.test.ts
@@ -132,6 +132,22 @@ describe('batch execution', () => {
     expect(executorCalls).toEqual(1);
   });
 
+  it('renames input variable definitions even if no variables passed', async () => {
+    const [first, second] = (await Promise.all([
+      batchExec({
+        document: parse('query($a: String = \"1\"){ field3(input: $a) }'),
+      }),
+      batchExec({
+        document: parse('query($a: String = \"2\"){ field3(input: $a) }'),
+      }),
+    ])) as ExecutionResult[];
+
+    expect(first?.data).toEqual({ field3: '1' });
+    expect(second?.data).toEqual({ field3: '2' });
+    expect(executorVariables).toEqual({});
+    expect(executorCalls).toEqual(1);
+  });
+
   it('renames fields within inline spreads', async () => {
     const [first, second] = (await Promise.all([
       batchExec({ document: parse('{ ...on Query { field1 } }') }),


### PR DESCRIPTION
Fixes  https://github.com/graphql-hive/gateway/issues/225 that batched query generation when optional variables are not prefixed and sent correctly.

See the use case below;

When two batched queries are sent like below;

```graphql
query TestOne($someOptionalVar: String) {
  foo(someOptionalArg: $someOptionalVar) {
    id
    name
  }
}
```

```graphql
query TestTwo($someOptionalVar: String) {
  foo(someOptionalArg: $someOptionalVar) {
    id
    name
  }
}
```

And then `someOptionalVar` is not prefixed if the value is not sent by the user. The batched queries will be sent as below, then it will cause issues.

```graphql
query TestOneTwo($someOptionalVar: String, $someOptionalVar: String) {
  _0_foo: foo(someOptionalArg: $someOptionalVar) {
    id
    name
  }
  _1_foo: foo(someOptionalArg: $someOptionalVar) {
    id
    name
  }
}
```