### PR TITLE
enhance(cli): load `node:http(s)` easily to allow tracing instrumentations to attach

### DIFF
--- a/.changeset/dirty-parrots-smash.md
+++ b/.changeset/dirty-parrots-smash.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+Load \`node:http\` and \`node:https\` lazily so that instrumentations of tracing/metrics tools can attach easily such as Sentry, AppDynamic etc

--- a/packages/gateway/src/servers/bun.ts
+++ b/packages/gateway/src/servers/bun.ts
@@ -1,8 +1,9 @@
 import type { Server, TLSServeOptions, WebSocketServeOptions } from 'bun';
 import type { Extra } from 'graphql-ws/lib/use/bun';
-import { defaultOptions, GatewayRuntime } from '..';
 import { getGraphQLWSOptions } from './graphqlWs';
 import type { ServerForRuntimeOptions } from './types';
+import { defaultOptions } from '../cli';
+import { GatewayRuntime } from '@graphql-hive/gateway-runtime';
 
 export async function startBunServer<TContext extends Record<string, any>>(
   gwRuntime: GatewayRuntime<TContext>,

--- a/packages/gateway/src/servers/bun.ts
+++ b/packages/gateway/src/servers/bun.ts
@@ -1,9 +1,9 @@
+import { GatewayRuntime } from '@graphql-hive/gateway-runtime';
 import type { Server, TLSServeOptions, WebSocketServeOptions } from 'bun';
 import type { Extra } from 'graphql-ws/lib/use/bun';
+import { defaultOptions } from '../cli';
 import { getGraphQLWSOptions } from './graphqlWs';
 import type { ServerForRuntimeOptions } from './types';
-import { defaultOptions } from '../cli';
-import { GatewayRuntime } from '@graphql-hive/gateway-runtime';
 
 export async function startBunServer<TContext extends Record<string, any>>(
   gwRuntime: GatewayRuntime<TContext>,

--- a/packages/gateway/src/servers/graphqlWs.ts
+++ b/packages/gateway/src/servers/graphqlWs.ts
@@ -1,15 +1,18 @@
 // yoga's envelop may augment the `execute` and `subscribe` operations
 
+import { GetEnvelopedFn } from '@envelop/core';
 import type { GatewayRuntime } from '@graphql-hive/gateway-runtime';
 import { MaybePromise } from '@graphql-tools/utils';
-import { execute, subscribe, type ExecutionArgs } from 'graphql';
+import { type ExecutionArgs } from 'graphql';
 import type { ConnectionInitMessage, Context, ServerOptions } from 'graphql-ws';
+
+type Envelope = ReturnType<GetEnvelopedFn<unknown>>;
 
 // so we need to make sure we always use the freshest instance
 type EnvelopedExecutionArgs = ExecutionArgs & {
   rootValue: {
-    execute: typeof execute;
-    subscribe: typeof subscribe;
+    execute: Envelope['execute'];
+    subscribe: Envelope['subscribe'];
   };
 };
 

--- a/packages/gateway/src/servers/nodeHttp.ts
+++ b/packages/gateway/src/servers/nodeHttp.ts
@@ -1,6 +1,5 @@
 import { promises as fsPromises } from 'node:fs';
-import { createServer as createHTTPServer, type Server } from 'node:http';
-import { createServer as createHTTPSServer } from 'node:https';
+import type { Server } from 'node:http';
 import type { SecureContextOptions } from 'node:tls';
 import type { GatewayRuntime } from '@graphql-hive/gateway-runtime';
 import type { Extra } from 'graphql-ws/lib/use/ws';
@@ -56,7 +55,8 @@ export async function startNodeHttpServer<TContext extends Record<string, any>>(
     if (sslCredentials.ssl_prefer_low_memory_usage) {
       sslOptionsForNodeHttp.honorCipherOrder = true;
     }
-    server = createHTTPSServer(
+    const { createServer } = await import('node:https');
+    server = createServer(
       {
         ...sslOptionsForNodeHttp,
         maxHeaderSize,
@@ -66,7 +66,8 @@ export async function startNodeHttpServer<TContext extends Record<string, any>>(
     );
   } else {
     protocol = 'http';
-    server = createHTTPServer(
+    const { createServer } = await import('node:http');
+    server = createServer(
       {
         maxHeaderSize,
         requestTimeout,

--- a/packages/gateway/src/servers/startServerForRuntime.ts
+++ b/packages/gateway/src/servers/startServerForRuntime.ts
@@ -1,8 +1,6 @@
 import type { GatewayRuntime } from '@graphql-hive/gateway-runtime';
-import { MaybePromise } from '@graphql-tools/utils';
+import type { MaybePromise } from '@graphql-tools/utils';
 import { defaultOptions } from '../cli';
-import { startBunServer } from './bun';
-import { startNodeHttpServer } from './nodeHttp';
 import { ServerForRuntimeOptions } from './types';
 
 export function startServerForRuntime<
@@ -34,7 +32,8 @@ export function startServerForRuntime<
     ...(sslCredentials ? { sslCredentials } : {}),
   };
 
-  const startServer = globalThis.Bun ? startBunServer : startNodeHttpServer;
-
-  return startServer(runtime, serverOpts);
+  if (globalThis.Bun) {
+    return import('./bun').then(({ startBunServer }) => startBunServer(runtime, serverOpts));
+  }
+  return import('./nodeHttp').then(({ startNodeHttpServer }) => startNodeHttpServer(runtime, serverOpts));
 }

--- a/packages/gateway/src/servers/startServerForRuntime.ts
+++ b/packages/gateway/src/servers/startServerForRuntime.ts
@@ -33,7 +33,11 @@ export function startServerForRuntime<
   };
 
   if (globalThis.Bun) {
-    return import('./bun').then(({ startBunServer }) => startBunServer(runtime, serverOpts));
+    return import('./bun').then(({ startBunServer }) =>
+      startBunServer(runtime, serverOpts),
+    );
   }
-  return import('./nodeHttp').then(({ startNodeHttpServer }) => startNodeHttpServer(runtime, serverOpts));
+  return import('./nodeHttp').then(({ startNodeHttpServer }) =>
+    startNodeHttpServer(runtime, serverOpts),
+  );
 }


### PR DESCRIPTION
Sentry, AppDynamic etc need to be loaded before the configuration loaded, so they can hook into `node:http(s)`.
This PR replaces the static imports of `node:http(s)`  into dynamic ones.

[ ] - Needs a use case tested via E2E Tests @EmrysMyrddin 