### PR TITLE
refactor(runtime): move subgraph execution batching out

### DIFF
--- a/.changeset/@graphql-mesh_fusion-runtime-605-dependencies.md
+++ b/.changeset/@graphql-mesh_fusion-runtime-605-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/fusion-runtime': patch
+---
+
+dependencies updates: 
+
+- Added dependency [`@graphql-tools/batch-execute@workspace:^` ↗︎](https://www.npmjs.com/package/@graphql-tools/batch-execute/v/workspace:^) (to `dependencies`)

--- a/.changeset/chatty-humans-collect.md
+++ b/.changeset/chatty-humans-collect.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/fusion-runtime': minor
+---
+
+Extract subgraph execution batching logic outside, so batching is handled by the Gateway not Stitching
+
+**BREAKING**; `UnifiedGraphHandlerOpts` no longer takes `batch` option, it is handled by the runtime itself

--- a/packages/fusion-runtime/package.json
+++ b/packages/fusion-runtime/package.json
@@ -48,6 +48,7 @@
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.103.6",
     "@graphql-mesh/utils": "^0.103.6",
+    "@graphql-tools/batch-execute": "^9.0.11",
     "@graphql-tools/delegate": "workspace:^",
     "@graphql-tools/executor": "^1.3.10",
     "@graphql-tools/federation": "workspace:^",

--- a/packages/fusion-runtime/package.json
+++ b/packages/fusion-runtime/package.json
@@ -48,7 +48,7 @@
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.103.6",
     "@graphql-mesh/utils": "^0.103.6",
-    "@graphql-tools/batch-execute": "^9.0.11",
+    "@graphql-tools/batch-execute": "workspace:^",
     "@graphql-tools/delegate": "workspace:^",
     "@graphql-tools/executor": "^1.3.10",
     "@graphql-tools/federation": "workspace:^",

--- a/packages/fusion-runtime/src/federation/supergraph.ts
+++ b/packages/fusion-runtime/src/federation/supergraph.ts
@@ -158,7 +158,6 @@ export const handleFederationSupergraph: UnifiedGraphHandler = function ({
   onDelegateHooks,
   additionalTypeDefs: additionalTypeDefsFromConfig = [],
   additionalResolvers: additionalResolversFromConfig = [],
-  batch = true,
   logger,
 }: UnifiedGraphHandlerOpts): UnifiedGraphHandlerResult {
   const additionalTypeDefs = [...asArray(additionalTypeDefsFromConfig)];
@@ -204,7 +203,6 @@ export const handleFederationSupergraph: UnifiedGraphHandler = function ({
         stitchingDirectivesTransformer,
         onSubgraphExecute,
       }),
-    batch,
     onStitchingOptions(opts) {
       subschemas = opts.subschemas;
       opts.typeDefs = handleResolveToDirectives(

--- a/packages/fusion-runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion-runtime/src/unifiedGraphManager.ts
@@ -64,11 +64,6 @@ export interface UnifiedGraphHandlerOpts {
   onDelegationPlanHooks?: OnDelegationPlanHook<any>[];
   onDelegationStageExecuteHooks?: OnDelegationStageExecuteHook<any>[];
   onDelegateHooks?: OnDelegateHook<unknown>[];
-  /**
-   * Whether to batch the subgraph executions.
-   * @default true
-   */
-  batch?: boolean;
 
   logger?: Logger;
 }
@@ -327,7 +322,6 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
           onDelegationPlanHooks: this.onDelegationPlanHooks,
           onDelegationStageExecuteHooks: this.onDelegationStageExecuteHooks,
           onDelegateHooks: this.opts.onDelegateHooks,
-          batch: this.batch,
           logger: this.opts.transportContext?.logger,
         });
         this.unifiedGraph = newUnifiedGraph;
@@ -340,6 +334,7 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
           getSubgraphSchema,
           transportExecutorStack: this._transportExecutorStack,
           getDisposeReason: () => this.disposeReason,
+          batch: this.batch,
         });
         this.inContextSDK = inContextSDK;
         this.lastLoadTime = Date.now();

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -13,7 +13,7 @@ import {
   loggerForExecutionRequest,
   requestIdByRequest,
 } from '@graphql-mesh/utils';
-import { createBatchingExecutor } from '@graphql-tools/batch-execute';
+import { getBatchingExecutor } from '@graphql-tools/batch-execute';
 import {
   DelegationPlanBuilder,
   MergedTypeResolver,
@@ -222,9 +222,6 @@ export function getOnSubgraphExecute({
             if (isDisposable(executor_)) {
               transportExecutorStack.use(executor_);
             }
-            if (batch) {
-              executor = createBatchingExecutor(executor_);
-            }
             // Wraps the transport executor with hooks
             executor = wrapExecutorWithHooks({
               executor: executor_,
@@ -242,6 +239,9 @@ export function getOnSubgraphExecute({
       };
       // Caches the lazy executor to prevent race conditions
       subgraphExecutorMap.set(subgraphName, executor);
+    }
+    if (batch) {
+      executor = getBatchingExecutor(executionRequest.context || subgraphExecutorMap, executor);
     }
     return executor(executionRequest);
   };

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -241,7 +241,10 @@ export function getOnSubgraphExecute({
       subgraphExecutorMap.set(subgraphName, executor);
     }
     if (batch) {
-      executor = getBatchingExecutor(executionRequest.context || subgraphExecutorMap, executor);
+      executor = getBatchingExecutor(
+        executionRequest.context || subgraphExecutorMap,
+        executor,
+      );
     }
     return executor(executionRequest);
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,6 +3481,7 @@ __metadata:
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.103.6"
     "@graphql-mesh/utils": "npm:^0.103.6"
+    "@graphql-tools/batch-execute": "npm:^9.0.11"
     "@graphql-tools/delegate": "workspace:^"
     "@graphql-tools/executor": "npm:^1.3.10"
     "@graphql-tools/federation": "workspace:^"
@@ -3965,7 +3966,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@graphql-tools/batch-execute@workspace:^, @graphql-tools/batch-execute@workspace:packages/batch-execute":
+"@graphql-tools/batch-execute@npm:^9.0.11, @graphql-tools/batch-execute@workspace:^, @graphql-tools/batch-execute@workspace:packages/batch-execute":
   version: 0.0.0-use.local
   resolution: "@graphql-tools/batch-execute@workspace:packages/batch-execute"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,7 +3481,7 @@ __metadata:
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.103.6"
     "@graphql-mesh/utils": "npm:^0.103.6"
-    "@graphql-tools/batch-execute": "npm:^9.0.11"
+    "@graphql-tools/batch-execute": "workspace:^"
     "@graphql-tools/delegate": "workspace:^"
     "@graphql-tools/executor": "npm:^1.3.10"
     "@graphql-tools/federation": "workspace:^"
@@ -3966,7 +3966,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@graphql-tools/batch-execute@npm:^9.0.11, @graphql-tools/batch-execute@workspace:^, @graphql-tools/batch-execute@workspace:packages/batch-execute":
+"@graphql-tools/batch-execute@workspace:^, @graphql-tools/batch-execute@workspace:packages/batch-execute":
   version: 0.0.0-use.local
   resolution: "@graphql-tools/batch-execute@workspace:packages/batch-execute"
   dependencies:


### PR DESCRIPTION
Batching is now handled by the Gateway not Stitching so a future supergraph executor doesn't need to handle this on its own