### PR TITLE
`@cacheControl` support tests, fixes...

### DIFF
--- a/.changeset/tricky-paws-walk.md
+++ b/.changeset/tricky-paws-walk.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/federation': patch
+---
+
+Keep the custom directives(using @composeDirective) from the supergraph, in the unified schema served by the gateway should keep it.

--- a/examples/apq-subgraphs/package-lock.json
+++ b/examples/apq-subgraphs/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@example/apq-subgraphs",
       "dependencies": {
         "@apollo/server": "^4.11.2",
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "graphql": "^16.9.0",
         "tslib": "^2.8.1"
@@ -1301,9 +1301,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4816,9 +4816,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/apq-subgraphs/package.json
+++ b/examples/apq-subgraphs/package.json
@@ -9,7 +9,7 @@
     "@graphql-mesh/compose-cli": "^1.2.13",
     "graphql": "^16.9.0",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "scripts": {
     "service:greetings": "tsx services/greetings.ts",

--- a/examples/extra-fields/package-lock.json
+++ b/examples/extra-fields/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/extra-fields",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "graphql": "^16.9.0",
         "graphql-yoga": "^5.10.6",
@@ -1088,9 +1088,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4231,9 +4231,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/extra-fields/package.json
+++ b/examples/extra-fields/package.json
@@ -6,7 +6,7 @@
     "graphql": "^16.9.0",
     "graphql-yoga": "^5.10.6",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/examples/federation-example/package-lock.json
+++ b/examples/federation-example/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@apollo/server": "^4.10.3",
         "@apollo/subgraph": "^2.7.2",
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "graphql": "^16.9.0"
       },
       "devDependencies": {
@@ -1363,9 +1363,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4788,9 +4788,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/federation-example/package.json
+++ b/examples/federation-example/package.json
@@ -9,7 +9,7 @@
     "@apollo/server": "^4.10.3",
     "@apollo/subgraph": "^2.7.2",
     "graphql": "^16.9.0",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "scripts": {
     "service:accounts": "tsx services/accounts/index.ts",

--- a/examples/federation-mixed/package-lock.json
+++ b/examples/federation-mixed/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/federation-mixed",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "@omnigraph/openapi": "^0.108.6",
         "graphql": "^16.9.0",
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4500,9 +4500,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/federation-mixed/package.json
+++ b/examples/federation-mixed/package.json
@@ -6,7 +6,7 @@
     "@omnigraph/openapi": "^0.108.6",
     "graphql": "^16.9.0",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/federation-subscriptions-passthrough/package-lock.json
+++ b/examples/federation-subscriptions-passthrough/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/federation-subscriptions-passthrough",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/transport-ws": "^0.4.15",
         "@whatwg-node/fetch": "^0.10.1",
         "graphql": "^16.9.0",
@@ -1116,9 +1116,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -3992,9 +3992,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/federation-subscriptions-passthrough/package.json
+++ b/examples/federation-subscriptions-passthrough/package.json
@@ -6,7 +6,7 @@
     "@whatwg-node/fetch": "^0.10.1",
     "graphql": "^16.9.0",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/examples/file-upload/package-lock.json
+++ b/examples/file-upload/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/file-upload",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "graphql": "^16.9.0",
         "tslib": "^2.8.1"
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4230,9 +4230,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/file-upload/package.json
+++ b/examples/file-upload/package.json
@@ -5,7 +5,7 @@
     "@graphql-mesh/compose-cli": "^1.2.13",
     "graphql": "^16.9.0",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/examples/hmac-auth-https/package-lock.json
+++ b/examples/hmac-auth-https/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/server": "^4.10.3",
         "@apollo/subgraph": "^2.9.3",
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.3.3",
         "@graphql-mesh/hmac-upstream-signature": "^1.2.19",
         "@graphql-mesh/plugin-jwt-auth": "^1.4.0",
@@ -1340,9 +1340,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4865,9 +4865,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/hmac-auth-https/package.json
+++ b/examples/hmac-auth-https/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@apollo/server": "^4.10.3",
     "@apollo/subgraph": "^2.9.3",
-    "@graphql-hive/gateway": "^1.7.6",
+    "@graphql-hive/gateway": "^1.7.7",
     "@graphql-mesh/compose-cli": "^1.3.3",
     "@graphql-mesh/hmac-upstream-signature": "^1.2.19",
     "@graphql-mesh/plugin-jwt-auth": "^1.4.0",

--- a/examples/interface-additional-resolvers/package-lock.json
+++ b/examples/interface-additional-resolvers/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/interface-additional-resolvers",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "graphql": "^16.9.0",
         "graphql-yoga": "^5.10.6",
@@ -1088,9 +1088,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4231,9 +4231,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/interface-additional-resolvers/package.json
+++ b/examples/interface-additional-resolvers/package.json
@@ -6,7 +6,7 @@
     "graphql": "^16.9.0",
     "graphql-yoga": "^5.10.6",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/examples/json-schema-subscriptions/package-lock.json
+++ b/examples/json-schema-subscriptions/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/json-schema-subscriptions",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "@graphql-mesh/cross-helpers": "^0.4.9",
         "@graphql-mesh/plugin-live-query": "^0.103.0",
@@ -1112,9 +1112,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4412,9 +4412,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/json-schema-subscriptions/package.json
+++ b/examples/json-schema-subscriptions/package.json
@@ -10,7 +10,7 @@
     "graphql": "^16.9.0",
     "graphql-sse": "^2.5.3",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/examples/openapi-additional-resolvers/package-lock.json
+++ b/examples/openapi-additional-resolvers/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/openapi-additional-resolvers",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "@omnigraph/openapi": "^0.108.6",
         "graphql": "^16.9.0",
@@ -678,9 +678,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -3928,9 +3928,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/openapi-additional-resolvers/package.json
+++ b/examples/openapi-additional-resolvers/package.json
@@ -7,7 +7,7 @@
     "graphql": "^16.9.0",
     "moment": "^2.30.1",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "scripts": {
     "compose": "mesh-compose -o supergraph.graphql",

--- a/examples/openapi-arg-rename/package-lock.json
+++ b/examples/openapi-arg-rename/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/openapi-arg-rename",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "@omnigraph/openapi": "^0.108.6",
         "graphql": "16.10.0",
@@ -1089,9 +1089,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4339,9 +4339,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/openapi-arg-rename/package.json
+++ b/examples/openapi-arg-rename/package.json
@@ -7,7 +7,7 @@
     "graphql": "16.10.0",
     "moment": "2.30.1",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/examples/openapi-javascript-wiki/package-lock.json
+++ b/examples/openapi-javascript-wiki/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/openapi-javascript-wiki",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "@omnigraph/openapi": "^0.108.6",
         "graphql": "^16.9.0",
@@ -678,9 +678,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -3928,9 +3928,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/openapi-javascript-wiki/package.json
+++ b/examples/openapi-javascript-wiki/package.json
@@ -7,7 +7,7 @@
     "graphql": "^16.9.0",
     "moment": "^2.30.1",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "scripts": {
     "compose": "mesh-compose -o supergraph.graphql",

--- a/examples/openapi-subscriptions/package-lock.json
+++ b/examples/openapi-subscriptions/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/openapi-subscriptions",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "@omnigraph/openapi": "^0.108.6",
         "fets": "^0.8.4",
@@ -1091,9 +1091,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4359,9 +4359,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/openapi-subscriptions/package.json
+++ b/examples/openapi-subscriptions/package.json
@@ -9,7 +9,7 @@
     "graphql-sse": "^2.5.3",
     "tslib": "^2.8.1",
     "url-join": "^5.0.0",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/examples/operation-field-permissions/package-lock.json
+++ b/examples/operation-field-permissions/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@envelop/core": "^5.0.2",
         "@envelop/operation-field-permissions": "^6.0.0",
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "graphql": "^16.10.0"
       },
@@ -1105,9 +1105,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4248,9 +4248,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/operation-field-permissions/package.json
+++ b/examples/operation-field-permissions/package.json
@@ -6,7 +6,7 @@
     "@envelop/operation-field-permissions": "^6.0.0",
     "@graphql-mesh/compose-cli": "^1.2.13",
     "graphql": "^16.10.0",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/examples/programmatic-batching/package-lock.json
+++ b/examples/programmatic-batching/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/programmatic-batching",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "@omnigraph/openapi": "^0.108.6",
         "fets": "^0.8.4",
@@ -1089,9 +1089,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4345,9 +4345,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/programmatic-batching/package.json
+++ b/examples/programmatic-batching/package.json
@@ -7,7 +7,7 @@
     "fets": "^0.8.4",
     "graphql": "16.10.0",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/examples/subscriptions-with-transforms/package-lock.json
+++ b/examples/subscriptions-with-transforms/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/subscriptions-with-transforms",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "graphql": "16.10.0",
         "graphql-sse": "^2.5.3",
@@ -1089,9 +1089,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4232,9 +4232,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/subscriptions-with-transforms/package.json
+++ b/examples/subscriptions-with-transforms/package.json
@@ -7,7 +7,7 @@
     "graphql-sse": "^2.5.3",
     "graphql-yoga": "^5.10.6",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/examples/type-merging-batching/package-lock.json
+++ b/examples/type-merging-batching/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@example/type-merging-batching",
       "dependencies": {
-        "@graphql-hive/gateway": "^1.7.6",
+        "@graphql-hive/gateway": "^1.7.7",
         "@graphql-mesh/compose-cli": "^1.2.13",
         "graphql": "^16.9.0",
         "graphql-yoga": "^5.10.6",
@@ -1088,9 +1088,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.6.tgz",
-      "integrity": "sha512-9/ccq8muJU/zL8a+R2eZjBhKhUZ+V+2j1JVA8BLam9lEmKKwp0DfPK8R4jHSiFLZG8te+jtw1UoyxKrtzMiQDA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.7.7.tgz",
+      "integrity": "sha512-NokJnWFePO69B9LahCbVtIrUD+pDmsU3lgBdBK8vA6VDzPRO23YJOa2S1IpT3jtC5wNaUC/kc8Xbs4QpMtuvTQ==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.0.0",
@@ -4231,9 +4231,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/examples/type-merging-batching/package.json
+++ b/examples/type-merging-batching/package.json
@@ -6,7 +6,7 @@
     "graphql": "^16.9.0",
     "graphql-yoga": "^5.10.6",
     "tslib": "^2.8.1",
-    "@graphql-hive/gateway": "^1.7.6"
+    "@graphql-hive/gateway": "^1.7.7"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/internal/testing/src/composeLocalSchemasWithApollo.ts
+++ b/internal/testing/src/composeLocalSchemasWithApollo.ts
@@ -9,12 +9,14 @@ export interface ComposeLocalSchemaWithApolloSubgraphOpts {
 export async function composeLocalSchemasWithApollo(
   subgraphs: ComposeLocalSchemaWithApolloSubgraphOpts[],
 ) {
-  const { IntrospectAndCompose, LocalGraphQLDataSource } = await import('@apollo/gateway');
+  const { IntrospectAndCompose, LocalGraphQLDataSource } = await import(
+    '@apollo/gateway'
+  );
   let { supergraphSdl, cleanup } = await new IntrospectAndCompose({
     subgraphs: subgraphs.map(({ name, url = `http://localhost/${name}` }) => ({
       name,
       url,
-    }))
+    })),
   }).initialize({
     update(updatedSupergraphSdl: string) {
       supergraphSdl = updatedSupergraphSdl;

--- a/internal/testing/src/composeLocalSchemasWithApollo.ts
+++ b/internal/testing/src/composeLocalSchemasWithApollo.ts
@@ -1,4 +1,3 @@
-import { IntrospectAndCompose, LocalGraphQLDataSource } from '@apollo/gateway';
 import { GraphQLSchema } from 'graphql';
 
 export interface ComposeLocalSchemaWithApolloSubgraphOpts {
@@ -10,8 +9,12 @@ export interface ComposeLocalSchemaWithApolloSubgraphOpts {
 export async function composeLocalSchemasWithApollo(
   subgraphs: ComposeLocalSchemaWithApolloSubgraphOpts[],
 ) {
+  const { IntrospectAndCompose, LocalGraphQLDataSource } = await import('@apollo/gateway');
   let { supergraphSdl, cleanup } = await new IntrospectAndCompose({
-    subgraphs,
+    subgraphs: subgraphs.map(({ name, url = `http://localhost/${name}` }) => ({
+      name,
+      url,
+    }))
   }).initialize({
     update(updatedSupergraphSdl: string) {
       supergraphSdl = updatedSupergraphSdl;

--- a/internal/testing/src/composeLocalSchemasWithApollo.ts
+++ b/internal/testing/src/composeLocalSchemasWithApollo.ts
@@ -1,0 +1,30 @@
+import { IntrospectAndCompose, LocalGraphQLDataSource } from '@apollo/gateway';
+import { GraphQLSchema } from 'graphql';
+
+export interface ComposeLocalSchemaWithApolloSubgraphOpts {
+  name: string;
+  schema: GraphQLSchema;
+  url?: string;
+}
+
+export async function composeLocalSchemasWithApollo(
+  subgraphs: ComposeLocalSchemaWithApolloSubgraphOpts[],
+) {
+  let { supergraphSdl, cleanup } = await new IntrospectAndCompose({
+    subgraphs,
+  }).initialize({
+    update(updatedSupergraphSdl: string) {
+      supergraphSdl = updatedSupergraphSdl;
+    },
+    healthCheck: async () => {},
+    getDataSource({ name }) {
+      const subgraph = subgraphs.find((subgraph) => subgraph.name === name);
+      if (!subgraph) {
+        throw new Error(`Subgraph ${name} not found`);
+      }
+      return new LocalGraphQLDataSource(subgraph.schema);
+    },
+  });
+  await cleanup();
+  return supergraphSdl;
+}

--- a/internal/testing/src/index.ts
+++ b/internal/testing/src/index.ts
@@ -5,3 +5,4 @@ export * from './opts';
 export * from './assertions';
 export * from './benchConfig';
 export * from './trimError';
+export * from './composeLocalSchemasWithApollo';

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -1433,6 +1433,11 @@ export function getStitchingOptionsFromSupergraphSdl(
           }
         }
       }
+    } else if (
+      definition.kind === Kind.DIRECTIVE_DEFINITION &&
+      !definition.name.value.startsWith('join__')
+    ) {
+      extraDefinitions.push(definition);
     }
   }
   const additionalTypeDefs: DocumentNode = {

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -1435,7 +1435,8 @@ export function getStitchingOptionsFromSupergraphSdl(
       }
     } else if (
       definition.kind === Kind.DIRECTIVE_DEFINITION &&
-      !definition.name.value.startsWith('join__')
+      !definition.name.value.startsWith('join__') &&
+      !definition.name.value.startsWith('core')
     ) {
       extraDefinitions.push(definition);
     }

--- a/packages/federation/tests/defer-stream.test.ts
+++ b/packages/federation/tests/defer-stream.test.ts
@@ -1,17 +1,18 @@
 import { setTimeout } from 'timers/promises';
 import { inspect } from 'util';
-import { IntrospectAndCompose, LocalGraphQLDataSource } from '@apollo/gateway';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { normalizedExecutor } from '@graphql-tools/executor';
 import { buildHTTPExecutor } from '@graphql-tools/executor-http';
 import {
   asArray,
   ExecutionResult,
-  fakePromise,
   mergeDeep,
 } from '@graphql-tools/utils';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
-import { assertAsyncIterable, composeLocalSchemasWithApollo } from '@internal/testing';
+import {
+  assertAsyncIterable,
+  composeLocalSchemasWithApollo,
+} from '@internal/testing';
 import { GraphQLSchema, parse, print } from 'graphql';
 import { createYoga } from 'graphql-yoga';
 import _ from 'lodash';
@@ -176,7 +177,7 @@ describe('Defer/Stream', () => {
     const supergraphSdl = await composeLocalSchemasWithApollo([
       { name: 'users', schema: usersSubgraph },
       { name: 'posts', schema: postsSubgraph },
-    ])
+    ]);
     schema = getStitchedSchemaFromSupergraphSdl({
       supergraphSdl,
       onSubschemaConfig(subschemaConfig) {

--- a/packages/federation/tests/defer-stream.test.ts
+++ b/packages/federation/tests/defer-stream.test.ts
@@ -3,11 +3,7 @@ import { inspect } from 'util';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { normalizedExecutor } from '@graphql-tools/executor';
 import { buildHTTPExecutor } from '@graphql-tools/executor-http';
-import {
-  asArray,
-  ExecutionResult,
-  mergeDeep,
-} from '@graphql-tools/utils';
+import { asArray, ExecutionResult, mergeDeep } from '@graphql-tools/utils';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import {
   assertAsyncIterable,

--- a/packages/federation/tests/defer-stream.test.ts
+++ b/packages/federation/tests/defer-stream.test.ts
@@ -11,7 +11,7 @@ import {
   mergeDeep,
 } from '@graphql-tools/utils';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
-import { assertAsyncIterable } from '@internal/testing';
+import { assertAsyncIterable, composeLocalSchemasWithApollo } from '@internal/testing';
 import { GraphQLSchema, parse, print } from 'graphql';
 import { createYoga } from 'graphql-yoga';
 import _ from 'lodash';
@@ -173,20 +173,10 @@ describe('Defer/Stream', () => {
   let schema: GraphQLSchema;
   let finalResult: ExecutionResult;
   beforeAll(async () => {
-    const { supergraphSdl } = await new IntrospectAndCompose({
-      subgraphs: [
-        { name: 'users', url: 'http://localhost:4001/graphql' },
-        { name: 'posts', url: 'http://localhost:4002/graphql' },
-      ],
-    }).initialize({
-      update() {},
-      healthCheck: () => fakePromise(undefined),
-      getDataSource({ name }) {
-        if (name === 'users') return new LocalGraphQLDataSource(usersSubgraph);
-        if (name === 'posts') return new LocalGraphQLDataSource(postsSubgraph);
-        throw new Error(`Unknown subgraph: ${name}`);
-      },
-    });
+    const supergraphSdl = await composeLocalSchemasWithApollo([
+      { name: 'users', schema: usersSubgraph },
+      { name: 'posts', schema: postsSubgraph },
+    ])
     schema = getStitchedSchemaFromSupergraphSdl({
       supergraphSdl,
       onSubschemaConfig(subschemaConfig) {

--- a/packages/federation/tests/fixtures/gateway/supergraph.ts
+++ b/packages/federation/tests/fixtures/gateway/supergraph.ts
@@ -1,6 +1,4 @@
-import { IntrospectAndCompose, LocalGraphQLDataSource } from '@apollo/gateway';
 import { buildSubgraphSchema } from '@apollo/subgraph';
-import { fakePromise } from '@graphql-tools/utils';
 import { accounts, inventory, products, reviews } from '@internal/e2e';
 import { composeLocalSchemasWithApollo } from '@internal/testing';
 import { DocumentNode, GraphQLSchema } from 'graphql';

--- a/packages/federation/tests/fixtures/gateway/supergraph.ts
+++ b/packages/federation/tests/fixtures/gateway/supergraph.ts
@@ -2,6 +2,7 @@ import { IntrospectAndCompose, LocalGraphQLDataSource } from '@apollo/gateway';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { fakePromise } from '@graphql-tools/utils';
 import { accounts, inventory, products, reviews } from '@internal/e2e';
+import { composeLocalSchemasWithApollo } from '@internal/testing';
 import { DocumentNode, GraphQLSchema } from 'graphql';
 
 const services = {
@@ -26,23 +27,5 @@ export function getServiceInputs() {
 }
 
 export async function getSupergraph() {
-  const serviceInputs = getServiceInputs();
-  const { supergraphSdl, cleanup } = await new IntrospectAndCompose({
-    subgraphs: serviceInputs.map(({ name }) => ({
-      name,
-      url: `http://localhost/${name}`,
-    })),
-  }).initialize({
-    update() {},
-    healthCheck: () => fakePromise(undefined),
-    getDataSource({ name }) {
-      const serviceInput = serviceInputs.find((input) => input.name === name);
-      if (!serviceInput) {
-        throw new Error(`Service ${name} not found`);
-      }
-      return new LocalGraphQLDataSource(serviceInput.schema);
-    },
-  });
-  await cleanup();
-  return supergraphSdl;
+  return composeLocalSchemasWithApollo(getServiceInputs());
 }

--- a/packages/federation/tests/getStitchedSchemaFromLocalSchemas.ts
+++ b/packages/federation/tests/getStitchedSchemaFromLocalSchemas.ts
@@ -4,10 +4,10 @@ import {
   ExecutionResult,
   mapMaybePromise,
 } from '@graphql-tools/utils';
+import { composeLocalSchemasWithApollo } from '@internal/testing';
 import { GraphQLSchema } from 'graphql';
 import { kebabCase } from 'lodash';
 import { getStitchedSchemaFromSupergraphSdl } from '../src/supergraph';
-import { composeLocalSchemasWithApollo } from '@internal/testing';
 
 export interface LocalSchemaItem {
   name: string;
@@ -22,11 +22,13 @@ export async function getStitchedSchemaFromLocalSchemas(
     result: ExecutionResult | AsyncIterable<ExecutionResult>,
   ) => void,
 ): Promise<GraphQLSchema> {
-  const supergraphSdl = await composeLocalSchemasWithApollo(Object.entries(localSchemas).map(([name, schema]) => ({
-    name,
-    schema,
-    url: `http://localhost/${name}`,
-  })));
+  const supergraphSdl = await composeLocalSchemasWithApollo(
+    Object.entries(localSchemas).map(([name, schema]) => ({
+      name,
+      schema,
+      url: `http://localhost/${name}`,
+    })),
+  );
   function createTracedExecutor(name: string, schema: GraphQLSchema) {
     const executor = createDefaultExecutor(schema);
     return function tracedExecutor(request: ExecutionRequest) {

--- a/packages/federation/tests/optimizations.test.ts
+++ b/packages/federation/tests/optimizations.test.ts
@@ -1,7 +1,7 @@
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { createDefaultExecutor } from '@graphql-tools/delegate';
 import { normalizedExecutor } from '@graphql-tools/executor';
-import { ExecutionRequest, Executor, fakePromise } from '@graphql-tools/utils';
+import { ExecutionRequest, Executor } from '@graphql-tools/utils';
 import { GraphQLSchema, parse, print, versionInfo } from 'graphql';
 import { kebabCase } from 'lodash';
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
@@ -15,6 +15,7 @@ import {
   Eschema,
 } from './fixtures/optimizations/awareness-of-other-fields';
 import { getStitchedSchemaFromLocalSchemas } from './getStitchedSchemaFromLocalSchemas';
+import { composeLocalSchemasWithApollo } from '@internal/testing';
 
 describe('Optimizations', () => {
   let serviceCallCnt: Record<string, number>;
@@ -160,86 +161,63 @@ describe('awareness-of-other-fields', () => {
     subgraphCalls = {};
   });
   beforeAll(async () => {
-    const { IntrospectAndCompose, LocalGraphQLDataSource } = await import(
-      '@apollo/gateway'
-    );
-    return new IntrospectAndCompose({
-      subgraphs: [
-        { name: 'A', url: 'A' },
-        { name: 'B', url: 'B' },
-        { name: 'C', url: 'C' },
-        { name: 'D', url: 'D' },
-        { name: 'E', url: 'E' },
-      ],
-    })
-      .initialize({
-        healthCheck() {
-          return fakePromise(undefined);
-        },
-        update(updatedSupergraphSdl) {
-          supergraphSdl = updatedSupergraphSdl;
-        },
-        getDataSource({ name }) {
-          switch (name) {
-            case 'A':
-              return new LocalGraphQLDataSource(Aschema);
-            case 'B':
-              return new LocalGraphQLDataSource(Bschema);
-            case 'C':
-              return new LocalGraphQLDataSource(Cschema);
-            case 'D':
-              return new LocalGraphQLDataSource(Dschema);
-            case 'E':
-              return new LocalGraphQLDataSource(Eschema);
-          }
-          throw new Error(`Unknown subgraph ${name}`);
-        },
-      })
-      .then((result) => {
-        supergraphSdl = result.supergraphSdl;
-      })
-      .then(() => {
-        gwSchema = getStitchedSchemaFromSupergraphSdl({
-          supergraphSdl,
-          onSubschemaConfig(subschemaConfig) {
-            const subgraphName = subschemaConfig.name;
-            switch (subgraphName) {
-              case 'A':
-                subschemaConfig.executor = getTracedExecutor(
-                  subgraphName,
-                  Aschema,
-                );
-                break;
-              case 'B':
-                subschemaConfig.executor = getTracedExecutor(
-                  subgraphName,
-                  Bschema,
-                );
-                break;
-              case 'C':
-                subschemaConfig.executor = getTracedExecutor(
-                  subgraphName,
-                  Cschema,
-                );
-                break;
-              case 'D':
-                subschemaConfig.executor = getTracedExecutor(
-                  subgraphName,
-                  Dschema,
-                );
-                break;
-              case 'E':
-                subschemaConfig.executor = getTracedExecutor(
-                  subgraphName,
-                  Eschema,
-                );
-                break;
-              default:
-                throw new Error(`Unknown subgraph ${subgraphName}`);
-            }
-          },
-        });
-      });
+    supergraphSdl = await composeLocalSchemasWithApollo([
+      {
+        name: 'A',
+        schema: Aschema,
+      },
+      {
+        name: 'B',
+        schema: Bschema,
+      },
+      {
+        name: 'C',
+        schema: Cschema,
+      },
+      {
+        name: 'D',
+        schema: Dschema,
+      },
+      {
+        name: 'E',
+        schema: Eschema,
+      },
+    ]);
+    gwSchema = getStitchedSchemaFromSupergraphSdl({
+      supergraphSdl,
+      onSubschemaConfig(subschemaConfig) {
+        const subgraphName = subschemaConfig.name;
+        switch (subgraphName) {
+          case 'A':
+            subschemaConfig.executor = getTracedExecutor(
+              subgraphName,
+              Aschema);
+            break;
+          case 'B':
+            subschemaConfig.executor = getTracedExecutor(
+              subgraphName,
+              Bschema);
+            break;
+          case 'C':
+            subschemaConfig.executor = getTracedExecutor(
+              subgraphName,
+              Cschema);
+            break;
+          case 'D':
+            subschemaConfig.executor = getTracedExecutor(
+              subgraphName,
+              Dschema);
+            break;
+          case 'E':
+            subschemaConfig.executor = getTracedExecutor(
+              subgraphName,
+              Eschema);
+            break;
+          default:
+            throw new Error(`Unknown subgraph ${subgraphName}`);
+        }
+      },
+    });
   });
   it('do not call A subgraph as an extra', async () => {
     const result = await normalizedExecutor({
@@ -433,34 +411,20 @@ it('prevents recursively depending fields in case of multiple keys', async () =>
     },
   });
 
-  const { IntrospectAndCompose, LocalGraphQLDataSource } = await import(
-    '@apollo/gateway'
-  );
-  const introspectAndCompose = await new IntrospectAndCompose({
-    subgraphs: [
-      { name: 'books', url: 'books' },
-      { name: 'other-service', url: 'other-service' },
-      { name: 'authors', url: 'authors' },
-    ],
-  }).initialize({
-    healthCheck() {
-      return fakePromise(undefined);
+  const supergraphSdl = await composeLocalSchemasWithApollo([
+    {
+      name: 'books',
+      schema: booksSchema,
     },
-    update() {},
-    getDataSource({ name }) {
-      switch (kebabCase(name)) {
-        case 'books':
-          return new LocalGraphQLDataSource(booksSchema);
-        case 'other-service':
-          return new LocalGraphQLDataSource(multiLocationMgmt);
-        case 'authors':
-          return new LocalGraphQLDataSource(authorsSchema);
-      }
-      throw new Error(`Unknown subgraph ${name}`);
+    {
+      name: 'authors',
+      schema: authorsSchema,
     },
-  });
-  const supergraphSdl = introspectAndCompose.supergraphSdl;
-  await introspectAndCompose.cleanup();
+    {
+      name: 'other-service',
+      schema: multiLocationMgmt,
+    },
+  ])
   let subgraphCallsMap: Record<
     string,
     {

--- a/packages/federation/tests/optimizations.test.ts
+++ b/packages/federation/tests/optimizations.test.ts
@@ -2,6 +2,7 @@ import { buildSubgraphSchema } from '@apollo/subgraph';
 import { createDefaultExecutor } from '@graphql-tools/delegate';
 import { normalizedExecutor } from '@graphql-tools/executor';
 import { ExecutionRequest, Executor } from '@graphql-tools/utils';
+import { composeLocalSchemasWithApollo } from '@internal/testing';
 import { GraphQLSchema, parse, print, versionInfo } from 'graphql';
 import { kebabCase } from 'lodash';
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
@@ -15,7 +16,6 @@ import {
   Eschema,
 } from './fixtures/optimizations/awareness-of-other-fields';
 import { getStitchedSchemaFromLocalSchemas } from './getStitchedSchemaFromLocalSchemas';
-import { composeLocalSchemasWithApollo } from '@internal/testing';
 
 describe('Optimizations', () => {
   let serviceCallCnt: Record<string, number>;
@@ -189,29 +189,19 @@ describe('awareness-of-other-fields', () => {
         const subgraphName = subschemaConfig.name;
         switch (subgraphName) {
           case 'A':
-            subschemaConfig.executor = getTracedExecutor(
-              subgraphName,
-              Aschema);
+            subschemaConfig.executor = getTracedExecutor(subgraphName, Aschema);
             break;
           case 'B':
-            subschemaConfig.executor = getTracedExecutor(
-              subgraphName,
-              Bschema);
+            subschemaConfig.executor = getTracedExecutor(subgraphName, Bschema);
             break;
           case 'C':
-            subschemaConfig.executor = getTracedExecutor(
-              subgraphName,
-              Cschema);
+            subschemaConfig.executor = getTracedExecutor(subgraphName, Cschema);
             break;
           case 'D':
-            subschemaConfig.executor = getTracedExecutor(
-              subgraphName,
-              Dschema);
+            subschemaConfig.executor = getTracedExecutor(subgraphName, Dschema);
             break;
           case 'E':
-            subschemaConfig.executor = getTracedExecutor(
-              subgraphName,
-              Eschema);
+            subschemaConfig.executor = getTracedExecutor(subgraphName, Eschema);
             break;
           default:
             throw new Error(`Unknown subgraph ${subgraphName}`);
@@ -424,7 +414,7 @@ it('prevents recursively depending fields in case of multiple keys', async () =>
       name: 'other-service',
       schema: multiLocationMgmt,
     },
-  ])
+  ]);
   let subgraphCallsMap: Record<
     string,
     {

--- a/packages/federation/tests/subscription.test.ts
+++ b/packages/federation/tests/subscription.test.ts
@@ -104,7 +104,7 @@ describe('Subscriptions in Federation', () => {
         name: 'comments',
         schema: commentsSchema,
       },
-    ])
+    ]);
     const schema = getStitchedSchemaFromSupergraphSdl({
       supergraphSdl,
       onSubschemaConfig(subschemaConfig) {

--- a/packages/federation/tests/supergraphs.test.ts
+++ b/packages/federation/tests/supergraphs.test.ts
@@ -29,7 +29,13 @@ describe('Supergraphs', () => {
           fieldFilter: (_, __, fieldConfig) =>
             !getDirective(sortedInputSchema, fieldConfig, 'inaccessible')
               ?.length,
-          directiveFilter: () => false,
+          directiveFilter: typeName =>
+            !typeName.startsWith('link__') &&
+            !typeName.startsWith('join__') &&
+            !typeName.startsWith('core__') &&
+            typeName !== 'core' &&
+            typeName !== 'link' &&
+            typeName !== 'inaccessible',
           enumValueFilter: (_, __, enumValueConfig) =>
             !getDirective(sortedInputSchema, enumValueConfig, 'inaccessible')
               ?.length,

--- a/packages/federation/tests/supergraphs.test.ts
+++ b/packages/federation/tests/supergraphs.test.ts
@@ -29,7 +29,7 @@ describe('Supergraphs', () => {
           fieldFilter: (_, __, fieldConfig) =>
             !getDirective(sortedInputSchema, fieldConfig, 'inaccessible')
               ?.length,
-          directiveFilter: typeName =>
+          directiveFilter: (typeName) =>
             !typeName.startsWith('link__') &&
             !typeName.startsWith('join__') &&
             !typeName.startsWith('core__') &&

--- a/packages/runtime/tests/cache-control.test.ts
+++ b/packages/runtime/tests/cache-control.test.ts
@@ -171,9 +171,7 @@ describe.skipIf(process.env['LEAK_TEST'])(
         await using gw = createGatewayRuntime({
           supergraph,
           cache,
-          plugins: (ctx) => [
-            useHttpCache(ctx),
-          ],
+          plugins: (ctx) => [useHttpCache(ctx)],
         });
         async function makeRequest() {
           const res = await gw.fetch('http://localhost:4000/graphql', {

--- a/packages/runtime/tests/cache-control.test.ts
+++ b/packages/runtime/tests/cache-control.test.ts
@@ -1,244 +1,223 @@
-import { createServer, Server } from 'http';
-import { AddressInfo, Socket } from 'net';
+import { setTimeout } from 'timers/promises';
 import { ApolloServer } from '@apollo/server';
-import { expressMiddleware } from '@apollo/server/express4';
+import { startStandaloneServer } from '@apollo/server/standalone';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { createGatewayRuntime } from '@graphql-hive/gateway-runtime';
 import InmemoryLRUCache from '@graphql-mesh/cache-inmemory-lru';
 import useHttpCache from '@graphql-mesh/plugin-http-cache';
 import { composeLocalSchemasWithApollo } from '@internal/testing';
-import express from 'express';
 import { parse } from 'graphql';
-import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-describe('Cache Control directives w/ Apollo Server subgraph', () => {
-  vi.useFakeTimers();
-  const products = [
-    { id: '1', name: 'Product 1', price: 100 },
-    { id: '2', name: 'Product 2', price: 200 },
-    { id: '3', name: 'Product 3', price: 300 },
-  ];
-  const productsSchema = buildSubgraphSchema({
-    typeDefs: parse(/* GraphQL */ `
-      enum CacheControlScope {
-        PUBLIC
-        PRIVATE
-      }
+// ApolloServer is not playing nice with Leak Tests
+describe.skipIf(process.env['LEAK_TEST'])(
+  'Cache Control directives w/ Apollo Server subgraph',
+  () => {
+    vi.useFakeTimers?.();
+    const advanceTimersByTimeAsync = vi.advanceTimersByTimeAsync || setTimeout;
+    const products = [
+      { id: '1', name: 'Product 1', price: 100 },
+      { id: '2', name: 'Product 2', price: 200 },
+      { id: '3', name: 'Product 3', price: 300 },
+    ];
+    const productsSchema = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        enum CacheControlScope {
+          PUBLIC
+          PRIVATE
+        }
 
-      directive @cacheControl(
-        maxAge: Int
-        scope: CacheControlScope
-        inheritMaxAge: Boolean
-      ) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+        directive @cacheControl(
+          maxAge: Int
+          scope: CacheControlScope
+          inheritMaxAge: Boolean
+        ) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
 
-      type Product @key(fields: "id") @cacheControl(maxAge: 30) {
-        id: ID!
-        name: String!
-        price: Int!
-      }
+        type Product @key(fields: "id") @cacheControl(maxAge: 3) {
+          id: ID!
+          name: String!
+          price: Int!
+        }
 
-      extend type Query {
-        products: [Product!]!
-        product(id: ID!): Product
-      }
+        extend type Query {
+          products: [Product!]!
+          product(id: ID!): Product
+        }
 
-      extend schema
-        @link(
-          url: "https://specs.apollo.dev/federation/v2.6"
-          import: ["@key", "@composeDirective"]
-        )
-        @link(url: "https://the-guild.dev/mesh/v1.0", import: ["@cacheControl"])
-        @composeDirective(name: "@cacheControl") {
-        query: Query
-      }
-    `),
-    resolvers: {
-      Query: {
-        product(_root, { id }) {
-          return products.find((product) => product.id === id);
-        },
-        products() {
-          return products;
+        extend schema
+          @link(
+            url: "https://specs.apollo.dev/federation/v2.6"
+            import: ["@key", "@composeDirective"]
+          )
+          @link(
+            url: "https://the-guild.dev/mesh/v1.0"
+            import: ["@cacheControl"]
+          )
+          @composeDirective(name: "@cacheControl") {
+          query: Query
+        }
+      `),
+      resolvers: {
+        Query: {
+          product(_root, { id }) {
+            return products.find((product) => product.id === id);
+          },
+          products() {
+            return products;
+          },
         },
       },
-    },
-  });
-  let supergraph: string;
-  let productsServer: Server;
-  let requestDidStart: Mock;
-  const sockets = new Set<Socket>();
-  beforeEach(async () => {
-    requestDidStart = vi.fn();
-    const app = express();
-    productsServer = createServer(app);
-    const apolloServer = new ApolloServer({
-      schema: productsSchema,
-      plugins: [
-        {
-          requestDidStart,
-        },
-      ],
     });
-    await apolloServer.start();
-    app.use(
-      // @ts-expect-error - Express typings are wrong
-      express.json(),
-      expressMiddleware(apolloServer),
-    );
-    await new Promise<void>((resolve, reject) => {
-      productsServer.once('error', reject);
-      productsServer.listen(0, () => {
-        resolve();
-      });
-    });
-    productsServer.on('connection', (socket) => {
-      sockets.add(socket);
-      socket.once('close', () => {
-        sockets.delete(socket);
-      });
-    });
-    supergraph = await composeLocalSchemasWithApollo([
-      {
+    let supergraph: string;
+    let apolloServer: ApolloServer;
+    let requestDidStart: Mock;
+    beforeEach(async () => {
+      requestDidStart = vi.fn();
+      apolloServer = new ApolloServer({
         schema: productsSchema,
-        name: 'products',
-        url: `http://localhost:${(productsServer.address() as AddressInfo).port}/graphql`,
-      },
-    ]);
-  });
-  afterEach(
-    () =>
-      new Promise<void>((resolve, reject) => {
-        productsServer.closeAllConnections();
-        productsServer.close((err) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve();
-          }
+        plugins: [
+          {
+            requestDidStart,
+          },
+        ],
+      });
+      const { url } = await startStandaloneServer(apolloServer, {
+        listen: { port: 0 },
+      });
+      supergraph = await composeLocalSchemasWithApollo([
+        {
+          schema: productsSchema,
+          name: 'products',
+          url,
+        },
+      ]);
+    });
+    it('response caching plugin respect @cacheControl(maxAge:) w/ @composeDirective', async () => {
+      await using cache = new InmemoryLRUCache();
+      await using gw = createGatewayRuntime({
+        supergraph,
+        cache,
+        responseCaching: {
+          session: () => null,
+          includeExtensionMetadata: true,
+        },
+      });
+      async function makeRequest() {
+        const res = await gw.fetch('http://localhost:4000/graphql', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            query: /* GraphQL */ `
+              query {
+                products {
+                  id
+                  name
+                  price
+                }
+              }
+            `,
+          }),
         });
-      }),
-  );
-  it('response caching plugin respect @cacheControl(maxAge:) w/ @composeDirective', async () => {
-    await using cache = new InmemoryLRUCache();
-    await using gw = createGatewayRuntime({
-      supergraph,
-      cache,
-      responseCaching: {
-        session: () => null,
-        includeExtensionMetadata: true,
-      },
-    });
-    async function makeRequest() {
-      const res = await gw.fetch('http://localhost:4000/graphql', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+        return res.json();
+      }
+      await expect(makeRequest()).resolves.toEqual({
+        data: {
+          products,
         },
-        body: JSON.stringify({
-          query: /* GraphQL */ `
-            query {
-              products {
-                id
-                name
-                price
-              }
-            }
-          `,
-        }),
+        extensions: {
+          responseCache: {
+            didCache: true,
+            hit: false,
+            ttl: 3_000,
+          },
+        },
       });
-      return res.json();
-    }
-    await expect(makeRequest()).resolves.toEqual({
-      data: {
-        products,
-      },
-      extensions: {
-        responseCache: {
-          didCache: true,
-          hit: false,
-          ttl: 30_000,
+      // 15 seconds later
+      await advanceTimersByTimeAsync(1_000);
+      await expect(makeRequest()).resolves.toEqual({
+        data: {
+          products,
         },
-      },
-    });
-    // 15 seconds later
-    await vi.advanceTimersByTimeAsync(15_000);
-    await expect(makeRequest()).resolves.toEqual({
-      data: {
-        products,
-      },
-      extensions: {
-        responseCache: {
-          hit: true,
+        extensions: {
+          responseCache: {
+            hit: true,
+          },
         },
-      },
-    });
-    // 15 seconds later but the cache is expired
-    await vi.advanceTimersByTimeAsync(15_000);
-    await expect(makeRequest()).resolves.toEqual({
-      data: {
-        products,
-      },
-      extensions: {
-        responseCache: {
-          didCache: true,
-          hit: false,
-          ttl: 30_000,
-        },
-      },
-    });
-    // GW received 3 requests but only 2 were forwarded to the subgraph
-    expect(requestDidStart).toHaveBeenCalledTimes(2);
-  });
-  it('http caching plugin should respect cache control headers', async () => {
-    await using cache = new InmemoryLRUCache();
-    await using gw = createGatewayRuntime({
-      supergraph,
-      cache,
-      plugins: (ctx) => [
-        // @ts-expect-error - we need to fix the types
-        useHttpCache(ctx),
-      ],
-    });
-    async function makeRequest() {
-      const res = await gw.fetch('http://localhost:4000/graphql', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          query: /* GraphQL */ `
-            query {
-              products {
-                id
-                name
-                price
-              }
-            }
-          `,
-        }),
       });
-      return res.json();
-    }
-    await expect(makeRequest()).resolves.toEqual({
-      data: {
-        products,
-      },
+      // 15 seconds later but the cache is expired
+      await advanceTimersByTimeAsync(2_000);
+      await expect(makeRequest()).resolves.toEqual({
+        data: {
+          products,
+        },
+        extensions: {
+          responseCache: {
+            didCache: true,
+            hit: false,
+            ttl: 3_000,
+          },
+        },
+      });
+      // GW received 3 requests but only 2 were forwarded to the subgraph
+      expect(requestDidStart).toHaveBeenCalledTimes(2);
     });
-    // 15 seconds later
-    await vi.advanceTimersByTimeAsync(15_000);
-    await expect(makeRequest()).resolves.toEqual({
-      data: {
-        products,
+    // TODO: HTTP Cache plugin has issues with Bun
+    it.skipIf(globalThis.Bun)(
+      'http caching plugin should respect cache control headers',
+      async () => {
+        await using cache = new InmemoryLRUCache();
+        await using gw = createGatewayRuntime({
+          supergraph,
+          cache,
+          plugins: (ctx) => [
+            // @ts-expect-error - we need to fix the types
+            useHttpCache(ctx),
+          ],
+        });
+        async function makeRequest() {
+          const res = await gw.fetch('http://localhost:4000/graphql', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              query: /* GraphQL */ `
+                query {
+                  products {
+                    id
+                    name
+                    price
+                  }
+                }
+              `,
+            }),
+          });
+          return res.json();
+        }
+        await expect(makeRequest()).resolves.toEqual({
+          data: {
+            products,
+          },
+        });
+        // 15 seconds later
+        await advanceTimersByTimeAsync(1_000);
+        await expect(makeRequest()).resolves.toEqual({
+          data: {
+            products,
+          },
+        });
+        // 15 seconds later but the cache is expired
+        await advanceTimersByTimeAsync(2_000);
+        await expect(makeRequest()).resolves.toEqual({
+          data: {
+            products,
+          },
+        });
+        // GW received 3 requests but only 2 were forwarded to the subgraph
+        expect(requestDidStart).toHaveBeenCalledTimes(2);
       },
-    });
-    // 15 seconds later but the cache is expired
-    await vi.advanceTimersByTimeAsync(15_000);
-    await expect(makeRequest()).resolves.toEqual({
-      data: {
-        products,
-      },
-    });
-    // GW received 3 requests but only 2 were forwarded to the subgraph
-    expect(requestDidStart).toHaveBeenCalledTimes(2);
-  });
-});
+    );
+  },
+);

--- a/packages/runtime/tests/cache-control.test.ts
+++ b/packages/runtime/tests/cache-control.test.ts
@@ -172,7 +172,6 @@ describe.skipIf(process.env['LEAK_TEST'])(
           supergraph,
           cache,
           plugins: (ctx) => [
-            // @ts-expect-error - we need to fix the types
             useHttpCache(ctx),
           ],
         });

--- a/packages/runtime/tests/cache-control.test.ts
+++ b/packages/runtime/tests/cache-control.test.ts
@@ -1,0 +1,244 @@
+import { createServer, Server } from 'http';
+import { AddressInfo, Socket } from 'net';
+import { ApolloServer } from '@apollo/server';
+import { expressMiddleware } from '@apollo/server/express4';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { createGatewayRuntime } from '@graphql-hive/gateway-runtime';
+import InmemoryLRUCache from '@graphql-mesh/cache-inmemory-lru';
+import useHttpCache from '@graphql-mesh/plugin-http-cache';
+import { composeLocalSchemasWithApollo } from '@internal/testing';
+import express from 'express';
+import { parse } from 'graphql';
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+
+describe('Cache Control directives w/ Apollo Server subgraph', () => {
+  vi.useFakeTimers();
+  const products = [
+    { id: '1', name: 'Product 1', price: 100 },
+    { id: '2', name: 'Product 2', price: 200 },
+    { id: '3', name: 'Product 3', price: 300 },
+  ];
+  const productsSchema = buildSubgraphSchema({
+    typeDefs: parse(/* GraphQL */ `
+      enum CacheControlScope {
+        PUBLIC
+        PRIVATE
+      }
+
+      directive @cacheControl(
+        maxAge: Int
+        scope: CacheControlScope
+        inheritMaxAge: Boolean
+      ) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+
+      type Product @key(fields: "id") @cacheControl(maxAge: 30) {
+        id: ID!
+        name: String!
+        price: Int!
+      }
+
+      extend type Query {
+        products: [Product!]!
+        product(id: ID!): Product
+      }
+
+      extend schema
+        @link(
+          url: "https://specs.apollo.dev/federation/v2.6"
+          import: ["@key", "@composeDirective"]
+        )
+        @link(url: "https://the-guild.dev/mesh/v1.0", import: ["@cacheControl"])
+        @composeDirective(name: "@cacheControl") {
+        query: Query
+      }
+    `),
+    resolvers: {
+      Query: {
+        product(_root, { id }) {
+          return products.find((product) => product.id === id);
+        },
+        products() {
+          return products;
+        },
+      },
+    },
+  });
+  let supergraph: string;
+  let productsServer: Server;
+  let requestDidStart: Mock;
+  const sockets = new Set<Socket>();
+  beforeEach(async () => {
+    requestDidStart = vi.fn();
+    const app = express();
+    productsServer = createServer(app);
+    const apolloServer = new ApolloServer({
+      schema: productsSchema,
+      plugins: [
+        {
+          requestDidStart,
+        },
+      ],
+    });
+    await apolloServer.start();
+    app.use(
+      // @ts-expect-error - Express typings are wrong
+      express.json(),
+      expressMiddleware(apolloServer),
+    );
+    await new Promise<void>((resolve, reject) => {
+      productsServer.once('error', reject);
+      productsServer.listen(0, () => {
+        resolve();
+      });
+    });
+    productsServer.on('connection', (socket) => {
+      sockets.add(socket);
+      socket.once('close', () => {
+        sockets.delete(socket);
+      });
+    });
+    supergraph = await composeLocalSchemasWithApollo([
+      {
+        schema: productsSchema,
+        name: 'products',
+        url: `http://localhost:${(productsServer.address() as AddressInfo).port}/graphql`,
+      },
+    ]);
+  });
+  afterEach(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        productsServer.closeAllConnections();
+        productsServer.close((err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      }),
+  );
+  it('response caching plugin respect @cacheControl(maxAge:) w/ @composeDirective', async () => {
+    await using cache = new InmemoryLRUCache();
+    await using gw = createGatewayRuntime({
+      supergraph,
+      cache,
+      responseCaching: {
+        session: () => null,
+        includeExtensionMetadata: true,
+      },
+    });
+    async function makeRequest() {
+      const res = await gw.fetch('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: /* GraphQL */ `
+            query {
+              products {
+                id
+                name
+                price
+              }
+            }
+          `,
+        }),
+      });
+      return res.json();
+    }
+    await expect(makeRequest()).resolves.toEqual({
+      data: {
+        products,
+      },
+      extensions: {
+        responseCache: {
+          didCache: true,
+          hit: false,
+          ttl: 30_000,
+        },
+      },
+    });
+    // 15 seconds later
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(makeRequest()).resolves.toEqual({
+      data: {
+        products,
+      },
+      extensions: {
+        responseCache: {
+          hit: true,
+        },
+      },
+    });
+    // 15 seconds later but the cache is expired
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(makeRequest()).resolves.toEqual({
+      data: {
+        products,
+      },
+      extensions: {
+        responseCache: {
+          didCache: true,
+          hit: false,
+          ttl: 30_000,
+        },
+      },
+    });
+    // GW received 3 requests but only 2 were forwarded to the subgraph
+    expect(requestDidStart).toHaveBeenCalledTimes(2);
+  });
+  it('http caching plugin should respect cache control headers', async () => {
+    await using cache = new InmemoryLRUCache();
+    await using gw = createGatewayRuntime({
+      supergraph,
+      cache,
+      plugins: (ctx) => [
+        // @ts-expect-error - we need to fix the types
+        useHttpCache(ctx),
+      ],
+    });
+    async function makeRequest() {
+      const res = await gw.fetch('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: /* GraphQL */ `
+            query {
+              products {
+                id
+                name
+                price
+              }
+            }
+          `,
+        }),
+      });
+      return res.json();
+    }
+    await expect(makeRequest()).resolves.toEqual({
+      data: {
+        products,
+      },
+    });
+    // 15 seconds later
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(makeRequest()).resolves.toEqual({
+      data: {
+        products,
+      },
+    });
+    // 15 seconds later but the cache is expired
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(makeRequest()).resolves.toEqual({
+      data: {
+        products,
+      },
+    });
+    // GW received 3 requests but only 2 were forwarded to the subgraph
+    expect(requestDidStart).toHaveBeenCalledTimes(2);
+  });
+});

--- a/vitest-jest.js
+++ b/vitest-jest.js
@@ -19,6 +19,9 @@ module.exports = new Proxy(require('@jest/globals'), {
       describeFn.only = function describeOnly(name, ...args) {
         return jestGlobals.describe.only(name, ...args);
       };
+      describeFn.each = function describeEach(table) {
+        return jestGlobals.describe.each(table);
+      }
       return describeFn;
     }
     if (prop === 'it') {
@@ -34,6 +37,9 @@ module.exports = new Proxy(require('@jest/globals'), {
       itFn.only = function itOnly(name, ...args) {
         return jestGlobals.it.only(name, ...args);
       };
+      itFn.each = function itEach(table) {
+        return jestGlobals.it.each(table);
+      }
       return itFn;
     }
     return Reflect.get(jestGlobals, prop, receiver);

--- a/vitest-jest.js
+++ b/vitest-jest.js
@@ -21,6 +21,21 @@ module.exports = new Proxy(require('@jest/globals'), {
       };
       return describeFn;
     }
+    if (prop === 'it') {
+      const itFn = function it(name, ...args) {
+        return jestGlobals.it(name, ...args);
+      };
+      itFn.skipIf = function itSkipIf(condition) {
+        return condition ? itFn.skip : itFn;
+      };
+      itFn.skip = function itSkip(name, ...args) {
+        return jestGlobals.it.skip(name, ...args);
+      };
+      itFn.only = function itOnly(name, ...args) {
+        return jestGlobals.it.only(name, ...args);
+      };
+      return itFn;
+    }
     return Reflect.get(jestGlobals, prop, receiver);
   },
 });

--- a/vitest-jest.js
+++ b/vitest-jest.js
@@ -21,7 +21,7 @@ module.exports = new Proxy(require('@jest/globals'), {
       };
       describeFn.each = function describeEach(table) {
         return jestGlobals.describe.each(table);
-      }
+      };
       return describeFn;
     }
     if (prop === 'it') {
@@ -39,7 +39,7 @@ module.exports = new Proxy(require('@jest/globals'), {
       };
       itFn.each = function itEach(table) {
         return jestGlobals.it.each(table);
-      }
+      };
       return itFn;
     }
     return Reflect.get(jestGlobals, prop, receiver);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,10 +6,7 @@ import { defineConfig } from 'vitest/config';
 // packages as per the Node resolution spec.
 //
 // Vite will process inlined modules.
-const inline = [
-  /@graphql-mesh\/.*/,
-  /@omnigraph\/.*/,
-];
+const inline = [/@graphql-mesh\/.*/, /@omnigraph\/.*/];
 
 export default defineConfig({
   plugins: [tsconfigPaths()],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,11 +7,7 @@ import { defineConfig } from 'vitest/config';
 //
 // Vite will process inlined modules.
 const inline = [
-  /@graphql-mesh\/utils/,
-  /@graphql-mesh\/runtime/,
-  /@graphql-mesh\/fusion-composition/,
-  /@graphql-mesh\/plugin-hive/,
-  /@graphql-mesh\/transport-rest/,
+  /@graphql-mesh\/.*/,
   /@omnigraph\/.*/,
 ];
 


### PR DESCRIPTION
Today if you `@cacheControl` directive in your subgraphs with Apollo Server, it sends cache control headers. And this is supported by http cache plugin. You don't need `@composeDirective` etc.

If you use those directives without ApolloServer, you can give the control to the gateway using Response Caching plugin but in order to have those directives in your gateway, you have to add the directive using `@composeDirective` so the supergraph can have it and response caching plugin can pick it up and use it.

This PR fixes the following issue when the directive definitions got lost while handling the supergraph using `@graphql-tools/federation`.
It also adds tests for both the cases mentioned above.

## ~Needs to be documented on the website!!!~(Done!)
See the conversation below with @kamilkisiela to make sure to get what is documented!

After merging this PR, we need to update the docs with the two cases. And we need to mention http caching plugin can be used with the subgraph services returning cache control headers on its own and no `@composeDirective`.
If the subgraph is expected to control gateway's caching, response caching should be added and `@composeDirective` should be added for `@cacheControl`;

```ts
extend schema
  @link(
    url: "https://specs.apollo.dev/federation/v2.1"
    import: ["@composeDirective"]
  )
  @link(url: "https://the-guild.dev/mesh/v1.0", import: ["@cacheControl"])
  @composeDirective(name: "@cacheControl")
  ```