### PR TITLE
Potential fix for code scanning alert no. 55: Prototype-polluting assignment

### DIFF
--- a/packages/wrap/src/transforms/WrapQuery.ts
+++ b/packages/wrap/src/transforms/WrapQuery.ts
@@ -87,11 +87,18 @@ export default class WrapQuery<TContext = Record<string, any>>
       const path = [...this.path];
       while (path.length > 1) {
         const next = path.shift()!;
+        if (next === '__proto__' || next === 'constructor' || next === 'prototype') {
+          throw new Error('Invalid path key');
+        }
         if (data[next]) {
           data = data[next];
         }
       }
-      data[path[0]!] = this.extractor(data[path[0]!]);
+      const lastKey = path[0]!;
+      if (lastKey === '__proto__' || lastKey === 'constructor' || lastKey === 'prototype') {
+        throw new Error('Invalid path key');
+      }
+      data[lastKey] = this.extractor(data[lastKey]);
     }
 
     return {


### PR DESCRIPTION
Potential fix for [https://github.com/graphql-hive/gateway/security/code-scanning/55](https://github.com/graphql-hive/gateway/security/code-scanning/55)

To fix the prototype pollution issue, we need to ensure that the keys used to access and modify the `data` object are safe and do not include special property names like `__proto__`. One way to achieve this is by validating the keys in the `path` array before using them. We can reject any keys that match `__proto__`, `constructor`, or `prototype`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
