### PR TITLE
fix: setting the default polling interval correctly

### DIFF
--- a/.changeset/forty-timers-fly.md
+++ b/.changeset/forty-timers-fly.md
@@ -1,0 +1,10 @@
+---
+'@graphql-mesh/fusion-runtime': patch
+'@graphql-hive/gateway': patch
+'@graphql-hive/gateway-runtime': patch
+---
+
+Fix the bug on setting the default polling interval to 10 seconds
+So by default, the gateway will poll the schema every 10 seconds, and update the schema if it has changed.
+
+This PR also contains improvements on logging about polling

--- a/e2e/supergraph-url/supergraph-url.e2e.ts
+++ b/e2e/supergraph-url/supergraph-url.e2e.ts
@@ -3276,3 +3276,26 @@ it('should gateway a schema from a url with pathname and extension', async () =>
     }
   `);
 });
+
+it('should set the default polling interval to 10 seconds', async () => {
+  const cdn = await service('cdn');
+
+  const { execute, getStd } = await gateway({
+    supergraph: `http://0.0.0.0:${cdn.port}`,
+    env: {
+      DEBUG: 1,
+    },
+  });
+
+  await expect(execute({ query: `{ __typename }` })).resolves.toEqual({
+    data: {
+      __typename: 'Query',
+    },
+  });
+
+  const logs = getStd('both');
+
+  expect(logs).toContain(
+    'Starting polling to Supergraph with interval 10 seconds',
+  );
+});

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -584,3 +584,32 @@ export function wrapMergedTypeResolver<TContext extends Record<string, any>>(
     );
   };
 }
+
+// Taken from https://stackoverflow.com/questions/8211744/convert-time-interval-given-in-seconds-into-more-human-readable-form
+export function millisecondsToStr(milliseconds: number): string {
+  // TIP: to find current time in milliseconds, use:
+  // current_time_milliseconds = new Date().getTime();
+
+  function numberEnding(number: number) {
+    return number > 1 ? 's' : '';
+  }
+
+  let temp = Math.floor(milliseconds / 1000);
+  const days = Math.floor((temp %= 31536000) / 86400);
+  if (days) {
+    return days + ' day' + numberEnding(days);
+  }
+  const hours = Math.floor((temp %= 86400) / 3600);
+  if (hours) {
+    return hours + ' hour' + numberEnding(hours);
+  }
+  const minutes = Math.floor((temp %= 3600) / 60);
+  if (minutes) {
+    return minutes + ' minute' + numberEnding(minutes);
+  }
+  const seconds = temp % 60;
+  if (seconds) {
+    return seconds + ' second' + numberEnding(seconds);
+  }
+  return 'less than a second'; //'just now' //or other string you like;
+}

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -246,6 +246,7 @@ let cli = new Command()
       '--polling <duration>',
       `schema polling interval in human readable duration (default: ${JSON.stringify(defaultOptions.polling)})`,
     )
+      .default(parseDuration(defaultOptions.polling))
       .env('POLLING')
       .argParser((v) => {
         const interval = parseDuration(v);

--- a/packages/gateway/src/commands/supergraph.ts
+++ b/packages/gateway/src/commands/supergraph.ts
@@ -74,7 +74,7 @@ export const addCommand: AddCommand = (ctx, cli) =>
         | GatewayHiveCDNOptions
         | GatewayGraphOSManagedFederationOptions = 'supergraph.graphql';
       if (schemaPathOrUrl) {
-        ctx.log.info(`Found schema path or URL: ${schemaPathOrUrl}`);
+        ctx.log.info(`Supergraph will be loaded from ${schemaPathOrUrl}`);
         if (hiveCdnKey) {
           ctx.log.info(`Using Hive CDN key`);
           if (!isUrl(schemaPathOrUrl)) {

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -662,7 +662,12 @@ export function createGatewayRuntime<
 
       if (!isDynamicUnifiedGraphSchema(config.supergraph)) {
         // no polling for static schemas
+        logger.debug(`Disabling polling for static supergraph`);
         delete config.pollingInterval;
+      } else if (!config.pollingInterval) {
+        logger.debug(
+          `Polling interval not set for supergraph, if you want to get updates of supergraph, we recommend setting a polling interval`,
+        );
       }
 
       unifiedGraphFetcher = () =>
@@ -1087,10 +1092,6 @@ function isDynamicUnifiedGraphSchema(
     return false;
   }
   if (typeof schema === 'string') {
-    if (isValidPath(schema) && !isUrl(String(schema))) {
-      // local path
-      return false;
-    }
     try {
       // sdl
       parse(schema);


### PR DESCRIPTION
Fix the bug on setting the default polling interval to 10 seconds
So by default, the gateway will poll the schema every 10 seconds, and update the schema if it has changed.

This PR also contains improvements on logging about polling