### PR TITLE
fix(wrap/RenameObjectFieldArguments): transform `args` given in delegation parameters

### DIFF
--- a/.changeset/tender-queens-wait.md
+++ b/.changeset/tender-queens-wait.md
@@ -1,0 +1,66 @@
+---
+'@graphql-tools/wrap': patch
+---
+
+`RenameObjectFieldArguments` should transform the passed `args` in `delegationContext`.
+
+When a subschema's a root field argument is renamed, the passed arguments should be also transformed;
+
+```graphql
+type Query {
+    # This is the original field
+    book(book_id: ID): [Book]
+}
+
+type Book {
+    id: ID
+    title: String
+}
+```
+
+When the subschema above is transformed to;
+
+```graphql
+type Query {
+    # This is the transformed field
+    book(bookId: ID): [Book]
+}
+
+type Book {
+    id: ID
+    title: String
+}
+```
+
+The following call should be transformed;
+
+```ts
+delegateToSchema({
+    schema: {
+        schema,
+        transforms: [
+            new RenameObjectFieldArguments((typeName, fieldName, argName) => {
+                if (typeName === 'Query' && fieldName === 'book' && argName === 'book_id') {
+                    return 'bookId';
+                }
+                return argName;
+            })
+        ]
+    },
+    operation: 'query',
+    fieldName: 'book',
+    args: {
+        bookId: '1'
+    }
+})
+```
+
+To this query;
+
+```graphql
+{
+    book(book_id: "1") {
+        # ...
+    }
+}
+```

--- a/e2e/naming-convention-additional-typedefs/__snapshots__/naming-convention-additional-typedefs.e2e.ts.snap
+++ b/e2e/naming-convention-additional-typedefs/__snapshots__/naming-convention-additional-typedefs.e2e.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Additional Type Definitions with Naming Convention composes the schema correctly 1`] = `
-"schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://the-guild.dev/graphql/mesh/spec/v1.0", import: ["@statusCodeTypeName", "@httpOperation", "@transport", "@source", "@extraSchemaDefinitionDirective"]) {
+"schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://the-guild.dev/graphql/mesh/spec/v1.0", import: ["@httpOperation", "@transport", "@source", "@extraSchemaDefinitionDirective"]) {
   query: Query
 }
 
@@ -18,8 +18,6 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-
-directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: String) repeatable on UNION
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) repeatable on FIELD_DEFINITION
 
