### PR TITLE
enhance(runtime): prepare for the future supergraph executor

### DIFF
--- a/.changeset/light-badgers-tan.md
+++ b/.changeset/light-badgers-tan.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/fusion-runtime': patch
+---
+
+Refactor to make it easier to replace the supergraph execution

--- a/packages/fusion-runtime/src/federation/subgraph.ts
+++ b/packages/fusion-runtime/src/federation/subgraph.ts
@@ -39,7 +39,11 @@ import {
   typeFromAST,
   visit,
 } from 'graphql';
-import { compareSubgraphNames, TransportEntry, type getOnSubgraphExecute } from '../utils';
+import {
+  compareSubgraphNames,
+  TransportEntry,
+  type getOnSubgraphExecute,
+} from '../utils';
 
 export interface HandleFederationSubschemaOpts {
   subschemaConfig: SubschemaConfig & { endpoint?: string };
@@ -64,10 +68,11 @@ export function handleFederationSubschema({
   const subgraphName =
     (subschemaConfig.name =
       realSubgraphNameMap?.get(subschemaConfig.name || '') ||
-      subschemaConfig.name) || ''; const subgraphDirectives = getDirectiveExtensions<{
-        transport: TransportEntry;
-        [key: string]: any;
-      }>(subschemaConfig.schema);
+      subschemaConfig.name) || '';
+  const subgraphDirectives = getDirectiveExtensions<{
+    transport: TransportEntry;
+    [key: string]: any;
+  }>(subschemaConfig.schema);
 
   // We need to add subgraph specific directives from supergraph to the subgraph schema
   // So the executor can use it

--- a/packages/fusion-runtime/src/federation/supergraph.ts
+++ b/packages/fusion-runtime/src/federation/supergraph.ts
@@ -184,6 +184,8 @@ export const handleFederationSupergraph: UnifiedGraphHandler = function ({
     }
   }
 
+  const unifiedGraphDirectives = getDirectiveExtensions(unifiedGraph);
+
   let executableUnifiedGraph = getStitchedSchemaFromSupergraphSdl({
     supergraphSdl: getDocumentNodeFromSchema(unifiedGraph),
     /**
@@ -196,6 +198,7 @@ export const handleFederationSupergraph: UnifiedGraphHandler = function ({
     onSubschemaConfig: (subschemaConfig) =>
       handleFederationSubschema({
         subschemaConfig,
+        unifiedGraphDirectives,
         realSubgraphNameMap,
         additionalTypeDefs,
         stitchingDirectivesTransformer,

--- a/packages/fusion-runtime/src/federation/supergraph.ts
+++ b/packages/fusion-runtime/src/federation/supergraph.ts
@@ -1,4 +1,3 @@
-import type { TransportEntry } from '@graphql-mesh/transport-common';
 import type { YamlConfig } from '@graphql-mesh/types';
 import {
   getInContextSDK,
@@ -164,13 +163,9 @@ export const handleFederationSupergraph: UnifiedGraphHandler = function ({
 }: UnifiedGraphHandlerOpts): UnifiedGraphHandlerResult {
   const additionalTypeDefs = [...asArray(additionalTypeDefsFromConfig)];
   const additionalResolvers = [...asArray(additionalResolversFromConfig)];
-  const transportEntryMap: Record<string, TransportEntry> = {};
   let subschemas: SubschemaConfig[] = [];
   const stitchingDirectivesTransformer =
     getStitchingDirectivesTransformerForSubschema();
-  unifiedGraph = restoreExtraDirectives(unifiedGraph);
-  // Get Transport Information from Schema Directives
-  const schemaDirectives = getDirectiveExtensions(unifiedGraph);
   // Workaround to get the real name of the subschema
   const realSubgraphNameMap = new Map<string, string>();
   const joinGraphType = unifiedGraph.getType('join__Graph');
@@ -202,8 +197,6 @@ export const handleFederationSupergraph: UnifiedGraphHandler = function ({
       handleFederationSubschema({
         subschemaConfig,
         realSubgraphNameMap,
-        schemaDirectives,
-        transportEntryMap,
         additionalTypeDefs,
         stitchingDirectivesTransformer,
         onSubgraphExecute,
@@ -369,7 +362,6 @@ export const handleFederationSupergraph: UnifiedGraphHandler = function ({
   }
   return {
     unifiedGraph: executableUnifiedGraph,
-    transportEntryMap,
     inContextSDK,
     getSubgraphSchema(subgraphName) {
       const subgraph = subschemas.find(

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -685,5 +685,18 @@ export function getTransportEntryMapUsingFusionAndFederationDirectives(
       transportEntryMap[subgraphName] = mergeDeep(toBeMerged);
     }
   }
+  const schemaExtensions: {
+    directives?: {
+      transport?: TransportEntry[];
+    }
+  } = unifiedGraph.extensions ||= {};
+  const directivesInExtensions = schemaExtensions.directives ||= {};
+  const transportEntriesInExtensions: TransportEntry[] = directivesInExtensions.transport = [];
+  for (const subgraphName in transportEntryMap) {
+    const transportEntry = transportEntryMap[subgraphName];
+    if (transportEntry) {
+      transportEntriesInExtensions.push(transportEntry);
+    }
+  }
   return transportEntryMap;
 }

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -688,10 +688,11 @@ export function getTransportEntryMapUsingFusionAndFederationDirectives(
   const schemaExtensions: {
     directives?: {
       transport?: TransportEntry[];
-    }
-  } = unifiedGraph.extensions ||= {};
-  const directivesInExtensions = schemaExtensions.directives ||= {};
-  const transportEntriesInExtensions: TransportEntry[] = directivesInExtensions.transport = [];
+    };
+  } = (unifiedGraph.extensions ||= {});
+  const directivesInExtensions = (schemaExtensions.directives ||= {});
+  const transportEntriesInExtensions: TransportEntry[] =
+    (directivesInExtensions.transport = []);
   for (const subgraphName in transportEntryMap) {
     const transportEntry = transportEntryMap[subgraphName];
     if (transportEntry) {

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -1,3 +1,4 @@
+import { OnExecuteEventPayload, OnSubscribeEventPayload } from '@envelop/core';
 import { useDisableIntrospection } from '@envelop/disable-introspection';
 import { useGenericAuth } from '@envelop/generic-auth';
 import {
@@ -66,7 +67,6 @@ import {
   GraphQLSchema,
   isSchema,
   parse,
-  type ExecutionArgs,
 } from 'graphql';
 import {
   createYoga,
@@ -106,7 +106,11 @@ import type {
   GatewayPlugin,
   UnifiedGraphConfig,
 } from './types';
-import { checkIfDataSatisfiesSelectionSet, defaultQueryText } from './utils';
+import {
+  checkIfDataSatisfiesSelectionSet,
+  defaultQueryText,
+  getExecuteFnFromExecutor,
+} from './utils';
 
 // TODO: this type export is not properly accessible from graphql-yoga
 //       "graphql-yoga/typings/plugins/use-graphiql.js" is an illegal path
@@ -171,6 +175,7 @@ export function createGatewayRuntime<
   let getSchema: () => MaybePromise<GraphQLSchema> = () => unifiedGraph;
   let contextBuilder: <T>(context: T) => MaybePromise<T>;
   let readinessChecker: () => MaybePromise<boolean>;
+  let getExecutor: (() => MaybePromise<Executor | undefined>) | undefined;
   const { name: reportingTarget, plugin: registryPlugin } = getReportingPlugin(
     config,
     configContext,
@@ -216,18 +221,8 @@ export function createGatewayRuntime<
       onSubgraphExecuteHooks,
       transportExecutorStack,
     });
-    function createExecuteFnFromExecutor(executor: Executor) {
-      return function executeFn(args: ExecutionArgs) {
-        return executor({
-          rootValue: args.rootValue,
-          document: args.document,
-          ...(args.operationName ? { operationName: args.operationName } : {}),
-          ...(args.variableValues ? { variables: args.variableValues } : {}),
-          ...(args.contextValue ? { context: args.contextValue } : {}),
-        });
-      };
-    }
-    const executeFn = createExecuteFnFromExecutor(proxyExecutor);
+
+    getExecutor = () => proxyExecutor;
 
     let currentTimeout: ReturnType<typeof setTimeout>;
     const pollingInterval = config.pollingInterval;
@@ -343,12 +338,6 @@ export function createGatewayRuntime<
     const shouldSkipValidation =
       'skipValidation' in config ? config.skipValidation : false;
     const executorPlugin: GatewayPlugin = {
-      onExecute({ setExecuteFn }) {
-        setExecuteFn(executeFn);
-      },
-      onSubscribe({ setSubscribeFn }) {
-        setSubscribeFn(executeFn);
-      },
       onValidate({ params, setResult }) {
         if (shouldSkipValidation || !params.schema) {
           setResult([]);
@@ -705,6 +694,7 @@ export function createGatewayRuntime<
       );
     schemaInvalidator = () => unifiedGraphManager.invalidateUnifiedGraph();
     contextBuilder = (base) => unifiedGraphManager.getContext(base as any);
+    getExecutor = () => unifiedGraphManager.getExecutor();
     unifiedGraphPlugin = {
       [DisposableSymbols.asyncDispose]() {
         return unifiedGraphManager[DisposableSymbols.asyncDispose]();
@@ -817,6 +807,31 @@ export function createGatewayRuntime<
       }
     },
   };
+
+  if (getExecutor) {
+    const onExecute = ({
+      setExecuteFn,
+    }: OnExecuteEventPayload<GatewayContext>) =>
+      mapMaybePromise(getExecutor?.(), (executor) => {
+        if (executor) {
+          const executeFn = getExecuteFnFromExecutor(executor);
+          setExecuteFn(executeFn);
+        }
+      });
+    const onSubscribe = ({
+      setSubscribeFn,
+    }: OnSubscribeEventPayload<GatewayContext>) =>
+      mapMaybePromise(getExecutor?.(), (executor) => {
+        if (executor) {
+          const subscribeFn = getExecuteFnFromExecutor(executor);
+          setSubscribeFn(subscribeFn);
+        }
+      });
+    //@ts-expect-error - MaybePromise is not compatible with PromiseOrValue
+    defaultGatewayPlugin.onExecute = onExecute;
+    //@ts-expect-error - MaybePromise is not compatible with PromiseOrValue
+    defaultGatewayPlugin.onSubscribe = onSubscribe;
+  }
 
   const productName = config.productName || 'Hive Gateway';
   const productDescription =

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -13,6 +13,7 @@ import type {
 import {
   getOnSubgraphExecute,
   getStitchingDirectivesTransformerForSubschema,
+  getTransportEntryMapUsingFusionAndFederationDirectives,
   handleFederationSubschema,
   handleResolveToDirectives,
   restoreExtraDirectives,
@@ -432,7 +433,11 @@ export function createGatewayRuntime<
               ],
               schema: unifiedGraph,
             };
-            const transportEntryMap: Record<string, TransportEntry> = {};
+            const transportEntryMap: Record<string, TransportEntry> =
+              getTransportEntryMapUsingFusionAndFederationDirectives(
+                unifiedGraph,
+                config.transportEntries,
+              );
             const additionalTypeDefs: TypeSource[] = [];
 
             const stitchingDirectivesTransformer =
@@ -449,7 +454,6 @@ export function createGatewayRuntime<
             });
             subschemaConfig = handleFederationSubschema({
               subschemaConfig,
-              transportEntryMap,
               additionalTypeDefs,
               stitchingDirectivesTransformer,
               onSubgraphExecute,

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -1,3 +1,5 @@
+import type { ExecutionArgs } from '@graphql-tools/executor';
+import { Executor, memoize1 } from '@graphql-tools/utils';
 import type { SelectionSetNode } from 'graphql';
 
 export function checkIfDataSatisfiesSelectionSet(
@@ -75,3 +77,18 @@ export function delayInMs(ms: number, signal?: AbortSignal) {
     );
   });
 }
+
+export const getExecuteFnFromExecutor = memoize1(
+  function getExecuteFnFromExecutor(executor: Executor) {
+    return function executeFn(args: ExecutionArgs) {
+      return executor({
+        document: args.document,
+        variables: args.variableValues,
+        operationName: args.operationName ?? undefined,
+        rootValue: args.rootValue,
+        context: args.contextValue,
+        signal: args.signal,
+      });
+    };
+  },
+);


### PR DESCRIPTION
Isolate Stitching logic so then we can easily replace Stitching with another Supergraph executor