### PR TITLE
Potential fix for code scanning alert no. 54: Prototype-polluting assignment

### DIFF
--- a/packages/wrap/src/transforms/TransformQuery.ts
+++ b/packages/wrap/src/transforms/TransformQuery.ts
@@ -55,7 +55,7 @@ export default class TransformQuery<TContext = Record<string, any>>
     errorPathTransformer?: ErrorPathTransformer;
     fragments?: Record<string, FragmentDefinitionNode>;
   }) {
-    this.path = path;
+    this.path = path.filter(key => key !== '__proto__' && key !== 'constructor' && key !== 'prototype');
     this.queryTransformer = queryTransformer;
     this.resultTransformer = resultTransformer;
     this.errorPathTransformer = errorPathTransformer;


### PR DESCRIPTION
Potential fix for [https://github.com/graphql-hive/gateway/security/code-scanning/54](https://github.com/graphql-hive/gateway/security/code-scanning/54)

To fix the prototype pollution issue, we need to ensure that the `path` array does not contain any keys that could modify `Object.prototype`, such as `__proto__`, `constructor`, or `prototype`. We can achieve this by adding a validation step in the constructor to filter out any such keys from the `path` array.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
