### PR TITLE
fix(runtime): avoid `require` directly but use `globalThis.require`

### DIFF
--- a/.changeset/tall-games-destroy.md
+++ b/.changeset/tall-games-destroy.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/fusion-runtime': patch
+---
+
+Do not use require explicitly

--- a/.changeset/thick-files-end.md
+++ b/.changeset/thick-files-end.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/fusion-runtime': patch
+---
+
+Avoid \`require\` but use \`globalThis.require\` instead

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -68,20 +68,24 @@ function tryImportThenRequireTransport(
       );
     }
   }
+  function tryRequire(moduleName: string, e: unknown) {
+    if (!globalThis.require) {
+      throw e;
+    }
+    try {
+      return globalThis.require(moduleName);
+    } catch (e) {
+      handleModuleNotFoundError(e);
+      throw e;
+    }
+  }
   try {
     return mapMaybePromise(
       import(moduleName),
       (transport) => transport,
       (e) => {
         handleModuleNotFoundError(e);
-        return mapMaybePromise(
-          require(moduleName),
-          (transport) => transport,
-          (e) => {
-            handleModuleNotFoundError(e);
-            throw e;
-          },
-        );
+        return tryRequire(moduleName, e);
       },
     );
   } catch (e) {


### PR DESCRIPTION
`require` causes rollup to create `createRequire` statement etc.
Just use \`globalThis.require\` if exists