### PR TITLE
enhance: better debug messages for readiness check endpoint

### DIFF
--- a/.changeset/gorgeous-bananas-brake.md
+++ b/.changeset/gorgeous-bananas-brake.md
@@ -1,0 +1,29 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Better messages on debug logs of readiness check endpoint;
+
+Before;
+On successful readiness check, the gateway was logging the following message:
+```
+Readiness check passed: Supergraph loaded
+```
+Because this makes the users think it was just loaded.
+After;
+On successful readiness check, the gateway will log the following message:
+```
+Readiness check passed because supergraph has been loaded already
+```
+
+On failed readiness check, the gateway was logging the following message:
+Before;
+```
+Readiness check failed: Supergraph not loaded
+```
+It should make the users think it was not loaded or there is an issue with the supergraph.
+
+After;
+```
+Readiness check failed because supergraph has not been loaded yet or failed to load
+```

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -709,10 +709,14 @@ export function createGatewayRuntime<
         unifiedGraphManager.getUnifiedGraph(),
         (schema) => {
           if (!schema) {
-            logger.debug(`Readiness check failed: Supergraph cannot be loaded`);
+            logger.debug(
+              `Readiness check failed because supergraph has not been loaded yet or failed to load`,
+            );
             return false;
           }
-          logger.debug(`Readiness check passed: Supergraph loaded`);
+          logger.debug(
+            `Readiness check passed because supergraph has been loaded already`,
+          );
           return true;
         },
         (err) => {


### PR DESCRIPTION
Better and less confusing messages on debug logs of readiness check endpoint;

Before;
On successful readiness check, the gateway was logging the following message:
```
Readiness check passed: Supergraph loaded
```
Because this makes the users think it was just loaded.
After;
On successful readiness check, the gateway will log the following message:
```
Readiness check passed because supergraph has been loaded already
```

On failed readiness check, the gateway was logging the following message:
Before;
```
Readiness check failed: Supergraph not loaded
```
It should make the users think it was not loaded or there is an issue with the supergraph.

After;
```
Readiness check failed because supergraph has not been loaded yet or failed to load
```