### PR TITLE
Update peer dependencies of abort signal any package

### DIFF
--- a/.changeset/@graphql-hive_gateway-abort-signal-any-401-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-abort-signal-any-401-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway-abort-signal-any': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`graphql@^15.0.0 || ^16.9.0 || ^17.0.0` ↗︎](https://www.npmjs.com/package/graphql/v/15.0.0) (from `^16.9.0 || ^17.0.0`, in `peerDependencies`)

--- a/packages/abort-signal-any/package.json
+++ b/packages/abort-signal-any/package.json
@@ -34,7 +34,7 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "graphql": "^16.9.0 || ^17.0.0"
+    "graphql": "^15.0.0 || ^16.9.0 || ^17.0.0"
   },
   "dependencies": {
     "@graphql-tools/utils": "^10.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3132,7 +3132,7 @@ __metadata:
     pkgroll: "npm:2.6.0"
     tslib: "npm:^2.8.1"
   peerDependencies:
-    graphql: ^16.9.0 || ^17.0.0
+    graphql: ^15.0.0 || ^16.9.0 || ^17.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Update peer dependencies of abort signal any package which is needed because it uses utils as a dependency

Fixes #399 