### PR TITLE
fix(batch-delegate): memoize the key arguments correctly

### DIFF
--- a/.changeset/wicked-islands-march.md
+++ b/.changeset/wicked-islands-march.md
@@ -1,0 +1,65 @@
+---
+'@graphql-tools/batch-delegate': patch
+---
+
+Memoize the key arguments correctly;
+
+With the following schema and resolvers, `userById` should batch all the requests to `usersByIds`;
+
+```ts
+{
+      typeDefs: /* GraphQL */ `
+        type User {
+          id: ID!
+          email: String!
+        }
+        type Query {
+          userById(id: ID!): User
+          usersByIds(ids: [ID!]): [User]
+        }
+      `,
+      resolvers: {
+        Query: {
+          usersByIds: (_root, args) => {
+            return args.ids.map((id: string) => users.find((user) => user.id === id));
+          },
+          userById: (root, args, context, info) => {
+            return batchDelegateToSchema({
+              schema: userSubschema,
+              fieldName: 'usersByIds',
+              key: args.id,
+              rootValue: root,
+              context,
+              info,
+            })
+          },
+        },
+      },
+    }
+```
+
+This query should batch all the requests to `usersByIds`:
+
+```graphql
+{
+  userById(id: "1") {
+    id
+    email
+  }
+  userById(id: "2") {
+    id
+    email
+  }
+}
+```
+
+The delegation request should be;
+
+```graphql
+{
+  usersByIds(ids: ["1", "2"]) {
+    id
+    email
+  }
+}
+```

--- a/packages/batch-delegate/src/batchDelegateToSchema.ts
+++ b/packages/batch-delegate/src/batchDelegateToSchema.ts
@@ -1,8 +1,8 @@
 import { getLoader } from './getLoader.js';
 import { BatchDelegateOptions } from './types.js';
 
