### PR TITLE
Correct changeset to make a minor release

### DIFF
--- a/.changeset/cyan-zoos-sniff.md
+++ b/.changeset/cyan-zoos-sniff.md
@@ -1,6 +1,5 @@
 ---
-'@graphql-hive/gateway': patch
-'@graphql-hive/gateway-runtime': patch
+'@graphql-hive/gateway-runtime': minor
 ---
 
 Export `getGraphQLWSOptions` function that creates `graphql-ws` for the Hive Gateway


### PR DESCRIPTION
As we export a new thing, `minor` bump makes more sense