### PR TITLE
Potential fix for code scanning alert no. 50: Prototype-polluting assignment

### DIFF
--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -99,7 +99,9 @@ export function mergeFields<TContext>(
 
   const leftOver = leftOverByDelegationPlan.get(delegationMaps);
   if (leftOver) {
-    object[PLAN_LEFT_OVER] = leftOver;
+    if (PLAN_LEFT_OVER !== '__proto__' && PLAN_LEFT_OVER !== 'constructor' && PLAN_LEFT_OVER !== 'prototype') {
+      object[PLAN_LEFT_OVER] = leftOver;
+    }
   }
 
   return mapMaybePromise(


### PR DESCRIPTION
Potential fix for [https://github.com/graphql-hive/gateway/security/code-scanning/50](https://github.com/graphql-hive/gateway/security/code-scanning/50)

To fix the prototype pollution vulnerability, we need to ensure that the `object` parameter does not contain dangerous property names like `__proto__`, `constructor`, or `prototype`. One way to achieve this is by using a prototype-less object created with `Object.create(null)` or by explicitly checking and rejecting dangerous property names.

The best way to fix the problem without changing existing functionality is to add a check before assigning to `object[PLAN_LEFT_OVER]` to ensure that the property name is safe. We can also use a prototype-less object for `object` to prevent prototype pollution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
