### PR TITLE
fix(federation): choose the best mutation root field, not take the last available one

### DIFF
--- a/.changeset/heavy-ducks-worry.md
+++ b/.changeset/heavy-ducks-worry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/stitch': patch
+---
+
+Respect fragments while calculating the selection score

--- a/.changeset/real-bulldogs-work.md
+++ b/.changeset/real-bulldogs-work.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/federation': patch
+---
+
+In case of shared Mutation field in different subgraphs, choose the best option instead of choosing the last option just like we do in Query root fields

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,6 @@ on:
       - main
   pull_request:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
-
 env:
   NODE_NO_WARNINGS: 1
   CI: true
@@ -16,6 +14,9 @@ jobs:
   dependencies:
     if: github.event_name == 'pull_request' && github.event.pull_request.title != 'Upcoming Release Changes'
     name: Dependencies
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     uses: the-guild-org/shared-config/.github/workflows/changesets-dependencies.yml@v1
     with:
       node-version-file: .node-version
@@ -24,6 +25,9 @@ jobs:
   snapshot:
     if: github.event_name == 'pull_request'
     name: Snapshot
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
       id-token: write
@@ -38,6 +42,7 @@ jobs:
       npmToken: ${{ secrets.NPM_TOKEN }}
   stable:
     if: github.ref == 'refs/heads/main'
+    concurrency: ${{ github.workflow }}-${{ github.ref }}
     name: Stable
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.title != 'Upcoming Release Changes'
     name: Dependencies
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-dependencies
       cancel-in-progress: true
     uses: the-guild-org/shared-config/.github/workflows/changesets-dependencies.yml@v1
     with:
@@ -26,7 +26,7 @@ jobs:
     if: github.event_name == 'pull_request'
     name: Snapshot
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-release-snapshot
       cancel-in-progress: true
     permissions:
       contents: read
@@ -42,7 +42,7 @@ jobs:
       npmToken: ${{ secrets.NPM_TOKEN }}
   stable:
     if: github.ref == 'refs/heads/main'
-    concurrency: ${{ github.workflow }}-${{ github.ref }}
+    concurrency: ${{ github.workflow }}-${{ github.ref }}-release-stable
     name: Stable
     permissions:
       contents: read

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -1207,11 +1207,14 @@ export function getStitchingOptionsFromSupergraphSdl(
         return candidates[0].fieldConfig;
       }
     }
-    if (
-      candidates.some(
-        (candidate) => rootTypeMap.get(candidate.type.name) === 'query',
-      )
-    ) {
+    let operationType: OperationTypeNode | undefined;
+    for (const candidate of candidates) {
+      const candidateOperationType = rootTypeMap.get(candidate.type.name);
+      if (candidateOperationType) {
+        operationType = candidateOperationType;
+      }
+    }
+    if (operationType) {
       const defaultMergedField = defaultMerger(candidates);
       return {
         ...defaultMergedField,
@@ -1317,6 +1320,9 @@ export function getStitchingOptionsFromSupergraphSdl(
                 }
               : info,
           });
+          if (operationType !== 'query') {
+            return mainJob;
+          }
           if (isPromise(mainJob)) {
             hasPromise = true;
           }

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -1244,7 +1244,10 @@ export function getStitchingOptionsFromSupergraphSdl(
                   () => true,
                   info.fragments,
                 );
-              const score = calculateSelectionScore(unavailableFields);
+              const score = calculateSelectionScore(
+                unavailableFields,
+                info.fragments,
+              );
               if (score < currentScore) {
                 currentScore = score;
                 currentSubschema = candidate.transformedSubschema;
@@ -1278,6 +1281,7 @@ export function getStitchingOptionsFromSupergraphSdl(
                     );
                   const friendScore = calculateSelectionScore(
                     unavailableFieldsInFriend,
+                    info.fragments,
                   );
                   if (friendScore < score) {
                     const unavailableInFriendSelectionSet: SelectionSetNode = {


### PR DESCRIPTION
In case of shared Mutation field in different subgraphs, choose the best option instead of choosing the last option just like we do in Query root fields