### PR TITLE
enhance(executor-http/runtime): use `registerAbortSignalListener` more

### DIFF
--- a/.changeset/real-gifts-crash.md
+++ b/.changeset/real-gifts-crash.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/executor-http': patch
+'@graphql-hive/gateway-runtime': patch
+---
+
+No need to handle event listeners inside HTTP Executor thanks to the improvements with `@graphql-tools/utils`'s `registerAbortSignalListener` to avoid Node.js warnings when multiple event listeners registered to an `AbortSignal`


### PR DESCRIPTION
No need to handle event listeners inside HTTP Executor thanks to the improvements with `@graphql-tools/utils`'s `registerAbortSignalListener` to avoid Node.js warnings when multiple event listeners registered to an `AbortSignal`