### PR TITLE
fix(federation): shared mutation field should not be batched

### DIFF
--- a/.changeset/smart-wasps-smile.md
+++ b/.changeset/smart-wasps-smile.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/federation': patch
+---
+
+In case of shared root field on Mutation, it was batched incorrectly across subgraphs. But instead only one mutation should be called as mutations should not be parallel

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -1207,7 +1207,11 @@ export function getStitchingOptionsFromSupergraphSdl(
         return candidates[0].fieldConfig;
       }
     }
-    if (candidates.some((candidate) => rootTypeMap.has(candidate.type.name))) {
+    if (
+      candidates.some(
+        (candidate) => rootTypeMap.get(candidate.type.name) === 'query',
+      )
+    ) {
       const defaultMergedField = defaultMerger(candidates);
       return {
         ...defaultMergedField,


### PR DESCRIPTION
In case of shared root field on Mutation, it was batched incorrectly across subgraphs. But instead only one mutation should be called as mutations should not be parallel