### PR TITLE
fix(delegate): spread on unions

### DIFF
--- a/.changeset/beige-experts-rule.md
+++ b/.changeset/beige-experts-rule.md
@@ -1,0 +1,73 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+While creating a delegation request for the subschema, an selection set should be spreaded on the union type field correctly.
+
+In case of the following schema;
+
+```graphql
+type Query {
+    foo: Foo
+}
+
+union Foo = Bar | Baz
+
+type Bar {
+    id: ID!
+    name: String
+    age: Age
+}
+
+type Age {
+    years: Int
+    months: Int
+}
+
+type Baz {
+    id: ID!
+    name: Name
+    age: Int
+}
+
+type Name {
+    first: String
+    last: String
+}
+```
+
+If the operation is generated as following;
+```graphql
+query {
+    foo {
+        id
+        name
+        age {
+            years
+            months
+        }
+    }
+}
+```
+
+It should be spreaded on the union type field correctly as following;
+```graphql
+query {
+    foo {
+        ... on Bar {
+            id
+            age {
+                years
+                months
+            }
+        }
+        ... on Baz {
+            id
+            name {
+                first
+                last
+            }
+        }
+    }
+}
+```

--- a/packages/delegate/tests/finalizeGatewayRequest.test.ts
+++ b/packages/delegate/tests/finalizeGatewayRequest.test.ts
@@ -188,19 +188,17 @@ describe('finalizeGatewayRequest', () => {
         } as DelegationContext,
         () => {},
       );
-      expect(print(filteredQuery.document)).toBe(/* GraphQL */ `
-        query foo {
-          foo {
-            __typename
-            ... on Baz {
-              name {
-                first
-                last
-              }
-            }
-          }
-        }
-      `);
+      expect(print(filteredQuery.document)).toBe(`query foo {
+  foo {
+    __typename
+    ... on Baz {
+      name {
+        first
+        last
+      }
+    }
+  }
+}`);
     });
     it('should remove fields without selection sets on composite types', () => {
       const query = parse(/* GraphQL */ `
@@ -219,16 +217,14 @@ describe('finalizeGatewayRequest', () => {
         } as DelegationContext,
         () => {},
       );
-      expect(print(filteredQuery.document)).toBe(/* GraphQL */ `
-        query foo {
-          foo {
-            __typename
-            ... on Bar {
-              name
-            }
-          }
-        }
-      `);
+      expect(print(filteredQuery.document)).toBe(`query foo {
+  foo {
+    __typename
+    ... on Bar {
+      name
+    }
+  }
+}`);
     });
   });
 });


### PR DESCRIPTION
While creating a delegation request for the subschema, an selection set should be spreaded on the union type field correctly.

In case of the following schema;

```graphql
type Query {
    foo: Foo
}

union Foo = Bar | Baz

type Bar {
    id: ID!
    name: String
    age: Age
}

type Age {
    years: Int
    months: Int
}

type Baz {
    id: ID!
    name: Name
    age: Int
}

type Name {
    first: String
    last: String
}
```

If the operation is generated as following;
```graphql
query {
    foo {
        id
        name
        age {
            years
            months
        }
    }
}
```

It should be spreaded on the union type field correctly as following;
```graphql
query {
    foo {
        ... on Bar {
            id
            age {
                years
                months
            }
        }
        ... on Baz {
            id
            name {
                first
                last
            }
        }
    }
}
```