### PR TITLE
Redirect example services stdout and stderr to a file

### DIFF
--- a/examples/apq-subgraphs/.codesandbox/tasks.json
+++ b/examples/apq-subgraphs/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service greetings",
-      "command": "nohup npm run service:greetings $> service-greetings.out &"
+      "command": "nohup npm run service:greetings &> service-greetings.out &"
     },
     {
       "name": "Wait for service greetings",

--- a/examples/extra-fields/.codesandbox/tasks.json
+++ b/examples/extra-fields/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service foo",
-      "command": "nohup npm run service:foo $> service-foo.out &"
+      "command": "nohup npm run service:foo &> service-foo.out &"
     },
     {
       "name": "Wait for service foo",
@@ -14,7 +14,7 @@
     },
     {
       "name": "Start service bar",
-      "command": "nohup npm run service:bar $> service-bar.out &"
+      "command": "nohup npm run service:bar &> service-bar.out &"
     },
     {
       "name": "Wait for service bar",

--- a/examples/federation-example/.codesandbox/tasks.json
+++ b/examples/federation-example/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service accounts",
-      "command": "nohup npm run service:accounts $> service-accounts.out &"
+      "command": "nohup npm run service:accounts &> service-accounts.out &"
     },
     {
       "name": "Wait for service accounts",
@@ -14,7 +14,7 @@
     },
     {
       "name": "Start service inventory",
-      "command": "nohup npm run service:inventory $> service-inventory.out &"
+      "command": "nohup npm run service:inventory &> service-inventory.out &"
     },
     {
       "name": "Wait for service inventory",
@@ -22,7 +22,7 @@
     },
     {
       "name": "Start service products",
-      "command": "nohup npm run service:products $> service-products.out &"
+      "command": "nohup npm run service:products &> service-products.out &"
     },
     {
       "name": "Wait for service products",
@@ -30,7 +30,7 @@
     },
     {
       "name": "Start service reviews",
-      "command": "nohup npm run service:reviews $> service-reviews.out &"
+      "command": "nohup npm run service:reviews &> service-reviews.out &"
     },
     {
       "name": "Wait for service reviews",

--- a/examples/federation-mixed/.codesandbox/tasks.json
+++ b/examples/federation-mixed/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service accounts",
-      "command": "nohup npm run service:accounts $> service-accounts.out &"
+      "command": "nohup npm run service:accounts &> service-accounts.out &"
     },
     {
       "name": "Wait for service accounts",
@@ -14,7 +14,7 @@
     },
     {
       "name": "Start service inventory",
-      "command": "nohup npm run service:inventory $> service-inventory.out &"
+      "command": "nohup npm run service:inventory &> service-inventory.out &"
     },
     {
       "name": "Wait for service inventory",
@@ -22,7 +22,7 @@
     },
     {
       "name": "Start service products",
-      "command": "nohup npm run service:products $> service-products.out &"
+      "command": "nohup npm run service:products &> service-products.out &"
     },
     {
       "name": "Wait for service products",
@@ -30,7 +30,7 @@
     },
     {
       "name": "Start service reviews",
-      "command": "nohup npm run service:reviews $> service-reviews.out &"
+      "command": "nohup npm run service:reviews &> service-reviews.out &"
     },
     {
       "name": "Wait for service reviews",

--- a/examples/federation-subscriptions-passthrough/.codesandbox/tasks.json
+++ b/examples/federation-subscriptions-passthrough/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service products",
-      "command": "nohup npm run service:products $> service-products.out &"
+      "command": "nohup npm run service:products &> service-products.out &"
     },
     {
       "name": "Wait for service products",
@@ -14,7 +14,7 @@
     },
     {
       "name": "Start service reviews",
-      "command": "nohup npm run service:reviews $> service-reviews.out &"
+      "command": "nohup npm run service:reviews &> service-reviews.out &"
     },
     {
       "name": "Wait for service reviews",

--- a/examples/file-upload/.codesandbox/tasks.json
+++ b/examples/file-upload/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service bucket",
-      "command": "nohup npm run service:bucket $> service-bucket.out &"
+      "command": "nohup npm run service:bucket &> service-bucket.out &"
     },
     {
       "name": "Wait for service bucket",

--- a/examples/hmac-auth-https/.codesandbox/tasks.json
+++ b/examples/hmac-auth-https/.codesandbox/tasks.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "Start service users",
-      "command": "nohup npm run service:users $> service-users.out &"
+      "command": "nohup npm run service:users &> service-users.out &"
     },
     {
       "name": "Wait for service users",
@@ -18,7 +18,7 @@
     },
     {
       "name": "Start service comments",
-      "command": "nohup npm run service:comments $> service-comments.out &"
+      "command": "nohup npm run service:comments &> service-comments.out &"
     },
     {
       "name": "Wait for service comments",

--- a/examples/interface-additional-resolvers/.codesandbox/tasks.json
+++ b/examples/interface-additional-resolvers/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service Test",
-      "command": "nohup npm run service:Test $> service-Test.out &"
+      "command": "nohup npm run service:Test &> service-Test.out &"
     },
     {
       "name": "Wait for service Test",

--- a/examples/json-schema-subscriptions/.codesandbox/tasks.json
+++ b/examples/json-schema-subscriptions/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service api",
-      "command": "nohup npm run service:api $> service-api.out &"
+      "command": "nohup npm run service:api &> service-api.out &"
     },
     {
       "name": "Wait for service api",

--- a/examples/openapi-arg-rename/.codesandbox/tasks.json
+++ b/examples/openapi-arg-rename/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service Wiki",
-      "command": "nohup npm run service:Wiki $> service-Wiki.out &"
+      "command": "nohup npm run service:Wiki &> service-Wiki.out &"
     },
     {
       "name": "Wait for service Wiki",

--- a/examples/openapi-subscriptions/.codesandbox/tasks.json
+++ b/examples/openapi-subscriptions/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service api",
-      "command": "nohup npm run service:api $> service-api.out &"
+      "command": "nohup npm run service:api &> service-api.out &"
     },
     {
       "name": "Wait for service api",

--- a/examples/operation-field-permissions/.codesandbox/tasks.json
+++ b/examples/operation-field-permissions/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service users",
-      "command": "nohup npm run service:users $> service-users.out &"
+      "command": "nohup npm run service:users &> service-users.out &"
     },
     {
       "name": "Wait for service users",

--- a/examples/programmatic-batching/.codesandbox/tasks.json
+++ b/examples/programmatic-batching/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service api",
-      "command": "nohup npm run service:api $> service-api.out &"
+      "command": "nohup npm run service:api &> service-api.out &"
     },
     {
       "name": "Wait for service api",

--- a/examples/subscriptions-with-transforms/.codesandbox/tasks.json
+++ b/examples/subscriptions-with-transforms/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service my-subgraph",
-      "command": "nohup npm run service:my-subgraph $> service-my-subgraph.out &"
+      "command": "nohup npm run service:my-subgraph &> service-my-subgraph.out &"
     },
     {
       "name": "Wait for service my-subgraph",

--- a/examples/type-merging-batching/.codesandbox/tasks.json
+++ b/examples/type-merging-batching/.codesandbox/tasks.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "Start service authors",
-      "command": "nohup npm run service:authors $> service-authors.out &"
+      "command": "nohup npm run service:authors &> service-authors.out &"
     },
     {
       "name": "Wait for service authors",
@@ -14,7 +14,7 @@
     },
     {
       "name": "Start service books",
-      "command": "nohup npm run service:books $> service-books.out &"
+      "command": "nohup npm run service:books &> service-books.out &"
     },
     {
       "name": "Wait for service books",

--- a/internal/examples/src/convert.ts
+++ b/internal/examples/src/convert.ts
@@ -338,7 +338,7 @@ export async function convertE2EToExample(config: ConvertE2EToExampleConfig) {
 
         tasks.push({
           name: `Start service ${service}`,
-          // command: `nohup npm run service:${service} $> service-${service}.out &`,
+          // command: `nohup npm run service:${service} &> service-${service}.out &`,
           command: `npm run service:${service}`,
           background: {
             service,
@@ -492,7 +492,7 @@ export async function convertE2EToExample(config: ConvertE2EToExampleConfig) {
             ? [
                 {
                   name: task.name,
-                  command: `nohup ${task.command} $> service-${background.service}.out &`,
+                  command: `nohup ${task.command} &> service-${background.service}.out &`,
                 },
                 background.wait,
               ]


### PR DESCRIPTION
Correct syntax is using `&>` (and not `$>`).