### PR TITLE
Potential fix for code scanning alert no. 52: Prototype-polluting assignment

### DIFF
--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -215,15 +215,19 @@ export function handleResolverResult(
                   ),
           );
         } else if (!(sourcePropValue instanceof Error)) {
-          object[responseKey] = mergeDeep(
-            [existingPropValue, sourcePropValue],
-            undefined,
-            true,
-            true,
-          );
+          if (responseKey !== '__proto__' && responseKey !== 'constructor' && responseKey !== 'prototype') {
+            object[responseKey] = mergeDeep(
+              [existingPropValue, sourcePropValue],
+              undefined,
+              true,
+              true,
+            );
+          }
         }
       } else {
-        object[responseKey] = sourcePropValue;
+        if (responseKey !== '__proto__' && responseKey !== 'constructor' && responseKey !== 'prototype') {
+          object[responseKey] = sourcePropValue;
+        }
       }
     }
     combinedFieldSubschemaMap[responseKey] =


### PR DESCRIPTION
Potential fix for [https://github.com/graphql-hive/gateway/security/code-scanning/52](https://github.com/graphql-hive/gateway/security/code-scanning/52)

To fix the prototype pollution issue, we need to ensure that no dangerous keys like `__proto__`, `constructor`, or `prototype` are assigned to the `object`. This can be achieved by adding a check before the assignment to filter out these keys. 

The best way to fix the problem without changing existing functionality is to add a check before the assignment on line 218 to ensure that the key is not one of the dangerous keys. This can be done by adding a condition to skip the assignment if the key is `__proto__`, `constructor`, or `prototype`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
