### PR TITLE
enhance(stitch): validate given selection sets

### DIFF
--- a/.changeset/large-tigers-design.md
+++ b/.changeset/large-tigers-design.md
@@ -1,0 +1,37 @@
+---
+'@graphql-tools/stitch': patch
+---
+
+Validation of required selection sets in the additional resolvers and type merging configuration
+
+```ts
+stitchSchemas({
+    resolvers: {
+        Book: {
+            title: {
+                // This resolver will throw an error if the selection set does not contain the `nonExistingFieldInBook` field
+                // Stitching validates the selection set of the field resolver
+                selectionSet: '{ nonExistingFieldInBook }',
+                resolve() {
+
+                }
+            }
+        }
+    },
+    merge: {
+        Book: {
+            // This configuration will throw an error if the selection set does not contain the `nonExistingFieldInBook` field
+            // Stitching validates the selection set of the type merging configuration
+            selectionSet: '{ nonExistingFieldInBook }',
+            fields: {
+                title: {
+                    // This configuration will throw an error if the selection set does not contain the `nonExistingFieldInBook` field
+                    // Stitching validates the selection set of the field configuration
+                    selectionSet: '{ nonExistingFieldInBook }',
+                    fieldName: 'title'
+                }
+            }
+        }
+    }
+})
+```

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -90,9 +90,12 @@ export function stitchSchemas<
     mergeDirectives,
   });
 
+  const errors: Error[] = [];
+
   let stitchingInfo = createStitchingInfo(
     subschemaMap,
     typeCandidates,
+    errors,
     mergeTypes,
   );
 
@@ -131,7 +134,22 @@ export function stitchSchemas<
     ? extendResolversFromInterfaces(schema, resolverMap)
     : resolverMap;
 
-  stitchingInfo = completeStitchingInfo(stitchingInfo, finalResolvers, schema);
+  stitchingInfo = completeStitchingInfo(
+    stitchingInfo,
+    finalResolvers,
+    schema,
+    errors,
+  );
+
+  if (errors.length > 0) {
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    throw new AggregateError(
+      errors,
+      `Encountered ${errors.length} errors while validating stitching configuration;\n${errors.map((err) => err.message)}`,
+    );
+  }
 
   schema = addResolversToSchema({
     schema,


### PR DESCRIPTION
Validation of required selection sets in the additional resolvers and type merging configuration

```ts
stitchSchemas({
    resolvers: {
        Book: {
            title: {
                // This resolver will throw an error if the selection set does not contain the `nonExistingFieldInBook` field
                // Stitching validates the selection set of the field resolver
                selectionSet: '{ nonExistingFieldInBook }',
                resolve() {

                }
            }
        }
    },
    merge: {
        Book: {
            // This configuration will throw an error if the selection set does not contain the `nonExistingFieldInBook` field
            // Stitching validates the selection set of the type merging configuration
            selectionSet: '{ nonExistingFieldInBook }',
            fields: {
                title: {
                    // This configuration will throw an error if the selection set does not contain the `nonExistingFieldInBook` field
                    // Stitching validates the selection set of the field configuration
                    selectionSet: '{ nonExistingFieldInBook }',
                }
            }
        }
    }
})
```