@@ -57,18 +55,14 @@ scalar _DirectiveExtensions @join__type(graph: AUTHORS) @join__type(graph: BOOKS
 
 type Query @extraSchemaDefinitionDirective(directives: {transport: [{subgraph: "authors", kind: "rest", location: "http://localhost:<authors_port>"}]}) @extraSchemaDefinitionDirective(directives: {transport: [{subgraph: "books", kind: "rest", location: "http://localhost:<books_port>"}]}) @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
   getAuthors: [Author] @httpOperation(subgraph: "authors", path: "/authors", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @source(name: "get_authors", type: "[Author]", subgraph: "authors") @join__field(graph: AUTHORS)
-  getAuthor(authorId: String! @source(name: "author_id", type: "String!", subgraph: "authors")): get_author_response @httpOperation(subgraph: "authors", path: "/authors/{args.author_id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @source(name: "get_author", type: "get_author_response", subgraph: "authors") @join__field(graph: AUTHORS)
+  getAuthor(authorId: String! @source(name: "author_id", type: "String!", subgraph: "authors")): Author @httpOperation(subgraph: "authors", path: "/authors/{args.author_id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @source(name: "get_author", type: "Author", subgraph: "authors") @join__field(graph: AUTHORS)
   getBooks: [Book] @httpOperation(subgraph: "books", path: "/books", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @source(name: "get_books", type: "[Book]", subgraph: "books") @join__field(graph: BOOKS)
-  getBook(bookId: String! @source(name: "book_id", type: "String!", subgraph: "books")): get_book_response @httpOperation(subgraph: "books", path: "/books/{args.book_id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @source(name: "get_book", type: "get_book_response", subgraph: "books") @join__field(graph: BOOKS)
+  getBook(bookId: String! @source(name: "book_id", type: "String!", subgraph: "books")): Book @httpOperation(subgraph: "books", path: "/books/{args.book_id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @source(name: "get_book", type: "Book", subgraph: "books") @join__field(graph: BOOKS)
 }
 
 type Author @join__type(graph: AUTHORS) {
   id: String!
   name: String!
-}
-
-type get_author_404_response @join__type(graph: AUTHORS) {
-  message: String!
 }
 
 type Book @join__type(graph: BOOKS) {
@@ -77,14 +71,6 @@ type Book @join__type(graph: BOOKS) {
   authorId: String! @source(name: "author_id", type: "String!", subgraph: "books")
   author: Author @resolveTo(sourceName: "authors", sourceTypeName: "Query", sourceFieldName: "getAuthor", requiredSelectionSet: "{ authorId }", sourceArgs: {authorId: "{root.authorId}"}) @additionalField
 }
-
-type get_book_404_response @join__type(graph: BOOKS) {
-  message: String!
-}
-
-union get_author_response @statusCodeTypeName(subgraph: "authors", statusCode: "200", typeName: "Author") @statusCodeTypeName(subgraph: "authors", statusCode: "404", typeName: "get_author_404_response") @join__type(graph: AUTHORS) @join__unionMember(graph: AUTHORS, member: "Author") @join__unionMember(graph: AUTHORS, member: "get_author_404_response") = Author | get_author_404_response
-
-union get_book_response @statusCodeTypeName(subgraph: "books", statusCode: "200", typeName: "Book") @statusCodeTypeName(subgraph: "books", statusCode: "404", typeName: "get_book_404_response") @join__type(graph: BOOKS) @join__unionMember(graph: BOOKS, member: "Book") @join__unionMember(graph: BOOKS, member: "get_book_404_response") = Book | get_book_404_response
 
 enum HTTPMethod @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
   GET @join__enumValue(graph: AUTHORS) @join__enumValue(graph: BOOKS)

--- a/e2e/naming-convention-additional-typedefs/__snapshots__/naming-convention-additional-typedefs.e2e.ts.snap
+++ b/e2e/naming-convention-additional-typedefs/__snapshots__/naming-convention-additional-typedefs.e2e.ts.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Additional Type Definitions with Naming Convention composes the schema correctly 1`] = `
+"schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://the-guild.dev/graphql/mesh/spec/v1.0", import: ["@statusCodeTypeName", "@httpOperation", "@transport", "@source", "@extraSchemaDefinitionDirective"]) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: String) repeatable on UNION
+
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) repeatable on FIELD_DEFINITION
+
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
+
+directive @source(name: String!, type: String, subgraph: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions) repeatable on OBJECT
+
+directive @additionalField on FIELD_DEFINITION
+
+scalar join__FieldSet
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+enum join__Graph {
+  AUTHORS @join__graph(name: "authors", url: "http://localhost:<authors_port>")
+  BOOKS @join__graph(name: "books", url: "http://localhost:<books_port>")
+}
+
+scalar ObjMap @join__type(graph: AUTHORS) @join__type(graph: BOOKS)
+
+scalar _DirectiveExtensions @join__type(graph: AUTHORS) @join__type(graph: BOOKS)
+
+type Query @extraSchemaDefinitionDirective(directives: {transport: [{subgraph: "authors", kind: "rest", location: "http://localhost:<authors_port>"}]}) @extraSchemaDefinitionDirective(directives: {transport: [{subgraph: "books", kind: "rest", location: "http://localhost:<books_port>"}]}) @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
+  getAuthors: [Author] @httpOperation(subgraph: "authors", path: "/authors", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @source(name: "get_authors", type: "[Author]", subgraph: "authors") @join__field(graph: AUTHORS)
+  getAuthor(authorId: String! @source(name: "author_id", type: "String!", subgraph: "authors")): get_author_response @httpOperation(subgraph: "authors", path: "/authors/{args.author_id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @source(name: "get_author", type: "get_author_response", subgraph: "authors") @join__field(graph: AUTHORS)
+  getBooks: [Book] @httpOperation(subgraph: "books", path: "/books", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @source(name: "get_books", type: "[Book]", subgraph: "books") @join__field(graph: BOOKS)
+  getBook(bookId: String! @source(name: "book_id", type: "String!", subgraph: "books")): get_book_response @httpOperation(subgraph: "books", path: "/books/{args.book_id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @source(name: "get_book", type: "get_book_response", subgraph: "books") @join__field(graph: BOOKS)
+}
+
+type Author @join__type(graph: AUTHORS) {
+  id: String!
+  name: String!
+}
+
+type get_author_404_response @join__type(graph: AUTHORS) {
+  message: String!
+}
+
+type Book @join__type(graph: BOOKS) {
+  id: String!
+  title: String!
+  authorId: String! @source(name: "author_id", type: "String!", subgraph: "books")
+  author: Author @resolveTo(sourceName: "authors", sourceTypeName: "Query", sourceFieldName: "getAuthor", requiredSelectionSet: "{ authorId }", sourceArgs: {authorId: "{root.authorId}"}) @additionalField
+}
+
+type get_book_404_response @join__type(graph: BOOKS) {
+  message: String!
+}
+
+union get_author_response @statusCodeTypeName(subgraph: "authors", statusCode: "200", typeName: "Author") @statusCodeTypeName(subgraph: "authors", statusCode: "404", typeName: "get_author_404_response") @join__type(graph: AUTHORS) @join__unionMember(graph: AUTHORS, member: "Author") @join__unionMember(graph: AUTHORS, member: "get_author_404_response") = Author | get_author_404_response
+
+union get_book_response @statusCodeTypeName(subgraph: "books", statusCode: "200", typeName: "Book") @statusCodeTypeName(subgraph: "books", statusCode: "404", typeName: "get_book_404_response") @join__type(graph: BOOKS) @join__unionMember(graph: BOOKS, member: "Book") @join__unionMember(graph: BOOKS, member: "get_book_404_response") = Book | get_book_404_response
+
+enum HTTPMethod @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
+  GET @join__enumValue(graph: AUTHORS) @join__enumValue(graph: BOOKS)
+  HEAD @join__enumValue(graph: AUTHORS) @join__enumValue(graph: BOOKS)
+  POST @join__enumValue(graph: AUTHORS) @join__enumValue(graph: BOOKS)
+  PUT @join__enumValue(graph: AUTHORS) @join__enumValue(graph: BOOKS)
+  DELETE @join__enumValue(graph: AUTHORS) @join__enumValue(graph: BOOKS)
+  CONNECT @join__enumValue(graph: AUTHORS) @join__enumValue(graph: BOOKS)
+  OPTIONS @join__enumValue(graph: AUTHORS) @join__enumValue(graph: BOOKS)
+  TRACE @join__enumValue(graph: AUTHORS) @join__enumValue(graph: BOOKS)
+  PATCH @join__enumValue(graph: AUTHORS) @join__enumValue(graph: BOOKS)
+}
+"
+`;

--- a/e2e/naming-convention-additional-typedefs/mesh.config.ts
+++ b/e2e/naming-convention-additional-typedefs/mesh.config.ts
@@ -1,0 +1,52 @@
+import {
+  createNamingConventionTransform,
+  defineConfig,
+} from '@graphql-mesh/compose-cli';
+import { Opts } from '@internal/testing';
+import { loadOpenAPISubgraph } from '@omnigraph/openapi';
+
+const opts = Opts(process.argv);
+const authorsPort = opts.getServicePort('authors');
+const booksPort = opts.getServicePort('books');
+
+export const composeConfig = defineConfig({
+  subgraphs: [
+    {
+      sourceHandler: loadOpenAPISubgraph('authors', {
+        source: `http://localhost:${authorsPort}/openapi.json`,
+        endpoint: `http://localhost:${authorsPort}`,
+      }),
+      transforms: [
+        createNamingConventionTransform({
+          fieldNames: 'camelCase',
+          fieldArgumentNames: 'camelCase',
+        }),
+      ],
+    },
+    {
+      sourceHandler: loadOpenAPISubgraph('books', {
+        source: `http://localhost:${booksPort}/openapi.json`,
+        endpoint: `http://localhost:${booksPort}`,
+        ignoreErrorResponses: true,
+      }),
+      transforms: [
+        createNamingConventionTransform({
+          fieldNames: 'camelCase',
+          fieldArgumentNames: 'camelCase',
+        }),
+      ],
+    },
+  ],
+  additionalTypeDefs: /* GraphQL */ `
+    extend type Book {
+      author: Author
+        @resolveTo(
+          sourceName: "authors"
+          sourceTypeName: "Query"
+          sourceFieldName: "getAuthor"
+          requiredSelectionSet: "{ authorId }"
+          sourceArgs: { authorId: "{root.authorId}" }
+        )
+    }
+  `,
+});

