### PR TITLE
Potential fix for code scanning alert no. 53: Prototype-polluting assignment

### DIFF
--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -179,7 +179,7 @@ export function handleResolverResult(
   const objectSubschema = resolverResult[OBJECT_SUBSCHEMA_SYMBOL];
   const fieldSubschemaMap = resolverResult[FIELD_SUBSCHEMA_MAP_SYMBOL];
   for (const responseKey in resolverResult) {
-    if (responseKey === '__proto__') {
+    if (responseKey === '__proto__' || responseKey === 'constructor' || responseKey === 'prototype') {
       continue;
     }
     const existingPropValue = object[responseKey];


### PR DESCRIPTION
Potential fix for [https://github.com/graphql-hive/gateway/security/code-scanning/53](https://github.com/graphql-hive/gateway/security/code-scanning/53)

To fix the prototype pollution issue, we should ensure that no dangerous keys like `__proto__`, `constructor`, or `prototype` are used as property names. This can be achieved by adding a more comprehensive check before assigning values to `object[responseKey]`.

- Add a check to skip dangerous keys (`__proto__`, `constructor`, `prototype`) before assigning values to `object[responseKey]`.
- This change should be made in the `handleResolverResult` function in the `packages/delegate/src/mergeFields.ts` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
