### PR TITLE
Potential fix for code scanning alert no. 51: Prototype-polluting assignment

### DIFF
--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -179,7 +179,7 @@ export function handleResolverResult(
   const objectSubschema = resolverResult[OBJECT_SUBSCHEMA_SYMBOL];
   const fieldSubschemaMap = resolverResult[FIELD_SUBSCHEMA_MAP_SYMBOL];
   for (const responseKey in resolverResult) {
-    if (responseKey === '__proto__') {
+    if (responseKey === '__proto__' || responseKey === 'constructor' || responseKey === 'prototype') {
       continue;
     }
     const existingPropValue = object[responseKey];


### PR DESCRIPTION
Potential fix for [https://github.com/graphql-hive/gateway/security/code-scanning/51](https://github.com/graphql-hive/gateway/security/code-scanning/51)

To fix the prototype pollution issue, we need to ensure that user-controlled property names cannot be used to modify the prototype of objects. This can be achieved by:
1. Adding checks to prevent the use of special property names like `__proto__`, `constructor`, and `prototype`.
2. Using a safer data structure like `Map` to store key-value pairs if possible.

In this case, we will add checks to prevent the use of special property names.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
