### PR TITLE
Fix polling interval option

### DIFF
--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -256,7 +256,7 @@ let cli = new Command()
   )
   .addOption(
     new Option(
-      '--polling, --pollingInterval <duration>',
+      '--polling <duration>',
       `schema polling interval in human readable duration`,
     )
       .default(10_000, '10s')

--- a/packages/gateway/src/commands/proxy.ts
+++ b/packages/gateway/src/commands/proxy.ts
@@ -113,6 +113,7 @@ export const addCommand: AddCommand = (ctx, cli) =>
         ...defaultOptions,
         ...loadedConfig,
         ...opts,
+        pollingInterval: opts.polling,
         ...(hiveRegistryToken
           ? {
               reporting: {

--- a/packages/gateway/src/commands/subgraph.ts
+++ b/packages/gateway/src/commands/subgraph.ts
@@ -74,6 +74,7 @@ export const addCommand: AddCommand = (ctx, cli) =>
         ...defaultOptions,
         ...loadedConfig,
         ...opts,
+        pollingInterval: opts.polling,
         ...(hiveRegistryToken
           ? {
               reporting: {

--- a/packages/gateway/src/commands/supergraph.ts
+++ b/packages/gateway/src/commands/supergraph.ts
@@ -198,6 +198,7 @@ export const addCommand: AddCommand = (ctx, cli) =>
         ...defaultOptions,
         ...loadedConfig,
         ...opts,
+        pollingInterval: opts.polling,
         ...registryConfig,
         supergraph,
         logging: loadedConfig.logging ?? ctx.log,


### PR DESCRIPTION
No need for changeset because the CLI argument was already `polling`, and I changed it to use `pollingInterval` as an option as well to align it with the runtime option `pollingInterval`(we have never released this). 
Now that change is reverted, and the runtime value is taken from `--polling` again.
Reverts this; https://github.com/graphql-hive/gateway/commit/df203610ff9ed50adb3c3c82631ecb5324648486#diff-d6cbbbfb5c53370e686cde8de203e1c0922897847f0ce2595b178af2421197aeR259
It fixes the error when having both `--polling` and `--pollingInterval` in the commanderjs configuration