--- a/e2e/naming-convention-additional-typedefs/mesh.config.ts
+++ b/e2e/naming-convention-additional-typedefs/mesh.config.ts
@@ -15,6 +15,7 @@ export const composeConfig = defineConfig({
       sourceHandler: loadOpenAPISubgraph('authors', {
         source: `http://localhost:${authorsPort}/openapi.json`,
         endpoint: `http://localhost:${authorsPort}`,
+        ignoreErrorResponses: true,
       }),
       transforms: [
         createNamingConventionTransform({

--- a/e2e/naming-convention-additional-typedefs/naming-convention-additional-typedefs.e2e.ts
+++ b/e2e/naming-convention-additional-typedefs/naming-convention-additional-typedefs.e2e.ts
@@ -34,38 +34,36 @@ describe('Additional Type Definitions with Naming Convention', () => {
       `,
     });
     expect(result.errors).toBeUndefined();
-    expect(result.data).toMatchInlineSnapshot(`
-      {
-        "getBooks": [
-          {
-            "author": {
-              "id": "1",
-              "name": "F. Scott Fitzgerald",
-            },
-            "authorId": "1",
-            "id": "1",
-            "title": "The Great Gatsby",
+    expect(result.data).toEqual({
+      getBooks: [
+        {
+          author: {
+            id: '1',
+            name: 'F. Scott Fitzgerald',
           },
-          {
-            "author": {
-              "id": "2",
-              "name": "Harper Lee",
-            },
-            "authorId": "2",
-            "id": "2",
-            "title": "To Kill a Mockingbird",
+          authorId: '1',
+          id: '1',
+          title: 'The Great Gatsby',
+        },
+        {
+          author: {
+            id: '2',
+            name: 'Harper Lee',
           },
-          {
-            "author": {
-              "id": "3",
-              "name": "George Orwell",
-            },
-            "authorId": "3",
-            "id": "3",
-            "title": "1984",
+          authorId: '2',
+          id: '2',
+          title: 'To Kill a Mockingbird',
+        },
+        {
+          author: {
+            id: '3',
+            name: 'George Orwell',
           },
-        ],
-      }
-    `);
+          authorId: '3',
+          id: '3',
+          title: '1984',
+        },
+      ],
+    });
   });
 });

--- a/e2e/naming-convention-additional-typedefs/naming-convention-additional-typedefs.e2e.ts
+++ b/e2e/naming-convention-additional-typedefs/naming-convention-additional-typedefs.e2e.ts
@@ -1,0 +1,71 @@
+import { createTenv } from '@internal/e2e';
+import { describe, expect, it } from 'vitest';
+
+describe('Additional Type Definitions with Naming Convention', () => {
+  const tenv = createTenv(__dirname);
+  it('composes the schema correctly', async () => {
+    const composeResult = await tenv.composeWithMesh({
+      services: [await tenv.service('authors'), await tenv.service('books')],
+      maskServicePorts: true,
+    });
+    expect(composeResult.result).toMatchSnapshot();
+  });
+  it('executes the additional field correctly', async () => {
+    const composeResult = await tenv.composeWithMesh({
+      services: [await tenv.service('authors'), await tenv.service('books')],
+      output: 'graphql',
+    });
+    const gw = await tenv.gateway({
+      supergraph: composeResult.output,
+    });
+    const result = await gw.execute({
+      query: /* GraphQL */ `
+        query {
+          getBooks {
+            id
+            title
+            authorId
+            author {
+              id
+              name
+            }
+          }
+        }
+      `,
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toMatchInlineSnapshot(`
+      {
+        "getBooks": [
+          {
+            "author": {
+              "id": "1",
+              "name": "F. Scott Fitzgerald",
+            },
+            "authorId": "1",
+            "id": "1",
+            "title": "The Great Gatsby",
+          },
+          {
+            "author": {
+              "id": "2",
+              "name": "Harper Lee",
+            },
+            "authorId": "2",
+            "id": "2",
+            "title": "To Kill a Mockingbird",
+          },
+          {
+            "author": {
+              "id": "3",
+              "name": "George Orwell",
+            },
+            "authorId": "3",
+            "id": "3",
+            "title": "1984",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/e2e/naming-convention-additional-typedefs/package.json
+++ b/e2e/naming-convention-additional-typedefs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@e2e/naming-convention-additional-typedefs",
+  "private": true,
+  "dependencies": {
+    "@graphql-mesh/compose-cli": "^1.3.5",
+    "@omnigraph/openapi": "^0.108.14",
+    "fets": "^0.8.4",
+    "graphql": "16.10.0"
+  }
+}

--- a/e2e/naming-convention-additional-typedefs/services/authors.ts
+++ b/e2e/naming-convention-additional-typedefs/services/authors.ts
@@ -1,0 +1,62 @@
+import { createServer } from 'http';
+import { Opts } from '@internal/testing';
+import { createRouter, Response, Type } from 'fets';
+import { authors } from './data';
+
+const opts = Opts(process.argv);
+const port = opts.getServicePort('authors');
+
+const Author = Type.Object(
+  {
+    id: Type.String(),
+    name: Type.String(),
+  },
+  { title: 'Author' },
+);
+
+createServer(
+  createRouter()
+    .route({
+      operationId: 'get_authors',
+      method: 'GET',
+      path: '/authors',
+      schemas: {
+        responses: {
+          200: Type.Array(Author),
+        },
+      },
+      handler: () => Response.json(authors),
+    })
+    .route({
+      operationId: 'get_author',
+      method: 'GET',
+      path: '/authors/:author_id',
+      schemas: {
+        request: {
+          params: Type.Object({
+            author_id: Type.String(),
+          }),
+        },
+        responses: {
+          200: Author,
+          404: Type.Object({
+            message: Type.String(),
+          }),
+        },
+      },
+      handler: ({ params }) => {
+        const author = authors.find((author) => author.id === params.author_id);
+        if (!author) {
+          return Response.json(
+            {
+              message: 'Author not found',
+            },
+            {
+              status: 404,
+            },
+          );
+        }
+        return Response.json(author);
+      },
+    }),
+).listen(port);

--- a/e2e/naming-convention-additional-typedefs/services/books.ts
+++ b/e2e/naming-convention-additional-typedefs/services/books.ts
@@ -1,0 +1,63 @@
+import { createServer } from 'http';
+import { Opts } from '@internal/testing';
+import { createRouter, Response, Type } from 'fets';
+import { books } from './data';
+
+const opts = Opts(process.argv);
+const port = opts.getServicePort('books');
+
+const Book = Type.Object(
+  {
+    id: Type.String(),
+    title: Type.String(),
+    author_id: Type.String(),
+  },
+  { title: 'Book' },
+);
+
+createServer(
+  createRouter()
+    .route({
+      operationId: 'get_books',
+      method: 'GET',
+      path: '/books',
+      schemas: {
+        responses: {
+          200: Type.Array(Book),
+        },
+      },
+      handler: () => Response.json(books),
+    })
+    .route({
+      operationId: 'get_book',
+      method: 'GET',
+      path: '/books/:book_id',
+      schemas: {
+        request: {
+          params: Type.Object({
+            book_id: Type.String(),
+          }),
+        },
+        responses: {
+          200: Book,
+          404: Type.Object({
+            message: Type.String(),
+          }),
+        },
+      },
+      handler: ({ params }) => {
+        const book = books.find((book) => book.id === params.book_id);
+        if (!book) {
+          return Response.json(
+            {
+              message: 'Book not found',
+            },
+            {
+              status: 404,
+            },
+          );
+        }
+        return Response.json(book);
+      },
+    }),
+).listen(port);

--- a/e2e/naming-convention-additional-typedefs/services/data.ts
+++ b/e2e/naming-convention-additional-typedefs/services/data.ts
@@ -1,0 +1,32 @@
+export const books = [
+  {
+    id: '1',
+    title: 'The Great Gatsby',
+    author_id: '1',
+  },
+  {
+    id: '2',
+    title: 'To Kill a Mockingbird',
+    author_id: '2',
+  },
+  {
+    id: '3',
+    title: '1984',
+    author_id: '3',
+  },
+];
+
+export const authors = [
+  {
+    id: '1',
+    name: 'F. Scott Fitzgerald',
+  },
+  {
+    id: '2',
+    name: 'Harper Lee',
+  },
+  {
+    id: '3',
+    name: 'George Orwell',
+  },
+];

--- a/packages/wrap/src/transforms/RenameObjectFieldArguments.ts
+++ b/packages/wrap/src/transforms/RenameObjectFieldArguments.ts
@@ -23,6 +23,7 @@ export default class RenameObjectFieldArguments<TContext = Record<string, any>>
   private readonly renamer: RenamerFunction;
   private readonly transformer: TransformObjectFields<TContext>;
   private reverseMap: Record<string, Record<string, Record<string, string>>>;
+  private transformedSchema: GraphQLSchema;
 
   constructor(renamer: RenamerFunction) {
     this.renamer = renamer;
@@ -101,10 +102,11 @@ export default class RenameObjectFieldArguments<TContext = Record<string, any>>
       },
     });
 
-    return this.transformer.transformSchema(
+    this.transformedSchema = this.transformer.transformSchema(
       originalWrappingSchema,
       subschemaConfig,
     );
+    return this.transformedSchema;
   }
 
   public transformRequest(
@@ -113,7 +115,7 @@ export default class RenameObjectFieldArguments<TContext = Record<string, any>>
     transformationContext: RenameObjectFieldArgumentsTransformationContext,
   ): ExecutionRequest {
     if (delegationContext.args != null) {
-      const operationType = delegationContext.transformedSchema.getRootType(
+      const operationType = this.transformedSchema.getRootType(
         delegationContext.operation,
       );
       if (operationType != null) {

--- a/packages/wrap/src/transforms/RenameObjectFieldArguments.ts
+++ b/packages/wrap/src/transforms/RenameObjectFieldArguments.ts
@@ -23,7 +23,7 @@ export default class RenameObjectFieldArguments<TContext = Record<string, any>>
   private readonly renamer: RenamerFunction;
   private readonly transformer: TransformObjectFields<TContext>;
   private reverseMap: Record<string, Record<string, Record<string, string>>>;
-  private transformedSchema: GraphQLSchema;
+  private transformedSchema: GraphQLSchema | undefined;
 
   constructor(renamer: RenamerFunction) {
     this.renamer = renamer;
@@ -115,9 +115,9 @@ export default class RenameObjectFieldArguments<TContext = Record<string, any>>
     transformationContext: RenameObjectFieldArgumentsTransformationContext,
   ): ExecutionRequest {
     if (delegationContext.args != null) {
-      const operationType = this.transformedSchema.getRootType(
-        delegationContext.operation,
-      );
+      const operationType = (
+        this.transformedSchema || delegationContext.transformedSchema
+      ).getRootType(delegationContext.operation);
       if (operationType != null) {
         const reverseFieldsMap = this.reverseMap[operationType.name];
         if (reverseFieldsMap != null) {

--- a/packages/wrap/src/transforms/RenameObjectFieldArguments.ts
+++ b/packages/wrap/src/transforms/RenameObjectFieldArguments.ts
@@ -112,6 +112,30 @@ export default class RenameObjectFieldArguments<TContext = Record<string, any>>
     delegationContext: DelegationContext<TContext>,
     transformationContext: RenameObjectFieldArgumentsTransformationContext,
   ): ExecutionRequest {
+    if (delegationContext.args != null) {
+      const operationType = delegationContext.transformedSchema.getRootType(
+        delegationContext.operation,
+      );
+      if (operationType != null) {
+        const reverseFieldsMap = this.reverseMap[operationType.name];
+        if (reverseFieldsMap != null) {
+          const reverseArgsMap = reverseFieldsMap[delegationContext.fieldName];
+          if (reverseArgsMap) {
+            const newArgs = Object.create(null);
+            for (const argName in delegationContext.args) {
+              const argument = delegationContext.args[argName];
+              const newArgName = reverseArgsMap[argName];
+              if (newArgName != null) {
+                newArgs[newArgName] = argument;
+              } else {
+                newArgs[argName] = argument;
+              }
+            }
+            delegationContext.args = newArgs;
+          }
+        }
+      }
+    }
     return this.transformer.transformRequest(
       originalRequest,
       delegationContext,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,6 +2490,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/naming-convention-additional-typedefs@workspace:e2e/naming-convention-additional-typedefs":
+  version: 0.0.0-use.local
+  resolution: "@e2e/naming-convention-additional-typedefs@workspace:e2e/naming-convention-additional-typedefs"
+  dependencies:
+    "@graphql-mesh/compose-cli": "npm:^1.3.5"
+    "@omnigraph/openapi": "npm:^0.108.14"
+    fets: "npm:^0.8.4"
+    graphql: "npm:16.10.0"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/openapi-additional-resolvers@workspace:e2e/openapi-additional-resolvers":
   version: 0.0.0-use.local
   resolution: "@e2e/openapi-additional-resolvers@workspace:e2e/openapi-additional-resolvers"
@@ -3383,7 +3394,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/compose-cli@npm:^1.2.13, @graphql-mesh/compose-cli@npm:^1.2.7, @graphql-mesh/compose-cli@npm:^1.3.3":
+"@graphql-mesh/compose-cli@npm:^1.2.13, @graphql-mesh/compose-cli@npm:^1.2.7, @graphql-mesh/compose-cli@npm:^1.3.3, @graphql-mesh/compose-cli@npm:^1.3.5":
   version: 1.3.5
   resolution: "@graphql-mesh/compose-cli@npm:1.3.5"
   dependencies:
@@ -5170,7 +5181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@omnigraph/openapi@npm:^0.108.6":
+"@omnigraph/openapi@npm:^0.108.14, @omnigraph/openapi@npm:^0.108.6":
   version: 0.108.14
   resolution: "@omnigraph/openapi@npm:0.108.14"
   dependencies:


### PR DESCRIPTION
`RenameObjectFieldArguments` should transform the passed `args` in `delegationContext`.

When a subschema's a root field argument is renamed, the passed arguments should be also transformed;

```graphql
type Query {
    # This is the original field
    book(book_id: ID): [Book]
}

type Book {
    id: ID
    title: String
}
```

When the subschema above is transformed to;

```graphql
type Query {
    # This is the transformed field
    book(bookId: ID): [Book]
}

type Book {
    id: ID
    title: String
}
```

The following call should be transformed;

```ts
delegateToSchema({
    schema: {
        schema,
        transforms: [
            new RenameObjectFieldArguments((typeName, fieldName, argName) => {
                if (typeName === 'Query' && fieldName === 'book' && argName === 'book_id') {
                    return 'bookId';
                }
                return argName;
            })
        ]
    },
    operation: 'query',
    fieldName: 'book',
    args: {
        bookId: '1'
    }
})
```

To this query;

```graphql
{
    book(book_id: "1") {
        # ...
    }
}
```