### PR TITLE
fix(runtime): use `require` in CJS build

### DIFF
--- a/.changeset/calm-dragons-nail.md
+++ b/.changeset/calm-dragons-nail.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/fusion-runtime': patch
+---
+
+Use \`require\` directly on CommonJS

--- a/packages/fusion-runtime/package.json
+++ b/packages/fusion-runtime/package.json
@@ -36,7 +36,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "pkgroll --clean-dist",
+    "build": "pkgroll --clean-dist && node scripts/replace-import-with-require.mjs",
     "prepack": "yarn build"
   },
   "peerDependencies": {

--- a/packages/fusion-runtime/scripts/replace-import-with-require.mjs
+++ b/packages/fusion-runtime/scripts/replace-import-with-require.mjs
@@ -1,0 +1,6 @@
+import fs from 'node:fs';
+
+const cjsFile = './dist/index.cjs';
+const fileContent = fs.readFileSync(cjsFile, 'utf8');
+const newContent = fileContent.replace('import(kind)', 'require(kind)');
+fs.writeFileSync(cjsFile, newContent, 'utf8');

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -52,7 +52,7 @@ export type Transports =
     }
   | ((kind: string) => MaybePromise<Transport | { default: Transport }>);
 
-async function defaultTransportsGetter(kind: string): Promise<Transport> {
+function defaultTransportsGetter(kind: string): Promise<Transport> {
   return mapMaybePromise(import(kind), (transport) => {
     if (typeof transport !== 'object') {
       throw new Error(

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -53,23 +53,22 @@ export type Transports =
   | ((kind: string) => MaybePromise<Transport | { default: Transport }>);
 
 function defaultTransportsGetter(kind: string): Promise<Transport> {
-  return mapMaybePromise(import(kind), (transport) => {
+  const moduleName = `@graphql-mesh/transport-${kind}`;
+  return mapMaybePromise(import(moduleName), (transport) => {
     if (typeof transport !== 'object') {
-      throw new Error(
-        `@graphql-mesh/transport-${kind} module does not export an object`,
-      );
+      throw new Error(`${moduleName} module does not export an object`);
     }
     if (transport?.default?.getSubgraphExecutor) {
       transport = transport.default;
     }
     if (!transport?.getSubgraphExecutor) {
       throw new Error(
-        `@graphql-mesh/transport-${kind} module does not export "getSubgraphExecutor"`,
+        `${moduleName} module does not export "getSubgraphExecutor"`,
       );
     }
     if (typeof transport?.getSubgraphExecutor !== 'function') {
       throw new Error(
-        `@graphql-mesh/transport-${kind} module's export "getSubgraphExecutor" is not a function`,
+        `${moduleName} module's export "getSubgraphExecutor" is not a function`,
       );
     }
     return transport;


### PR DESCRIPTION
Always use \`require\` in CJS builds to avoid confusion between \`import\` and \`require\`.
Environments like Jest etc do not support \`import\` on built CJS files in node_modules.