-export function batchDelegateToSchema<TContext = any>(
-  options: BatchDelegateOptions<TContext>,
+export function batchDelegateToSchema<TContext = any, K = any, V = any, C = K>(
+  options: BatchDelegateOptions<TContext, K, V, C>,
 ): any {
   const key = options.key;
   if (key == null) {

--- a/packages/batch-delegate/tests/basic.example.test.ts
+++ b/packages/batch-delegate/tests/basic.example.test.ts
@@ -102,7 +102,6 @@ describe('batch delegation within basic stitching example', () => {
     const chirps: any = result.data!['trendingChirps'];
     expect(chirps[0].chirpedAtUser.email).not.toBe(null);
   });
-
   test('works with key arrays', async () => {
     let numCalls = 0;
 
@@ -216,7 +215,6 @@ describe('batch delegation within basic stitching example', () => {
       ],
     });
   });
-
   test('works with keys passed to lazyOptionsFn', async () => {
     let numCalls = 0;
 

--- a/packages/batch-delegate/tests/cacheByArguments.test.ts
+++ b/packages/batch-delegate/tests/cacheByArguments.test.ts
@@ -123,26 +123,34 @@ describe('non-key arguments are taken into account when memoizing result', () =>
     const query = /* GraphQL */ `
       query {
         trendingChirps {
-          withObfuscatedEmail: chirpedAtUser(obfuscateEmail: true) { # Batch 1
+          withObfuscatedEmail: chirpedAtUser(obfuscateEmail: true) {
+            # Batch 1
             id
             email
-            friendsWithoutObfuscatedEmail: friends(obfuscateEmail: false) { # Batch 3
+            friendsWithoutObfuscatedEmail: friends(obfuscateEmail: false) {
+              # Batch 3
               id
               email
             }
-            friendsWithObfuscatedEmail: friends(obfuscateEmail: true) { # Batch 4
+            friendsWithObfuscatedEmail: friends(obfuscateEmail: true) {
+              # Batch 4
               id
               email
             }
           }
-          withoutObfuscatedEmail: chirpedAtUser(obfuscateEmail: false) { # Batch 2
+          withoutObfuscatedEmail: chirpedAtUser(obfuscateEmail: false) {
+            # Batch 2
             id
             email
-            friendsWithoutObfuscatedEmailArgButEmailObfuscatedArg: friends(obfuscateEmail: false) { # Batch 5
+            friendsWithoutObfuscatedEmailArgButEmailObfuscatedArg: friends(
+              obfuscateEmail: false
+            ) {
+              # Batch 5
               id
               email(obfuscated: true)
             }
-            friendsWithObfuscatedEmail: friends(obfuscateEmail: true) { # Batch 4
+            friendsWithObfuscatedEmail: friends(obfuscateEmail: true) {
+              # Batch 4
               id
               email
             }
@@ -162,106 +170,106 @@ describe('non-key arguments are taken into account when memoizing result', () =>
     if (isIncrementalResult(result)) throw Error('result is incremental');
 
     expect(result).toEqual({
-      "data": {
-        "trendingChirps": [
+      data: {
+        trendingChirps: [
           {
-            "withObfuscatedEmail": {
-              "email": "***",
-              "friendsWithObfuscatedEmail": [
+            withObfuscatedEmail: {
+              email: '***',
+              friendsWithObfuscatedEmail: [
                 {
-                  "email": "***",
-                  "id": "2",
+                  email: '***',
+                  id: '2',
                 },
                 {
-                  "email": "***",
-                  "id": "4",
-                },
-              ],
-              "friendsWithoutObfuscatedEmail": [
-                {
-                  "email": "2@test.com",
-                  "id": "2",
-                },
-                {
-                  "email": "4@test.com",
-                  "id": "4",
+                  email: '***',
+                  id: '4',
                 },
               ],
-              "id": "1",
+              friendsWithoutObfuscatedEmail: [
+                {
+                  email: '2@test.com',
+                  id: '2',
+                },
+                {
+                  email: '4@test.com',
+                  id: '4',
+                },
+              ],
+              id: '1',
             },
-            "withoutObfuscatedEmail": {
-              "email": "1@test.com",
-              "friendsWithObfuscatedEmail": [
+            withoutObfuscatedEmail: {
+              email: '1@test.com',
+              friendsWithObfuscatedEmail: [
                 {
-                  "email": "***",
-                  "id": "2",
+                  email: '***',
+                  id: '2',
                 },
                 {
-                  "email": "***",
-                  "id": "4",
-                },
-              ],
-              "friendsWithoutObfuscatedEmailArgButEmailObfuscatedArg": [
-                {
-                  "email": "***",
-                  "id": "2",
-                },
-                {
-                  "email": "***",
-                  "id": "4",
+                  email: '***',
+                  id: '4',
                 },
               ],
-              "id": "1",
+              friendsWithoutObfuscatedEmailArgButEmailObfuscatedArg: [
+                {
+                  email: '***',
+                  id: '2',
+                },
+                {
+                  email: '***',
+                  id: '4',
+                },
+              ],
+              id: '1',
             },
           },
           {
-            "withObfuscatedEmail": {
-              "email": "***",
-              "friendsWithObfuscatedEmail": [
+            withObfuscatedEmail: {
+              email: '***',
+              friendsWithObfuscatedEmail: [
                 {
-                  "email": "***",
-                  "id": "1",
+                  email: '***',
+                  id: '1',
                 },
                 {
-                  "email": "***",
-                  "id": "3",
-                },
-              ],
-              "friendsWithoutObfuscatedEmail": [
-                {
-                  "email": "1@test.com",
-                  "id": "1",
-                },
-                {
-                  "email": "3@test.com",
-                  "id": "3",
+                  email: '***',
+                  id: '3',
                 },
               ],
-              "id": "2",
+              friendsWithoutObfuscatedEmail: [
+                {
+                  email: '1@test.com',
+                  id: '1',
+                },
+                {
+                  email: '3@test.com',
+                  id: '3',
+                },
+              ],
+              id: '2',
             },
-            "withoutObfuscatedEmail": {
-              "email": "2@test.com",
-              "friendsWithObfuscatedEmail": [
+            withoutObfuscatedEmail: {
+              email: '2@test.com',
+              friendsWithObfuscatedEmail: [
                 {
-                  "email": "***",
-                  "id": "1",
+                  email: '***',
+                  id: '1',
                 },
                 {
-                  "email": "***",
-                  "id": "3",
-                },
-              ],
-              "friendsWithoutObfuscatedEmailArgButEmailObfuscatedArg": [
-                {
-                  "email": "***",
-                  "id": "1",
-                },
-                {
-                  "email": "***",
-                  "id": "3",
+                  email: '***',
+                  id: '3',
                 },
               ],
-              "id": "2",
+              friendsWithoutObfuscatedEmailArgButEmailObfuscatedArg: [
+                {
+                  email: '***',
+                  id: '1',
+                },
+                {
+                  email: '***',
+                  id: '3',
+                },
+              ],
+              id: '2',
             },
           },
         ],

--- a/packages/batch-delegate/tests/cacheByArguments.test.ts
+++ b/packages/batch-delegate/tests/cacheByArguments.test.ts
@@ -151,6 +151,9 @@ describe('non-key arguments are taken into account when memoizing result', () =>
       document: parse(query),
     });
 
+    // With obfuscateEmail true on root, we expect 2 calls to usersByIds
+    // With obfuscateEmail false on root, we expect 2 calls to usersByIds
+    // With friends, we have 2 calls like above.
     expect(numCalls).toEqual(4);
 
     if (isIncrementalResult(result)) throw Error('result is incremental');

--- a/packages/batch-delegate/tests/cacheByArguments.test.ts
+++ b/packages/batch-delegate/tests/cacheByArguments.test.ts
@@ -244,82 +244,42 @@ describe('non-key arguments are taken into account when memoizing result', () =>
           }
         `),
       });
-      expect(result).toMatchInlineSnapshot(
-        {
-          data: {
-            user1: {
-              email: 'john@doe.com',
-              friends: [
-                {
-                  email: 'john@doe.com',
-                  friends: [
-                    {
-                      email: 'john@doe.com',
-                      id: '1',
-                    },
-                  ],
-                  id: '1',
-                },
-              ],
-              id: '1',
-            },
-            user2: {
-              email: 'jane@doe.com',
-              friends: [
-                {
-                  email: 'jane@doe.com',
-                  friends: [
-                    {
-                      email: 'jane@doe.com',
-                      id: '2',
-                    },
-                  ],
-                  id: '2',
-                },
-              ],
-              id: '2',
-            },
+      expect(result).toEqual({
+        data: {
+          user1: {
+            email: 'john@doe.com',
+            friends: [
+              {
+                email: 'john@doe.com',
+                friends: [
+                  {
+                    email: 'john@doe.com',
+                    id: '1',
+                  },
+                ],
+                id: '1',
+              },
+            ],
+            id: '1',
+          },
+          user2: {
+            email: 'jane@doe.com',
+            friends: [
+              {
+                email: 'jane@doe.com',
+                friends: [
+                  {
+                    email: 'jane@doe.com',
+                    id: '2',
+                  },
+                ],
+                id: '2',
+              },
+            ],
+            id: '2',
           },
         },
-        `
-        {
-          "data": {
-            "user1": {
-              "email": "john@doe.com",
-              "friends": [
-                {
-                  "email": "john@doe.com",
-                  "friends": [
-                    {
-                      "email": "john@doe.com",
-                      "id": "1",
-                    },
-                  ],
-                  "id": "1",
-                },
-              ],
-              "id": "1",
-            },
-            "user2": {
-              "email": "jane@doe.com",
-              "friends": [
-                {
-                  "email": "jane@doe.com",
-                  "friends": [
-                    {
-                      "email": "jane@doe.com",
-                      "id": "2",
-                    },
-                  ],
-                  "id": "2",
-                },
-              ],
-              "id": "2",
-            },
-          },
-        }
-      `,
-      );
+      });
       // For each level of the query, we expect a single executor call
       // So we have 3 levels in this query, so we expect 3 executor calls
       expect(executorFn).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
Fixes the regression introduced in https://github.com/graphql-hive/gateway/pull/382
And breaks tests here https://github.com/ardatan/graphql-mesh/pull/8213

This pr fixes the memoization/caching the key arguments correctly;

With the following schema and resolvers, `userById` should batch all the requests to `usersByIds`;

```ts
{
      typeDefs: /* GraphQL */ `
        type User {
          id: ID!
          email: String!
        }
        type Query {
          userById(id: ID!): User
          usersByIds(ids: [ID!]): [User]
        }
      `,
      resolvers: {
        Query: {
          usersByIds: (_root, args) => {
            return args.ids.map((id: string) => users.find((user) => user.id === id));
          },
          userById: (root, args, context, info) => {
            return batchDelegateToSchema({
              schema: userSubschema,
              fieldName: 'usersByIds',
              key: args.id,
              rootValue: root,
              context,
              info,
            })
          },
        },
      },
    }
```

This query should batch all the requests to `usersByIds`:

```graphql
{
  userById(id: "1") {
    id
    email
  }
  userById(id: "2") {
    id
    email
  }
}
```

The delegation request should be;

```graphql
{
  usersByIds(ids: ["1", "2"]) {
    id
    email
  }
}
```