### PR TITLE
fix(delegate): do not forward non-nullability errors to the gateway

### DIFF
--- a/.changeset/slow-cars-mate.md
+++ b/.changeset/slow-cars-mate.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+Do not show internal non-nullability errors in the gateway

--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -147,7 +147,18 @@ export function handleResolverResult(
     for (const [responseKey, fieldNodes] of fields) {
       const combinedPath = [...path, responseKey];
       if (resolverResult instanceof GraphQLError) {
-        nullResult[responseKey] = relocatedError(resolverResult, combinedPath);
+        if (
+          resolverResult.message.includes(
+            'Cannot return null for non-nullable field',
+          )
+        ) {
+          nullResult[responseKey] = null;
+        } else {
+          nullResult[responseKey] = relocatedError(
+            resolverResult,
+            combinedPath,
+          );
+        }
       } else if (resolverResult instanceof Error) {
         nullResult[responseKey] = locatedError(
           resolverResult,

--- a/packages/stitch/tests/mergeFailures.test.ts
+++ b/packages/stitch/tests/mergeFailures.test.ts
@@ -240,7 +240,7 @@ describe('merge failures', () => {
       data: { thing: null },
       errors: [
         createGraphQLError(
-          'Cannot return null for non-nullable field Thing.id.',
+          'Cannot return null for non-nullable field Thing.description.',
         ),
       ],
     };


### PR DESCRIPTION
Do not forward unnecessary post-execution validation errors to the gateway, stitched schema will already handle post-execution validation of non-nullability etc.