### PR TITLE
Winston Logger Adapter

### DIFF
--- a/.changeset/wild-balloons-repair.md
+++ b/.changeset/wild-balloons-repair.md
@@ -2,4 +2,28 @@
 '@graphql-hive/logger-winston': major
 ---
 
-Winston Adapter
+**Winston Adapter**
+
+Now you can integrate [Winston](https://github.com/winstonjs/winston) into Hive Gateway on Node.js
+
+```ts
+import { createLogger, format, transports } from 'winston'
+import { createLoggerFromWinston } from '@graphql-hive/winston'
+
+// Create a Winston logger
+const winstonLogger = createLogger({
+    level: 'info',
+    format: format.combine(
+        format.timestamp(),
+        format.json()
+    ),
+    transports: [
+        new transports.Console()
+    ]
+})
+
+export const gatewayConfig = defineConfig({
+    // Create an adapter for Winston
+    logging: createLoggerFromWinston(winstonLogger)
+})
+```

--- a/.changeset/wild-balloons-repair.md
+++ b/.changeset/wild-balloons-repair.md
@@ -7,6 +7,7 @@
 Now you can integrate [Winston](https://github.com/winstonjs/winston) into Hive Gateway on Node.js
 
 ```ts
+import { defineConfig } from '@graphql-hive/gateway'
 import { createLogger, format, transports } from 'winston'
 import { createLoggerFromWinston } from '@graphql-hive/winston'
 

--- a/.changeset/wild-balloons-repair.md
+++ b/.changeset/wild-balloons-repair.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/logger-winston': major
+---
+
+Winston Adapter

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -291,7 +291,7 @@ export function wrapExecutorWithHooks({
       }
       loggerForExecutionRequest.set(baseExecutionRequest, execReqLogger);
     }
-    execReqLogger = execReqLogger?.child?.(subgraphName);
+    execReqLogger = execReqLogger?.child?.({ subgraph: subgraphName });
     if (onSubgraphExecuteHooks.length === 0) {
       return baseExecutor(baseExecutionRequest);
     }

--- a/packages/logger-winston/package.json
+++ b/packages/logger-winston/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@graphql-hive/logger-winston",
+  "version": "0.0.0",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/graphql-hive/gateway.git",
+    "directory": "packages/logger-winston"
+  },
+  "homepage": "https://the-guild.dev/graphql/hive/docs/gateway",
+  "author": {
+    "email": "contact@the-guild.dev",
+    "name": "The Guild",
+    "url": "https://the-guild.dev"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pkgroll --clean-dist",
+    "prepack": "yarn build"
+  },
+  "peerDependencies": {
+    "graphql": "^15.9.0 || ^16.9.0",
+    "winston": "^3.17.0"
+  },
+  "peerDependenciesMeta": {
+    "@parcel/watcher": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@graphql-mesh/types": "^0.103.6",
+    "tslib": "^2.8.1"
+  },
+  "devDependencies": {
+    "graphql": "16.10.0",
+    "pkgroll": "2.8.2",
+    "winston": "^3.17.0"
+  },
+  "sideEffects": false
+}

--- a/packages/logger-winston/package.json
+++ b/packages/logger-winston/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@graphql-mesh/types": "^0.103.6",
+    "@whatwg-node/disposablestack": "^0.0.5",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/logger-winston/src/index.ts
+++ b/packages/logger-winston/src/index.ts
@@ -77,15 +77,18 @@ class WinstonLoggerAdapter implements MeshLogger, Disposable {
   }
   child(nameOrMeta: string | Record<string, string | number>) {
     if (typeof nameOrMeta === 'string') {
-      nameOrMeta = { name: this.name ? this.name.includes(nameOrMeta) ? this.name : `${this.name}, ${nameOrMeta}` : nameOrMeta };
+      nameOrMeta = {
+        name: this.name
+          ? this.name.includes(nameOrMeta)
+            ? this.name
+            : `${this.name}, ${nameOrMeta}`
+          : nameOrMeta,
+      };
     }
-    return new WinstonLoggerAdapter(
-      this.winstonLogger.child(nameOrMeta),
-      {
-        ...this.meta,
-        ...nameOrMeta,
-      }
-    );
+    return new WinstonLoggerAdapter(this.winstonLogger.child(nameOrMeta), {
+      ...this.meta,
+      ...nameOrMeta,
+    });
   }
   [DisposableSymbols.dispose]() {
     return this.winstonLogger.close();

--- a/packages/logger-winston/src/index.ts
+++ b/packages/logger-winston/src/index.ts
@@ -1,0 +1,71 @@
+import type {
+  LazyLoggerMessage,
+  Logger as MeshLogger,
+} from '@graphql-mesh/types';
+import type { Logger as WinstonLogger } from 'winston';
+
+function prepareArgs(lazyArgs: LazyLoggerMessage[]) {
+  const flattenedArgs = lazyArgs
+    .flatMap((lazyArg) => (typeof lazyArg === 'function' ? lazyArg() : lazyArg))
+    .flat(Infinity)
+    .map((arg) => {
+      if (typeof arg === 'string') {
+        try {
+          arg = JSON.parse(arg);
+        } catch (e) {
+          // Do nothing
+        }
+      }
+      return arg;
+    });
+  if (flattenedArgs.length === 1) {
+    return flattenedArgs[0];
+  }
+  return flattenedArgs;
+}
+
+class LoggerAdapter implements MeshLogger {
+  constructor(
+    private winstonLogger: WinstonLogger,
+    public names: string[] = [],
+  ) {}
+  get name() {
+    return this.names.join(' - ');
+  }
+  log(...args: any[]) {
+    if (this.winstonLogger.isInfoEnabled()) {
+      this.winstonLogger.info(prepareArgs(args));
+    }
+  }
+  info(...args: any[]) {
+    if (this.winstonLogger.isInfoEnabled()) {
+      this.winstonLogger.info(prepareArgs(args));
+    }
+  }
+  warn(...args: any[]) {
+    if (this.winstonLogger.isWarnEnabled()) {
+      this.winstonLogger.warn(prepareArgs(args));
+    }
+  }
+  error(...args: any[]) {
+    if (this.winstonLogger.isErrorEnabled()) {
+      this.winstonLogger.error(prepareArgs(args));
+    }
+  }
+  debug(...lazyArgs: LazyLoggerMessage[]) {
+    if (this.winstonLogger.isDebugEnabled()) {
+      this.winstonLogger.debug(prepareArgs(lazyArgs));
+    }
+  }
+  child(name: string) {
+    const newName = [...new Set([...this.names, name])];
+    const childWinston = this.winstonLogger.child({ name: newName });
+    return new LoggerAdapter(childWinston, newName);
+  }
+}
+
+export function createLoggerFromWinston(
+  winstonLogger: WinstonLogger,
+): MeshLogger {
+  return new LoggerAdapter(winstonLogger);
+}

--- a/packages/logger-winston/src/index.ts
+++ b/packages/logger-winston/src/index.ts
@@ -1,67 +1,91 @@
-import { DisposableSymbols } from '@whatwg-node/disposablestack';
 import type {
   LazyLoggerMessage,
   Logger as MeshLogger,
 } from '@graphql-mesh/types';
+import { DisposableSymbols } from '@whatwg-node/disposablestack';
 import type { Logger as WinstonLogger } from 'winston';
 
-function prepareArgs(lazyArgs: LazyLoggerMessage[]) {
-  const flattenedArgs = lazyArgs
-    .flatMap((lazyArg) => (typeof lazyArg === 'function' ? lazyArg() : lazyArg))
+function prepareArgs(messageArgs: LazyLoggerMessage[]) {
+  const flattenedMessageArgs = messageArgs
     .flat(Infinity)
-    .map((arg) => {
-      if (typeof arg === 'string') {
-        try {
-          arg = JSON.parse(arg);
-        } catch (e) {
-          // Do nothing
-        }
+    .flatMap((messageArg) => {
+      if (typeof messageArg === 'function') {
+        messageArg = messageArg();
       }
-      return arg;
+      if (messageArg?.toJSON) {
+        messageArg = messageArg.toJSON();
+      }
+      if (messageArg instanceof AggregateError) {
+        return messageArg.errors;
+      }
+      return messageArg;
     });
-  if (flattenedArgs.length === 1) {
-    return flattenedArgs[0];
+  let message: string = '';
+  const extras: any[] = [];
+  for (let messageArg of flattenedMessageArgs) {
+    if (messageArg == null) {
+      continue;
+    }
+    const typeofMessageArg = typeof messageArg;
+    if (
+      typeofMessageArg === 'string' ||
+      typeofMessageArg === 'number' ||
+      typeofMessageArg === 'boolean'
+    ) {
+      message = message ? message + ', ' + messageArg : messageArg;
+    } else if (typeofMessageArg === 'object') {
+      extras.push(messageArg);
+    }
   }
-  return flattenedArgs;
+  return [message, ...extras] as const;
 }
 
 class WinstonLoggerAdapter implements MeshLogger, Disposable {
+  public name?: string;
   constructor(
     private winstonLogger: WinstonLogger,
-    public names: string[] = [],
-  ) {}
-  get name() {
-    return this.names.join(' - ');
+    private meta: Record<string, any> = {},
+  ) {
+    if (meta['name']) {
+      this.name = meta['name'];
+    }
   }
   log(...args: any[]) {
     if (this.winstonLogger.isInfoEnabled()) {
-      this.winstonLogger.info(prepareArgs(args));
+      this.winstonLogger.info(...prepareArgs(args));
     }
   }
   info(...args: any[]) {
     if (this.winstonLogger.isInfoEnabled()) {
-      this.winstonLogger.info(prepareArgs(args));
+      this.winstonLogger.info(...prepareArgs(args));
     }
   }
   warn(...args: any[]) {
     if (this.winstonLogger.isWarnEnabled()) {
-      this.winstonLogger.warn(prepareArgs(args));
+      this.winstonLogger.warn(...prepareArgs(args));
     }
   }
   error(...args: any[]) {
     if (this.winstonLogger.isErrorEnabled()) {
-      this.winstonLogger.error(prepareArgs(args));
+      this.winstonLogger.error(...prepareArgs(args));
     }
   }
   debug(...lazyArgs: LazyLoggerMessage[]) {
     if (this.winstonLogger.isDebugEnabled()) {
-      this.winstonLogger.debug(prepareArgs(lazyArgs));
+      this.winstonLogger.debug(...prepareArgs(lazyArgs));
     }
   }
-  child(name: string) {
-    const newName = [...new Set([...this.names, name])];
-    const childWinston = this.winstonLogger.child({ name: newName });
-    return new WinstonLoggerAdapter(childWinston, newName);
+  child(nameOrMeta: string | Record<string, string | number>) {
+    if (typeof nameOrMeta === 'string') {
+      nameOrMeta = { name: this.name ? this.name.includes(nameOrMeta) ? this.name : `${this.name}, ${nameOrMeta}` : nameOrMeta };
+    }
+    return new WinstonLoggerAdapter(
+      this.winstonLogger.child(nameOrMeta),
+      {
+        ...this.meta,
+        ...nameOrMeta,
+      }
+    );
   }
   [DisposableSymbols.dispose]() {
     return this.winstonLogger.close();

--- a/packages/logger-winston/tests/winston.spec.ts
+++ b/packages/logger-winston/tests/winston.spec.ts
@@ -1,11 +1,11 @@
-import { Writable } from 'stream';
+import { Writable } from 'node:stream';
 import { describe, expect, it } from 'vitest';
 import * as winston from 'winston';
 import { createLoggerFromWinston } from '../src';
 
 describe('Winston', () => {
-  let log: string = '';
-  let lastCallback: () => void = () => {};
+  let log = '';
+  let lastCallback = () => {};
   const stream = new Writable({
     write(chunk, _encoding, callback) {
       log = chunk.toString('utf-8');

--- a/packages/logger-winston/tests/winston.spec.ts
+++ b/packages/logger-winston/tests/winston.spec.ts
@@ -41,16 +41,8 @@ describe('Winston', () => {
         const logJson = JSON.parse(log);
         expect(logJson).toEqual({
           level,
-          message: [
-            'Hello',
-            'World',
-            { foo: 'bar' },
-            42,
-            true,
-            null,
-            null,
-            'Expensive',
-          ],
+          foo: 'bar',
+          message: 'Hello, World, 42, true, Expensive',
         });
       });
       it('child', () => {
@@ -80,17 +72,9 @@ describe('Winston', () => {
         const logJson = JSON.parse(log);
         expect(logJson).toEqual({
           level,
-          message: [
-            'Hello',
-            'World',
-            { foo: 'bar' },
-            42,
-            true,
-            null,
-            null,
-            'Expensive',
-          ],
-          name: ['child'],
+          foo: 'bar',
+          message: 'Hello, World, 42, true, Expensive',
+          name: 'child',
         });
       });
       it('deduplicate names', () => {
@@ -120,17 +104,9 @@ describe('Winston', () => {
         const logJson = JSON.parse(log);
         expect(logJson).toEqual({
           level,
-          message: [
-            'Hello',
-            'World',
-            { foo: 'bar' },
-            42,
-            true,
-            null,
-            null,
-            'Expensive',
-          ],
-          name: ['child'],
+          foo: 'bar',
+          message: 'Hello, World, 42, true, Expensive',
+          name: 'child',
         });
       });
       it('nested', () => {
@@ -161,17 +137,9 @@ describe('Winston', () => {
         const logJson = JSON.parse(log);
         expect(logJson).toEqual({
           level,
-          message: [
-            'Hello',
-            'World',
-            { foo: 'bar' },
-            42,
-            true,
-            null,
-            null,
-            'Expensive',
-          ],
-          name: ['child', 'nested'],
+          foo: 'bar',
+          message: 'Hello, World, 42, true, Expensive',
+          name: 'child, nested',
         });
       });
     });

--- a/packages/logger-winston/tests/winston.spec.ts
+++ b/packages/logger-winston/tests/winston.spec.ts
@@ -25,7 +25,7 @@ describe('Winston', () => {
             }),
           ],
         });
-        const loggerAdapter = createLoggerFromWinston(logger);
+        using loggerAdapter = createLoggerFromWinston(logger);
         const testData = [
           'Hello',
           ['World'],

--- a/packages/logger-winston/tests/winston.spec.ts
+++ b/packages/logger-winston/tests/winston.spec.ts
@@ -1,0 +1,179 @@
+import { Writable } from 'stream';
+import { describe, expect, it } from 'vitest';
+import * as winston from 'winston';
+import { createLoggerFromWinston } from '../src';
+
+describe('Winston', () => {
+  let log: string = '';
+  let lastCallback: () => void = () => {};
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      log = chunk.toString('utf-8');
+      lastCallback = callback;
+    },
+  });
+  const logLevels = ['error', 'warn', 'info', 'debug'] as const;
+  for (const level of logLevels) {
+    describe(`Level: ${level}`, () => {
+      it('basic', () => {
+        const logger = winston.createLogger({
+          level,
+          format: winston.format.json(),
+          transports: [
+            new winston.transports.Stream({
+              stream,
+            }),
+          ],
+        });
+        const loggerAdapter = createLoggerFromWinston(logger);
+        const testData = [
+          'Hello',
+          ['World'],
+          { foo: 'bar' },
+          42,
+          true,
+          null,
+          undefined,
+          () => 'Expensive',
+        ];
+        loggerAdapter[level](...testData);
+        lastCallback();
+        const logJson = JSON.parse(log);
+        expect(logJson).toEqual({
+          level,
+          message: [
+            'Hello',
+            'World',
+            { foo: 'bar' },
+            42,
+            true,
+            null,
+            null,
+            'Expensive',
+          ],
+        });
+      });
+      it('child', () => {
+        const logger = winston.createLogger({
+          level,
+          format: winston.format.json(),
+          transports: [
+            new winston.transports.Stream({
+              stream,
+            }),
+          ],
+        });
+        const loggerAdapter = createLoggerFromWinston(logger);
+        const testData = [
+          'Hello',
+          ['World'],
+          { foo: 'bar' },
+          42,
+          true,
+          null,
+          undefined,
+          () => 'Expensive',
+        ];
+        const childLogger = loggerAdapter.child('child');
+        childLogger[level](...testData);
+        lastCallback();
+        const logJson = JSON.parse(log);
+        expect(logJson).toEqual({
+          level,
+          message: [
+            'Hello',
+            'World',
+            { foo: 'bar' },
+            42,
+            true,
+            null,
+            null,
+            'Expensive',
+          ],
+          name: ['child'],
+        });
+      });
+      it('deduplicate names', () => {
+        const logger = winston.createLogger({
+          level,
+          format: winston.format.json(),
+          transports: [
+            new winston.transports.Stream({
+              stream,
+            }),
+          ],
+        });
+        const loggerAdapter = createLoggerFromWinston(logger);
+        const testData = [
+          'Hello',
+          ['World'],
+          { foo: 'bar' },
+          42,
+          true,
+          null,
+          undefined,
+          () => 'Expensive',
+        ];
+        const childLogger = loggerAdapter.child('child').child('child');
+        childLogger[level](...testData);
+        lastCallback();
+        const logJson = JSON.parse(log);
+        expect(logJson).toEqual({
+          level,
+          message: [
+            'Hello',
+            'World',
+            { foo: 'bar' },
+            42,
+            true,
+            null,
+            null,
+            'Expensive',
+          ],
+          name: ['child'],
+        });
+      });
+      it('nested', () => {
+        const logger = winston.createLogger({
+          level,
+          format: winston.format.json(),
+          transports: [
+            new winston.transports.Stream({
+              stream,
+            }),
+          ],
+        });
+        const loggerAdapter = createLoggerFromWinston(logger);
+        const testData = [
+          'Hello',
+          ['World'],
+          { foo: 'bar' },
+          42,
+          true,
+          null,
+          undefined,
+          () => 'Expensive',
+        ];
+        const childLogger = loggerAdapter.child('child');
+        const nestedLogger = childLogger.child('nested');
+        nestedLogger[level](...testData);
+        lastCallback();
+        const logJson = JSON.parse(log);
+        expect(logJson).toEqual({
+          level,
+          message: [
+            'Hello',
+            'World',
+            { foo: 'bar' },
+            42,
+            true,
+            null,
+            null,
+            'Expensive',
+          ],
+          name: ['child', 'nested'],
+        });
+      });
+    });
+  }
+});

--- a/packages/runtime/src/plugins/useFetchDebug.ts
+++ b/packages/runtime/src/plugins/useFetchDebug.ts
@@ -10,15 +10,11 @@ export function useFetchDebug<TContext extends Record<string, any>>(opts: {
     onYogaInit({ yoga }) {
       fetchAPI = yoga.fetchAPI;
     },
-    onFetch({ url, options, logger = opts.logger, requestId }) {
+    onFetch({ url, options, logger = opts.logger }) {
       const fetchId = fetchAPI.crypto.randomUUID();
-      const loggerMeta: Record<string, string> = {
+      const fetchLogger = logger.child({
         fetchId,
-      };
-      if (requestId) {
-        loggerMeta['requestId'] = requestId;
-      }
-      const fetchLogger = logger.child(loggerMeta);
+      });
       const httpFetchRequestLogger = fetchLogger.child('http-fetch-request');
       httpFetchRequestLogger.debug(() => ({
         url,

--- a/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
+++ b/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
@@ -11,15 +11,11 @@ export function useSubgraphExecuteDebug<
     onYogaInit({ yoga }) {
       fetchAPI = yoga.fetchAPI;
     },
-    onSubgraphExecute({ executionRequest, logger = opts.logger, requestId }) {
+    onSubgraphExecute({ executionRequest, logger = opts.logger }) {
       const subgraphExecuteId = fetchAPI.crypto.randomUUID();
-      const loggerMeta: Record<string, string> = {
+      const subgraphExecuteHookLogger = logger.child({
         subgraphExecuteId,
-      };
-      if (requestId) {
-        loggerMeta['requestId'] = requestId;
-      }
-      const subgraphExecuteHookLogger = logger.child(loggerMeta);
+      });
       if (executionRequest) {
         const subgraphExecuteStartLogger = subgraphExecuteHookLogger.child(
           'subgraph-execute-start',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,7 +59,8 @@
       ],
       "@graphql-tools/wrap": ["./packages/wrap/src/index.ts"],
       "@graphql-tools/executor-*": ["./packages/executors/*/src/index.ts"],
-      "@graphql-hive/logger-json": ["./packages/logger-json/src/index.ts"]
+      "@graphql-hive/logger-json": ["./packages/logger-json/src/index.ts"],
+      "@graphql-hive/logger-winston": ["./packages/logger-winston/src/index.ts"]
     }
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2306,6 +2306,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.6.0, @colors/colors@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@colors/colors@npm:1.6.0"
+  checksum: 10c0/9328a0778a5b0db243af54455b79a69e3fb21122d6c15ef9e9fcc94881d8d17352d8b2b2590f9bdd46fac5c2d6c1636dcfc14358a20c70e22daf89e1a759b629
+  languageName: node
+  linkType: hard
+
 "@commander-js/extra-typings@npm:^13.0.0":
   version: 13.1.0
   resolution: "@commander-js/extra-typings@npm:13.1.0"
@@ -2321,6 +2328,17 @@ __metadata:
   dependencies:
     "@jridgewell/trace-mapping": "npm:0.3.9"
   checksum: 10c0/05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
+  languageName: node
+  linkType: hard
+
+"@dabh/diagnostics@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@dabh/diagnostics@npm:2.0.3"
+  dependencies:
+    colorspace: "npm:1.1.x"
+    enabled: "npm:2.0.x"
+    kuler: "npm:^2.0.0"
+  checksum: 10c0/a5133df8492802465ed01f2f0a5784585241a1030c362d54a602ed1839816d6c93d71dde05cf2ddb4fd0796238c19774406bd62fa2564b637907b495f52425fe
   languageName: node
   linkType: hard
 
@@ -3381,6 +3399,24 @@ __metadata:
     tslib: "npm:^2.8.1"
   peerDependencies:
     graphql: ^15.9.0 || ^16.9.0
+  languageName: unknown
+  linkType: soft
+
+"@graphql-hive/logger-winston@workspace:packages/logger-winston":
+  version: 0.0.0-use.local
+  resolution: "@graphql-hive/logger-winston@workspace:packages/logger-winston"
+  dependencies:
+    "@graphql-mesh/types": "npm:^0.103.6"
+    graphql: "npm:16.10.0"
+    pkgroll: "npm:2.8.2"
+    tslib: "npm:^2.8.1"
+    winston: "npm:^3.17.0"
+  peerDependencies:
+    graphql: ^15.9.0 || ^16.9.0
+    winston: ^3.17.0
+  peerDependenciesMeta:
+    "@parcel/watcher":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -6964,6 +7000,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/triple-beam@npm:^1.3.2":
+  version: 1.3.5
+  resolution: "@types/triple-beam@npm:1.3.5"
+  checksum: 10c0/d5d7f25da612f6d79266f4f1bb9c1ef8f1684e9f60abab251e1261170631062b656ba26ff22631f2760caeafd372abc41e64867cde27fba54fafb73a35b9056a
+  languageName: node
+  linkType: hard
+
 "@types/uuid@npm:^9.0.0":
   version: 9.0.8
   resolution: "@types/uuid@npm:9.0.8"
@@ -9100,12 +9143,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-convert@npm:^1.9.3":
+  version: 1.9.3
+  resolution: "color-convert@npm:1.9.3"
+  dependencies:
+    color-name: "npm:1.1.3"
+  checksum: 10c0/5ad3c534949a8c68fca8fbc6f09068f435f0ad290ab8b2f76841b9e6af7e0bb57b98cb05b0e19fe33f5d91e5a8611ad457e5f69e0a484caad1f7487fd0e8253c
+  languageName: node
+  linkType: hard
+
 "color-convert@npm:^2.0.1":
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
   dependencies:
     color-name: "npm:~1.1.4"
   checksum: 10c0/37e1150172f2e311fe1b2df62c6293a342ee7380da7b9cfdba67ea539909afbd74da27033208d01d6d5cfc65ee7868a22e18d7e7648e004425441c0f8a15a7d7
+  languageName: node
+  linkType: hard
+
+"color-name@npm:1.1.3":
+  version: 1.1.3
+  resolution: "color-name@npm:1.1.3"
+  checksum: 10c0/566a3d42cca25b9b3cd5528cd7754b8e89c0eb646b7f214e8e2eaddb69994ac5f0557d9c175eb5d8f0ad73531140d9c47525085ee752a91a2ab15ab459caf6d6
   languageName: node
   linkType: hard
 
@@ -9116,13 +9175,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-string@npm:^1.9.0":
+"color-string@npm:^1.6.0, color-string@npm:^1.9.0":
   version: 1.9.1
   resolution: "color-string@npm:1.9.1"
   dependencies:
     color-name: "npm:^1.0.0"
     simple-swizzle: "npm:^0.2.2"
   checksum: 10c0/b0bfd74c03b1f837f543898b512f5ea353f71630ccdd0d66f83028d1f0924a7d4272deb278b9aef376cacf1289b522ac3fb175e99895283645a2dc3a33af2404
+  languageName: node
+  linkType: hard
+
+"color@npm:^3.1.3":
+  version: 3.2.1
+  resolution: "color@npm:3.2.1"
+  dependencies:
+    color-convert: "npm:^1.9.3"
+    color-string: "npm:^1.6.0"
+  checksum: 10c0/39345d55825884c32a88b95127d417a2c24681d8b57069413596d9fcbb721459ef9d9ec24ce3e65527b5373ce171b73e38dbcd9c830a52a6487e7f37bf00e83c
   languageName: node
   linkType: hard
 
@@ -9133,6 +9202,16 @@ __metadata:
     color-convert: "npm:^2.0.1"
     color-string: "npm:^1.9.0"
   checksum: 10c0/7fbe7cfb811054c808349de19fb380252e5e34e61d7d168ec3353e9e9aacb1802674bddc657682e4e9730c2786592a4de6f8283e7e0d3870b829bb0b7b2f6118
+  languageName: node
+  linkType: hard
+
+"colorspace@npm:1.1.x":
+  version: 1.1.4
+  resolution: "colorspace@npm:1.1.4"
+  dependencies:
+    color: "npm:^3.1.3"
+    text-hex: "npm:1.0.x"
+  checksum: 10c0/af5f91ff7f8e146b96e439ac20ed79b197210193bde721b47380a75b21751d90fa56390c773bb67c0aedd34ff85091883a437ab56861c779bd507d639ba7e123
   languageName: node
   linkType: hard
 
@@ -9858,6 +9937,13 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10c0/af014e759a72064cf66e6e694a7fc6b0ed3d8db680427b021a89727689671cefe9d04151b2cad51dbaf85d5ba790d061cd167f1cf32eb7b281f6368b3c181639
+  languageName: node
+  linkType: hard
+
+"enabled@npm:2.0.x":
+  version: 2.0.0
+  resolution: "enabled@npm:2.0.0"
+  checksum: 10c0/3b2c2af9bc7f8b9e291610f2dde4a75cf6ee52a68f4dd585482fbdf9a55d65388940e024e56d40bb03e05ef6671f5f53021fa8b72a20e954d7066ec28166713f
   languageName: node
   linkType: hard
 
@@ -10722,6 +10808,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fecha@npm:^4.2.0":
+  version: 4.2.3
+  resolution: "fecha@npm:4.2.3"
+  checksum: 10c0/0e895965959cf6a22bb7b00f0bf546f2783836310f510ddf63f463e1518d4c96dec61ab33fdfd8e79a71b4856a7c865478ce2ee8498d560fe125947703c9b1cf
+  languageName: node
+  linkType: hard
+
 "fengari-interop@npm:^0.1.3":
   version: 0.1.3
   resolution: "fengari-interop@npm:0.1.3"
@@ -10869,6 +10962,13 @@ __metadata:
   version: 0.259.1
   resolution: "flow-parser@npm:0.259.1"
   checksum: 10c0/d9b4bcc512621f7560bd8604a2e4fa7e13d1fdcc9f9965e5c714daf005fa54c39a85a2434913b3cb4053d03685decb7674c3f5854122ae3cfe691003f9332ead
+  languageName: node
+  linkType: hard
+
+"fn.name@npm:1.x.x":
+  version: 1.1.0
+  resolution: "fn.name@npm:1.1.0"
+  checksum: 10c0/8ad62aa2d4f0b2a76d09dba36cfec61c540c13a0fd72e5d94164e430f987a7ce6a743112bbeb14877c810ef500d1f73d7f56e76d029d2e3413f20d79e3460a9a
   languageName: node
   linkType: hard
 
@@ -13326,6 +13426,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kuler@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "kuler@npm:2.0.0"
+  checksum: 10c0/0a4e99d92ca373f8f74d1dc37931909c4d0d82aebc94cf2ba265771160fc12c8df34eaaac80805efbda367e2795cb1f1dd4c3d404b6b1cf38aec94035b503d2d
+  languageName: node
+  linkType: hard
+
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -13582,6 +13689,20 @@ __metadata:
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+  languageName: node
+  linkType: hard
+
+"logform@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "logform@npm:2.7.0"
+  dependencies:
+    "@colors/colors": "npm:1.6.0"
+    "@types/triple-beam": "npm:^1.3.2"
+    fecha: "npm:^4.2.0"
+    ms: "npm:^2.1.1"
+    safe-stable-stringify: "npm:^2.3.1"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/4789b4b37413c731d1835734cb799240d31b865afde6b7b3e06051d6a4127bfda9e88c99cfbf296d084a315ccbed2647796e6a56b66e725bcb268c586f57558f
   languageName: node
   linkType: hard
 
@@ -14510,6 +14631,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"one-time@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "one-time@npm:1.0.0"
+  dependencies:
+    fn.name: "npm:1.x.x"
+  checksum: 10c0/6e4887b331edbb954f4e915831cbec0a7b9956c36f4feb5f6de98c448ac02ff881fd8d9b55a6b1b55030af184c6b648f340a76eb211812f4ad8c9b4b8692fdaa
+  languageName: node
+  linkType: hard
+
 "onetime@npm:^5.1.0, onetime@npm:^5.1.2":
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
@@ -15349,7 +15479,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0":
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.2":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -15856,6 +15986,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     is-regex: "npm:^1.2.1"
   checksum: 10c0/f2c25281bbe5d39cddbbce7f86fca5ea9b3ce3354ea6cd7c81c31b006a5a9fff4286acc5450a3b9122c56c33eba69c56b9131ad751457b2b4a585825e6a10665
+  languageName: node
+  linkType: hard
+
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.5.0
+  resolution: "safe-stable-stringify@npm:2.5.0"
+  checksum: 10c0/baea14971858cadd65df23894a40588ed791769db21bafb7fd7608397dbdce9c5aac60748abae9995e0fc37e15f2061980501e012cd48859740796bea2987f49
   languageName: node
   linkType: hard
 
@@ -16407,6 +16544,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stack-trace@npm:0.0.x":
+  version: 0.0.10
+  resolution: "stack-trace@npm:0.0.10"
+  checksum: 10c0/9ff3dabfad4049b635a85456f927a075c9d0c210e3ea336412d18220b2a86cbb9b13ec46d6c37b70a302a4ea4d49e30e5d4944dd60ae784073f1cde778ac8f4b
+  languageName: node
+  linkType: hard
+
 "stack-utils@npm:^2.0.2, stack-utils@npm:^2.0.3":
   version: 2.0.6
   resolution: "stack-utils@npm:2.0.6"
@@ -16796,6 +16940,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-hex@npm:1.0.x":
+  version: 1.0.0
+  resolution: "text-hex@npm:1.0.0"
+  checksum: 10c0/57d8d320d92c79d7c03ffb8339b825bb9637c2cbccf14304309f51d8950015c44464b6fd1b6820a3d4821241c68825634f09f5a2d9d501e84f7c6fd14376860d
+  languageName: node
+  linkType: hard
+
 "thenify-all@npm:^1.0.0":
   version: 1.6.0
   resolution: "thenify-all@npm:1.6.0"
@@ -16972,6 +17123,13 @@ __metadata:
   version: 1.1.0
   resolution: "treeify@npm:1.1.0"
   checksum: 10c0/2f0dea9e89328b8a42296a3963d341ab19897a05b723d6b0bced6b28701a340d2a7b03241aef807844198e46009aaf3755139274eb082cfce6fdc1935cbd69dd
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:^1.3.0":
+  version: 1.4.1
+  resolution: "triple-beam@npm:1.4.1"
+  checksum: 10c0/4bf1db71e14fe3ff1c3adbe3c302f1fdb553b74d7591a37323a7badb32dc8e9c290738996cbb64f8b10dc5a3833645b5d8c26221aaaaa12e50d1251c9aba2fea
   languageName: node
   linkType: hard
 
@@ -17924,6 +18082,36 @@ __metadata:
   dependencies:
     string-width: "npm:^4.0.0"
   checksum: 10c0/b1e623adcfb9df35350dd7fc61295d6d4a1eaa65a406ba39c4b8360045b614af95ad10e05abf704936ed022569be438c4bfa02d6d031863c4166a238c301119f
+  languageName: node
+  linkType: hard
+
+"winston-transport@npm:^4.9.0":
+  version: 4.9.0
+  resolution: "winston-transport@npm:4.9.0"
+  dependencies:
+    logform: "npm:^2.7.0"
+    readable-stream: "npm:^3.6.2"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/e2990a172e754dbf27e7823772214a22dc8312f7ec9cfba831e5ef30a5d5528792e5ea8f083c7387ccfc5b2af20e3691f64738546c8869086110a26f98671095
+  languageName: node
+  linkType: hard
+
+"winston@npm:^3.17.0":
+  version: 3.17.0
+  resolution: "winston@npm:3.17.0"
+  dependencies:
+    "@colors/colors": "npm:^1.6.0"
+    "@dabh/diagnostics": "npm:^2.0.2"
+    async: "npm:^3.2.3"
+    is-stream: "npm:^2.0.0"
+    logform: "npm:^2.7.0"
+    one-time: "npm:^1.0.0"
+    readable-stream: "npm:^3.4.0"
+    safe-stable-stringify: "npm:^2.3.1"
+    stack-trace: "npm:0.0.x"
+    triple-beam: "npm:^1.3.0"
+    winston-transport: "npm:^4.9.0"
+  checksum: 10c0/ec8eaeac9a72b2598aedbff50b7dac82ce374a400ed92e7e705d7274426b48edcb25507d78cff318187c4fb27d642a0e2a39c57b6badc9af8e09d4a40636a5f7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3407,6 +3407,7 @@ __metadata:
   resolution: "@graphql-hive/logger-winston@workspace:packages/logger-winston"
   dependencies:
     "@graphql-mesh/types": "npm:^0.103.6"
+    "@whatwg-node/disposablestack": "npm:^0.0.5"
     graphql: "npm:16.10.0"
     pkgroll: "npm:2.8.2"
     tslib: "npm:^2.8.1"


### PR DESCRIPTION
**Winston Adapter**

Now you can integrate [Winston](https://github.com/winstonjs/winston) into Hive Gateway on Node.js

```ts
import { createLogger, format, transports } from 'winston'
import { createLoggerFromWinston } from '@graphql-hive/winston'

// Create a Winston logger
const winstonLogger = createLogger({
    level: 'info',
    format: format.combine(
        format.timestamp(),
        format.json()
    ),
    transports: [
        new transports.Console()
    ]
})

export const gatewayConfig = defineConfig({
    // Create an adapter for Winston
    logging: createLoggerFromWinston(winstonLogger)
})
```

In order to try it now, install the alpha of `@graphql-hive/gateway` and `@graphql-hive/winston` below; https://github.com/graphql-hive/gateway/pull/622#issuecomment-2648428148

Related GW-163