### PR TITLE
JSON based logger

### DIFF
--- a/.changeset/@graphql-hive_gateway-642-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-642-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+dependencies updates: 
+
+- Added dependency [`@graphql-hive/logger-json@workspace:^` ↗︎](https://www.npmjs.com/package/@graphql-hive/logger-json/v/workspace:^) (to `dependencies`)

--- a/.changeset/@graphql-hive_gateway-runtime-642-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-runtime-642-dependencies.md
@@ -5,4 +5,3 @@
 dependencies updates: 
 
 - Added dependency [`@graphql-hive/logger-json@workspace:^` ↗︎](https://www.npmjs.com/package/@graphql-hive/logger-json/v/workspace:^) (to `dependencies`)
-- Added dependency [`pino-pretty@^13.0.0` ↗︎](https://www.npmjs.com/package/pino-pretty/v/13.0.0) (to `dependencies`)

--- a/.changeset/@graphql-hive_gateway-runtime-642-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-runtime-642-dependencies.md
@@ -1,7 +1,8 @@
 ---
-'@graphql-hive/gateway': patch
+'@graphql-hive/gateway-runtime': patch
 ---
 
 dependencies updates: 
 
 - Added dependency [`@graphql-hive/logger-json@workspace:^` ↗︎](https://www.npmjs.com/package/@graphql-hive/logger-json/v/workspace:^) (to `dependencies`)
+- Added dependency [`pino-pretty@^13.0.0` ↗︎](https://www.npmjs.com/package/pino-pretty/v/13.0.0) (to `dependencies`)

--- a/.changeset/big-waves-prove.md
+++ b/.changeset/big-waves-prove.md
@@ -9,3 +9,6 @@
 ---
 
 New JSON-based logger
+
+By default, it prints pretty still to the console unless NODE_ENV is production.
+For JSON output, set the `LOG_FORMAT` environment variable to `json`.

--- a/.changeset/big-waves-prove.md
+++ b/.changeset/big-waves-prove.md
@@ -6,6 +6,7 @@
 '@graphql-hive/importer': patch
 '@graphql-hive/gateway': patch
 '@graphql-hive/gateway-runtime': patch
+'@graphql-hive/logger-json': patch
 ---
 
 New JSON-based logger

--- a/.changeset/big-waves-prove.md
+++ b/.changeset/big-waves-prove.md
@@ -1,0 +1,11 @@
+---
+'@graphql-mesh/transport-http-callback': patch
+'@graphql-mesh/plugin-opentelemetry': patch
+'@graphql-mesh/fusion-runtime': patch
+'@graphql-mesh/transport-ws': patch
+'@graphql-hive/importer': patch
+'@graphql-hive/gateway': patch
+'@graphql-hive/gateway-runtime': patch
+---
+
+New JSON-based logger

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "vitest": "^3.0.1"
   },
   "resolutions": {
+    "@graphql-mesh/types": "0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a",
+    "@graphql-mesh/utils": "0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a",
     "@graphql-tools/delegate": "workspace:^",
     "@opentelemetry/exporter-trace-otlp-http": "patch:@opentelemetry/exporter-trace-otlp-http@npm%3A0.56.0#~/.yarn/patches/@opentelemetry-exporter-trace-otlp-http-npm-0.56.0-dddd282e41.patch",
     "@opentelemetry/otlp-exporter-base": "patch:@opentelemetry/otlp-exporter-base@npm%3A0.56.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.56.0-ba3dc5f5c5.patch",

--- a/packages/fusion-runtime/src/federation/supergraph.ts
+++ b/packages/fusion-runtime/src/federation/supergraph.ts
@@ -311,11 +311,13 @@ export const handleFederationSupergraph: UnifiedGraphHandler = function ({
           if (context?.request) {
             requestId = requestIdByRequest.get(context.request);
             if (requestId) {
-              currentLogger = currentLogger?.child(requestId);
+              currentLogger = currentLogger?.child({ requestId });
             }
           }
           if (sourceSubschema.name) {
-            currentLogger = currentLogger?.child(sourceSubschema.name);
+            currentLogger = currentLogger?.child({
+              subgraph: sourceSubschema.name,
+            });
           }
           for (const onDelegationPlan of onDelegationPlanHooks) {
             const onDelegationPlanDone = onDelegationPlan({

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -102,7 +102,7 @@ function getTransportExecutor({
   let logger = transportContext?.logger;
   if (logger) {
     if (subgraphName) {
-      logger = logger.child(subgraphName);
+      logger = logger.child({ subgraph: subgraphName });
     }
     logger?.debug(`Loading transport "${kind}"`);
   }
@@ -195,10 +195,10 @@ export function getOnSubgraphExecute({
           executionRequest.context?.request,
         );
         if (requestId) {
-          logger = logger.child(requestId);
+          logger = logger.child({ requestId });
         }
         if (subgraphName) {
-          logger = logger.child(subgraphName);
+          logger = logger.child({ subgraph: subgraphName });
         }
         logger.debug(`Initializing executor`);
       }
@@ -287,7 +287,7 @@ export function wrapExecutorWithHooks({
     let execReqLogger = transportContext?.logger;
     if (execReqLogger) {
       if (requestId) {
-        execReqLogger = execReqLogger.child(requestId);
+        execReqLogger = execReqLogger.child({ requestId });
       }
       loggerForExecutionRequest.set(baseExecutionRequest, execReqLogger);
     }
@@ -548,11 +548,11 @@ export function wrapMergedTypeResolver<TContext extends Record<string, any>>(
     if (logger && context['request']) {
       requestId = requestIdByRequest.get(context['request']);
       if (requestId) {
-        logger = logger.child(requestId);
+        logger = logger.child({ requestId });
       }
     }
     if (subschema.name) {
-      logger = logger?.child(subschema.name);
+      logger = logger?.child({ subgraph: subschema.name });
     }
     let resolver = originalResolver as MergedTypeResolver<TContext>;
     function setResolver(newResolver: MergedTypeResolver<TContext>) {

--- a/packages/fusion-runtime/tests/polling.test.ts
+++ b/packages/fusion-runtime/tests/polling.test.ts
@@ -17,8 +17,8 @@ import { DisposableSymbols } from '@whatwg-node/disposablestack';
 import { ExecutionResult, GraphQLSchema, parse } from 'graphql';
 import { createSchema } from 'graphql-yoga';
 import { describe, expect, it, vi } from 'vitest';
-import { UnifiedGraphManager } from '../src/unifiedGraphManager';
 import { getDefaultLogger } from '../../runtime/src/getDefaultLogger';
+import { UnifiedGraphManager } from '../src/unifiedGraphManager';
 
 describe('Polling', () => {
   const advanceTimersByTimeAsync = vi.advanceTimersByTimeAsync || setTimeout;

--- a/packages/fusion-runtime/tests/polling.test.ts
+++ b/packages/fusion-runtime/tests/polling.test.ts
@@ -1,11 +1,12 @@
 import { setTimeout } from 'timers/promises';
+import { JSONLogger } from '@graphql-hive/logger-json';
 import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
 import { getExecutorForUnifiedGraph } from '@graphql-mesh/fusion-runtime';
 import {
   createDefaultExecutor,
   type DisposableExecutor,
 } from '@graphql-mesh/transport-common';
-import { DefaultLogger, makeDisposable } from '@graphql-mesh/utils';
+import { makeDisposable } from '@graphql-mesh/utils';
 import { normalizedExecutor } from '@graphql-tools/executor';
 import {
   createDeferred,
@@ -334,7 +335,7 @@ describe('Polling', () => {
     const unifiedGraphFetcher = vi.fn(() => {
       return graphDeferred ? graphDeferred.promise : unifiedGraph;
     });
-    const logger = new DefaultLogger();
+    const logger = new JSONLogger();
     await using executor = getExecutorForUnifiedGraph({
       getUnifiedGraph: unifiedGraphFetcher,
       pollingInterval: 10_000,

--- a/packages/fusion-runtime/tests/polling.test.ts
+++ b/packages/fusion-runtime/tests/polling.test.ts
@@ -1,5 +1,4 @@
 import { setTimeout } from 'timers/promises';
-import { JSONLogger } from '@graphql-hive/logger-json';
 import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
 import { getExecutorForUnifiedGraph } from '@graphql-mesh/fusion-runtime';
 import {
@@ -19,6 +18,7 @@ import { ExecutionResult, GraphQLSchema, parse } from 'graphql';
 import { createSchema } from 'graphql-yoga';
 import { describe, expect, it, vi } from 'vitest';
 import { UnifiedGraphManager } from '../src/unifiedGraphManager';
+import { getDefaultLogger } from '../../runtime/src/getDefaultLogger';
 
 describe('Polling', () => {
   const advanceTimersByTimeAsync = vi.advanceTimersByTimeAsync || setTimeout;
@@ -335,7 +335,7 @@ describe('Polling', () => {
     const unifiedGraphFetcher = vi.fn(() => {
       return graphDeferred ? graphDeferred.promise : unifiedGraph;
     });
-    const logger = new JSONLogger();
+    const logger = getDefaultLogger();
     await using executor = getExecutorForUnifiedGraph({
       getUnifiedGraph: unifiedGraphFetcher,
       pollingInterval: 10_000,

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -58,6 +58,7 @@
     "@envelop/core": "^5.0.2",
     "@graphql-hive/gateway-runtime": "workspace:^",
     "@graphql-hive/importer": "workspace:^",
+    "@graphql-hive/logger-json": "workspace:^",
     "@graphql-mesh/cache-cfw-kv": "^0.104.12",
     "@graphql-mesh/cache-localforage": "^0.103.13",
     "@graphql-mesh/cache-redis": "^0.103.13",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -58,7 +58,6 @@
     "@envelop/core": "^5.0.2",
     "@graphql-hive/gateway-runtime": "workspace:^",
     "@graphql-hive/importer": "workspace:^",
-    "@graphql-hive/logger-json": "workspace:^",
     "@graphql-mesh/cache-cfw-kv": "^0.104.12",
     "@graphql-mesh/cache-localforage": "^0.103.13",
     "@graphql-mesh/cache-redis": "^0.103.13",

--- a/packages/gateway/src/bin.ts
+++ b/packages/gateway/src/bin.ts
@@ -2,8 +2,8 @@
 import 'dotenv/config'; // inject dotenv options to process.env
 
 import module from 'node:module';
+import { JSONLogger } from '@graphql-hive/gateway-runtime';
 import type { InitializeData } from '@graphql-hive/importer/hooks';
-import { DefaultLogger } from '@graphql-mesh/utils';
 import { enableModuleCachingIfPossible, handleNodeWarnings, run } from './cli';
 
 // @inject-version globalThis.__VERSION__ here
@@ -20,7 +20,7 @@ module.register('@graphql-hive/importer/hooks', {
 enableModuleCachingIfPossible();
 handleNodeWarnings();
 
-const log = new DefaultLogger();
+const log = new JSONLogger();
 
 run({ log }).catch((err) => {
   log.error(err);

--- a/packages/gateway/src/bin.ts
+++ b/packages/gateway/src/bin.ts
@@ -3,8 +3,8 @@ import 'dotenv/config'; // inject dotenv options to process.env
 
 import module from 'node:module';
 import type { InitializeData } from '@graphql-hive/importer/hooks';
-import { enableModuleCachingIfPossible, handleNodeWarnings, run } from './cli';
 import { getDefaultLogger } from '../../runtime/src/getDefaultLogger';
+import { enableModuleCachingIfPossible, handleNodeWarnings, run } from './cli';
 
 // @inject-version globalThis.__VERSION__ here
 

--- a/packages/gateway/src/bin.ts
+++ b/packages/gateway/src/bin.ts
@@ -2,9 +2,9 @@
 import 'dotenv/config'; // inject dotenv options to process.env
 
 import module from 'node:module';
-import { JSONLogger } from '@graphql-hive/gateway-runtime';
 import type { InitializeData } from '@graphql-hive/importer/hooks';
 import { enableModuleCachingIfPossible, handleNodeWarnings, run } from './cli';
+import { getDefaultLogger } from '../../runtime/src/getDefaultLogger';
 
 // @inject-version globalThis.__VERSION__ here
 
@@ -20,7 +20,7 @@ module.register('@graphql-hive/importer/hooks', {
 enableModuleCachingIfPossible();
 handleNodeWarnings();
 
-const log = new JSONLogger();
+const log = getDefaultLogger();
 
 run({ log }).catch((err) => {
   log.error(err);

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -15,6 +15,7 @@ import type {
   GatewayGraphOSReportingOptions,
   GatewayHiveReportingOptions,
 } from '@graphql-hive/gateway-runtime';
+import { JSONLogger } from '@graphql-hive/logger-json';
 import type UpstashRedisCache from '@graphql-mesh/cache-upstash-redis';
 import type { JWTAuthPluginOptions } from '@graphql-mesh/plugin-jwt-auth';
 import type { OpenTelemetryMeshPluginOptions } from '@graphql-mesh/plugin-opentelemetry';
@@ -26,7 +27,6 @@ import type {
   MeshPubSub,
   YamlConfig,
 } from '@graphql-mesh/types';
-import { DefaultLogger } from '@graphql-mesh/utils';
 import parseDuration from 'parse-duration';
 import { addCommands } from './commands/index';
 import { createDefaultConfigPaths } from './config';
@@ -177,7 +177,7 @@ export function defineConfig(config: GatewayCLIConfig) {
 
 /** The context of the running program. */
 export interface CLIContext {
-  /** @default new DefaultLogger() */
+  /** @default new JSONLogger() */
   log: Logger;
   /** @default 'Mesh Serve' */
   productName: string;
@@ -347,7 +347,7 @@ let cli = new Command()
 
 export async function run(userCtx: Partial<CLIContext>) {
   const ctx: CLIContext = {
-    log: userCtx.log || new DefaultLogger(),
+    log: userCtx.log || new JSONLogger(),
     productName: 'Hive Gateway',
     productDescription: 'Federated GraphQL Gateway',
     productPackageName: '@graphql-hive/gateway',
@@ -362,7 +362,7 @@ export async function run(userCtx: Partial<CLIContext>) {
   cli = cli.name(binName).description(productDescription).version(version);
 
   if (cluster.worker?.id) {
-    ctx.log = ctx.log.child(`Worker #${cluster.worker.id}`);
+    ctx.log = ctx.log.child({ worker: cluster.worker.id });
   }
 
   addCommands(ctx, cli);

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -14,7 +14,6 @@ import {
   type GatewayConfigSupergraph,
   type GatewayGraphOSReportingOptions,
   type GatewayHiveReportingOptions,
-  JSONLogger,
 } from '@graphql-hive/gateway-runtime';
 import type UpstashRedisCache from '@graphql-mesh/cache-upstash-redis';
 import type { JWTAuthPluginOptions } from '@graphql-mesh/plugin-jwt-auth';
@@ -28,11 +27,11 @@ import type {
   YamlConfig,
 } from '@graphql-mesh/types';
 import parseDuration from 'parse-duration';
+import { getDefaultLogger } from '../../runtime/src/getDefaultLogger';
 import { addCommands } from './commands/index';
 import { createDefaultConfigPaths } from './config';
 import { getMaxConcurrency } from './getMaxConcurrency';
 import type { ServerConfig } from './servers/types';
-import { getDefaultLogger } from '../../runtime/src/getDefaultLogger';
 
 export type GatewayCLIConfig = (
   | GatewayCLISupergraphConfig

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -7,15 +7,15 @@ import {
   InvalidArgumentError,
   Option,
 } from '@commander-js/extra-typings';
-import type {
-  GatewayConfigContext,
-  GatewayConfigProxy,
-  GatewayConfigSubgraph,
-  GatewayConfigSupergraph,
-  GatewayGraphOSReportingOptions,
-  GatewayHiveReportingOptions,
+import {
+  type GatewayConfigContext,
+  type GatewayConfigProxy,
+  type GatewayConfigSubgraph,
+  type GatewayConfigSupergraph,
+  type GatewayGraphOSReportingOptions,
+  type GatewayHiveReportingOptions,
+  JSONLogger,
 } from '@graphql-hive/gateway-runtime';
-import { JSONLogger } from '@graphql-hive/logger-json';
 import type UpstashRedisCache from '@graphql-mesh/cache-upstash-redis';
 import type { JWTAuthPluginOptions } from '@graphql-mesh/plugin-jwt-auth';
 import type { OpenTelemetryMeshPluginOptions } from '@graphql-mesh/plugin-opentelemetry';
@@ -32,6 +32,7 @@ import { addCommands } from './commands/index';
 import { createDefaultConfigPaths } from './config';
 import { getMaxConcurrency } from './getMaxConcurrency';
 import type { ServerConfig } from './servers/types';
+import { getDefaultLogger } from '../../runtime/src/getDefaultLogger';
 
 export type GatewayCLIConfig = (
   | GatewayCLISupergraphConfig
@@ -177,7 +178,7 @@ export function defineConfig(config: GatewayCLIConfig) {
 
 /** The context of the running program. */
 export interface CLIContext {
-  /** @default new JSONLogger() */
+  /** @default new DefaultLogger() */
   log: Logger;
   /** @default 'Mesh Serve' */
   productName: string;
@@ -347,7 +348,7 @@ let cli = new Command()
 
 export async function run(userCtx: Partial<CLIContext>) {
   const ctx: CLIContext = {
-    log: userCtx.log || new JSONLogger(),
+    log: userCtx.log || getDefaultLogger(),
     productName: 'Hive Gateway',
     productDescription: 'Federated GraphQL Gateway',
     productPackageName: '@graphql-hive/gateway',

--- a/packages/gateway/src/commands/handleFork.ts
+++ b/packages/gateway/src/commands/handleFork.ts
@@ -13,13 +13,10 @@ export function handleFork(log: Logger, config: { fork?: number }): boolean {
         const workerLogger = log.child({ worker: worker.id });
         worker.once('exit', (code, signal) => {
           if (expectedToExit) {
-            workerLogger.debug(
-              'exited',
-              {
-                code,
-                signal,
-              },
-            );
+            workerLogger.debug('exited', {
+              code,
+              signal,
+            });
           } else {
             workerLogger.error(
               'exited unexpectedly. A restart is recommended to ensure the stability of the service',

--- a/packages/gateway/src/commands/handleFork.ts
+++ b/packages/gateway/src/commands/handleFork.ts
@@ -12,30 +12,32 @@ export function handleFork(log: Logger, config: { fork?: number }): boolean {
         const worker = cluster.fork();
         const workerLogger = log.child({ worker: worker.id });
         worker.once('exit', (code, signal) => {
+          const logData: Record<string, string | number> = {
+            signal,
+          };
+          if (code != null) {
+            logData['code'] = code;
+          }
           if (expectedToExit) {
-            workerLogger.debug('exited', {
-              code,
-              signal,
-            });
+            workerLogger.debug('exited', logData);
           } else {
             workerLogger.error(
               'exited unexpectedly. A restart is recommended to ensure the stability of the service',
-              {
-                code,
-                signal,
-              },
+              logData,
             );
           }
           workers.delete(worker);
           if (!expectedToExit && workers.size === 0) {
-            log.error(`All workers exited unexpectedly. Exiting`);
+            log.error(`All workers exited unexpectedly. Exiting`, logData);
             process.exit(1);
           }
         });
         workers.add(worker);
       }
       registerTerminateHandler((signal) => {
-        log.info(`Killing workers with ${signal}`);
+        log.info('Killing workers', {
+          signal,
+        });
         expectedToExit = true;
         workers.forEach((w) => {
           w.kill(signal);

--- a/packages/gateway/src/commands/handleLoggingOption.ts
+++ b/packages/gateway/src/commands/handleLoggingOption.ts
@@ -1,6 +1,6 @@
-import { JSONLogger } from '@graphql-hive/logger-json';
 import { Logger } from '@graphql-mesh/types';
 import { CLIContext, LogLevel } from '..';
+import { getDefaultLogger } from '../../../runtime/src/getDefaultLogger';
 
 export function handleLoggingConfig(
   loggingConfig: boolean | Logger | LogLevel | undefined,
@@ -13,7 +13,7 @@ export function handleLoggingConfig(
       if ('logLevel' in ctx.log) {
         ctx.log.logLevel = LogLevel.silent;
       } else {
-        ctx.log = new JSONLogger({
+        ctx.log = getDefaultLogger({
           name: ctx.log.name,
           level: LogLevel.silent,
         });
@@ -23,7 +23,7 @@ export function handleLoggingConfig(
     if ('logLevel' in ctx.log) {
       ctx.log.logLevel = loggingConfig;
     } else {
-      ctx.log = new JSONLogger({
+      ctx.log = getDefaultLogger({
         name: ctx.log.name,
         level: loggingConfig,
       });

--- a/packages/gateway/src/commands/handleLoggingOption.ts
+++ b/packages/gateway/src/commands/handleLoggingOption.ts
@@ -1,5 +1,6 @@
+import { JSONLogger } from '@graphql-hive/logger-json';
 import { Logger } from '@graphql-mesh/types';
-import { CLIContext, DefaultLogger, LogLevel } from '..';
+import { CLIContext, LogLevel } from '..';
 
 export function handleLoggingConfig(
   loggingConfig: boolean | Logger | LogLevel | undefined,
@@ -9,17 +10,23 @@ export function handleLoggingConfig(
     ctx.log = loggingConfig;
   } else if (typeof loggingConfig === 'boolean') {
     if (!loggingConfig) {
-      if (ctx.log instanceof DefaultLogger) {
+      if ('logLevel' in ctx.log) {
         ctx.log.logLevel = LogLevel.silent;
       } else {
-        ctx.log = new DefaultLogger(ctx.log.name, LogLevel.silent);
+        ctx.log = new JSONLogger({
+          name: ctx.log.name,
+          level: LogLevel.silent,
+        });
       }
     }
   } else if (typeof loggingConfig === 'number') {
-    if (ctx.log instanceof DefaultLogger) {
+    if ('logLevel' in ctx.log) {
       ctx.log.logLevel = loggingConfig;
     } else {
-      ctx.log = new DefaultLogger(ctx.log.name, loggingConfig);
+      ctx.log = new JSONLogger({
+        name: ctx.log.name,
+        level: loggingConfig,
+      });
     }
   }
 }

--- a/packages/gateway/src/commands/proxy.ts
+++ b/packages/gateway/src/commands/proxy.ts
@@ -65,11 +65,12 @@ export const addCommand: AddCommand = (ctx, cli) =>
       const hiveCdnEndpointOpt =
         // TODO: take schema from optsWithGlobals once https://github.com/commander-js/extra-typings/pull/76 is merged
         this.opts().schema || hiveCdnEndpoint;
+      const hiveCdnLogger = ctx.log.child({ source: 'Hive CDN' });
       if (hiveCdnEndpointOpt) {
         if (hiveCdnKey) {
           if (!isUrl(hiveCdnEndpointOpt)) {
-            ctx.log.error(
-              'Hive CDN endpoint must be a URL when providing --hive-cdn-key but got ' +
+            hiveCdnLogger.error(
+              'Endpoint must be a URL when providing --hive-cdn-key but got ' +
                 hiveCdnEndpointOpt,
             );
             process.exit(1);

--- a/packages/importer/src/debug.ts
+++ b/packages/importer/src/debug.ts
@@ -1,9 +1,13 @@
-export const isDebug = ['1', 'y', 'yes', 't', 'true'].includes(
-  String(process.env['DEBUG']),
-);
+export const isDebug = ['importer'].includes(String(process.env['DEBUG']));
 
-export function debug(msg: string) {
+export function debug(message: string) {
   if (isDebug) {
-    process.stderr.write(`[${new Date().toISOString()}] HOOKS ${msg}\n`);
+    process.stderr.write(
+      `${JSON.stringify({
+        name: 'importer',
+        level: 'debug',
+        message,
+      })}\n`,
+    );
   }
 }

--- a/packages/logger-json/package.json
+++ b/packages/logger-json/package.json
@@ -42,9 +42,10 @@
     "graphql": "^15.9.0 || ^16.9.0"
   },
   "dependencies": {
-    "@graphql-mesh/cross-helpers": "^0.4.9",
-    "@graphql-mesh/types": "^0.103.6",
-    "@graphql-mesh/utils": "^0.103.6",
+    "@graphql-mesh/cross-helpers": "^0.4.10",
+    "@graphql-mesh/types": "^0.103.16",
+    "@graphql-mesh/utils": "^0.103.16",
+    "cross-inspect": "^1.0.1",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/logger-json/package.json
+++ b/packages/logger-json/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@graphql-hive/logger-json",
+  "version": "0.0.0",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/graphql-hive/gateway.git",
+    "directory": "packages/logger-json"
+  },
+  "author": {
+    "email": "contact@the-guild.dev",
+    "name": "The Guild",
+    "url": "https://the-guild.dev"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pkgroll --clean-dist",
+    "prepack": "yarn build"
+  },
+  "peerDependencies": {
+    "graphql": "^15.9.0 || ^16.9.0"
+  },
+  "dependencies": {
+    "@graphql-mesh/cross-helpers": "^0.4.9",
+    "@graphql-mesh/types": "^0.103.6",
+    "@graphql-mesh/utils": "^0.103.6",
+    "tslib": "^2.8.1"
+  },
+  "devDependencies": {
+    "graphql": "^16.9.0",
+    "pkgroll": "2.8.2"
+  },
+  "sideEffects": false
+}

--- a/packages/logger-json/src/index.ts
+++ b/packages/logger-json/src/index.ts
@@ -1,0 +1,184 @@
+import { process } from '@graphql-mesh/cross-helpers';
+import type { LazyLoggerMessage, Logger } from '@graphql-mesh/types';
+import { LogLevel } from '@graphql-mesh/utils';
+
+export interface JSONLoggerOptions {
+  name?: string;
+  meta?: Record<string, any>;
+  level?: LogLevel;
+  console?: Console;
+}
+function truthy(val: unknown) {
+  return (
+    val === true ||
+    val === 1 ||
+    ['1', 't', 'true', 'y', 'yes'].includes(String(val))
+  );
+}
+
+declare global {
+  var DEBUG: string;
+}
+
+export class JSONLogger implements Logger {
+  name?: string;
+  meta: Record<string, any>;
+  logLevel: LogLevel;
+  console: Console;
+  constructor(opts?: JSONLoggerOptions) {
+    this.name = opts?.name;
+    this.console = opts?.console || console;
+    this.meta = opts?.meta || {};
+    const debugStrs = [process.env['DEBUG'], globalThis.DEBUG];
+    if (opts?.level != null) {
+      this.logLevel = opts.level;
+    } else {
+      this.logLevel = LogLevel.info;
+      for (const debugStr of debugStrs) {
+        if (debugStr) {
+          if (truthy(debugStr)) {
+            this.logLevel = LogLevel.debug;
+            break;
+          }
+          if (opts?.name) {
+            if (debugStr?.toString()?.includes(opts.name)) {
+              this.logLevel = LogLevel.debug;
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  log(...messageArgs: LazyLoggerMessage[]) {
+    if (this.logLevel > LogLevel.info) {
+      return;
+    }
+    const finalMessage = this.prepareFinalMessage('info', messageArgs);
+    this.console.log(finalMessage);
+  }
+
+  warn(...messageArgs: LazyLoggerMessage[]) {
+    if (this.logLevel > LogLevel.warn) {
+      return;
+    }
+    const finalMessage = this.prepareFinalMessage('warn', messageArgs);
+    this.console.warn(finalMessage);
+  }
+
+  info(...messageArgs: LazyLoggerMessage[]) {
+    if (this.logLevel > LogLevel.info) {
+      return;
+    }
+    const finalMessage = this.prepareFinalMessage('info', messageArgs);
+    this.console.info(finalMessage);
+  }
+
+  error(...messageArgs: LazyLoggerMessage[]) {
+    if (this.logLevel > LogLevel.error) {
+      return;
+    }
+    const finalMessage = this.prepareFinalMessage('error', messageArgs);
+    this.console.error(finalMessage);
+  }
+
+  debug(...messageArgs: LazyLoggerMessage[]) {
+    if (this.logLevel > LogLevel.debug) {
+      return;
+    }
+    const finalMessage = this.prepareFinalMessage('debug', messageArgs);
+    this.console.debug(finalMessage);
+  }
+
+  child(nameOrMeta: string | Record<string, string | number>) {
+    let newName: string | undefined;
+    let newMeta: Record<string, any>;
+    if (typeof nameOrMeta === 'string') {
+      newName = this.name ? `${this.name}, ${nameOrMeta}` : nameOrMeta;
+      newMeta = this.meta;
+    } else if (typeof nameOrMeta === 'object') {
+      newName = this.name;
+      newMeta = { ...this.meta, ...nameOrMeta };
+    } else {
+      throw new Error('Invalid argument type');
+    }
+    return new JSONLogger({
+      name: newName,
+      meta: newMeta,
+      level: this.logLevel,
+      console: this.console,
+    });
+  }
+
+  addPrefix(prefix: string | Record<string, string>) {
+    if (typeof prefix === 'string') {
+      this.name = this.name ? `${this.name}, ${prefix}` : prefix;
+    } else if (typeof prefix === 'object') {
+      this.meta = { ...this.meta, ...prefix };
+    }
+    return this;
+  }
+
+  private prepareFinalMessage(level: string, messageArgs: LazyLoggerMessage[]) {
+    const flattenedMessageArgs = messageArgs
+      .flat(Infinity)
+      .flatMap((messageArg) => {
+        if (typeof messageArg === 'function') {
+          messageArg = messageArg();
+        }
+        if (messageArg?.toJSON) {
+          messageArg = messageArg.toJSON();
+        }
+        if (messageArg instanceof AggregateError) {
+          return messageArg.errors;
+        }
+        return messageArg;
+      });
+    const finalMessage: Record<string, any> = {
+      ...this.meta,
+      level,
+      time: new Date().toISOString(),
+    };
+    if (this.name) {
+      finalMessage['name'] = this.name;
+    }
+    const extras: any[] = [];
+    for (let messageArg of flattenedMessageArgs) {
+      if (messageArg == null) {
+        continue;
+      }
+      const typeofMessageArg = typeof messageArg;
+      if (
+        typeofMessageArg === 'string' ||
+        typeofMessageArg === 'number' ||
+        typeofMessageArg === 'boolean'
+      ) {
+        finalMessage['msg'] = finalMessage['msg']
+          ? finalMessage['msg'] + ', ' + messageArg
+          : messageArg;
+      } else if (typeofMessageArg === 'object') {
+        if (messageArg instanceof Error) {
+          finalMessage['msg'] = finalMessage['msg']
+            ? finalMessage['msg'] + ', ' + messageArg.message
+            : messageArg.message;
+          finalMessage['stack'] = messageArg.stack;
+        } else if (
+          Object.prototype.toString.call(messageArg).startsWith('[object')
+        ) {
+          Object.assign(finalMessage, messageArg);
+        } else {
+          extras.push(messageArg);
+        }
+      }
+    }
+    if (extras.length) {
+      if (extras.length === 1) {
+        finalMessage['extras'] = extras[0];
+      } else {
+        finalMessage['extras'] = extras;
+      }
+    }
+    return JSON.stringify(finalMessage);
+  }
+}

--- a/packages/logger-json/src/index.ts
+++ b/packages/logger-json/src/index.ts
@@ -1,6 +1,7 @@
 import { process } from '@graphql-mesh/cross-helpers';
 import type { LazyLoggerMessage, Logger } from '@graphql-mesh/types';
 import { LogLevel } from '@graphql-mesh/utils';
+import { inspect } from 'cross-inspect';
 
 export interface JSONLoggerOptions {
   name?: string;
@@ -174,9 +175,9 @@ export class JSONLogger implements Logger {
     }
     if (extras.length) {
       if (extras.length === 1) {
-        finalMessage['extras'] = extras[0];
+        finalMessage['extras'] = inspect(extras[0]);
       } else {
-        finalMessage['extras'] = extras;
+        finalMessage['extras'] = extras.map((extra) => inspect(extra));
       }
     }
     return JSON.stringify(finalMessage);

--- a/packages/plugins/opentelemetry/src/plugin.ts
+++ b/packages/plugins/opentelemetry/src/plugin.ts
@@ -194,7 +194,7 @@ export function useOpenTelemetry(
           webProvider.register();
           provider = webProvider;
         }
-        const pluginLogger = options.logger.child('OpenTelemetry');
+        const pluginLogger = options.logger.child({ plugin: 'OpenTelemetry' });
         diag.setLogger(
           {
             error: (message, ...args) => pluginLogger.error(message, ...args),

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -54,6 +54,7 @@
     "@envelop/disable-introspection": "^6.0.0",
     "@envelop/generic-auth": "^8.0.0",
     "@graphql-hive/core": "^0.9.0",
+    "@graphql-hive/logger-json": "workspace:^",
     "@graphql-mesh/cross-helpers": "^0.4.9",
     "@graphql-mesh/fusion-runtime": "workspace:^",
     "@graphql-mesh/hmac-upstream-signature": "workspace:^",
@@ -79,6 +80,7 @@
     "@whatwg-node/server": "^0.9.60",
     "graphql-ws": "^6.0.3",
     "graphql-yoga": "^5.10.11",
+    "pino-pretty": "^13.0.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -80,7 +80,6 @@
     "@whatwg-node/server": "^0.9.60",
     "graphql-ws": "^6.0.3",
     "graphql-yoga": "^5.10.11",
-    "pino-pretty": "^13.0.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -5,7 +5,6 @@ import {
   createSchemaFetcher,
   createSupergraphSDLFetcher,
 } from '@graphql-hive/core';
-import { JSONLogger } from '@graphql-hive/logger-json';
 import type {
   OnDelegationPlanHook,
   OnDelegationStageExecuteHook,
@@ -111,6 +110,7 @@ import {
   defaultQueryText,
   getExecuteFnFromExecutor,
 } from './utils';
+import { getDefaultLogger } from './getDefaultLogger';
 
 // TODO: this type export is not properly accessible from graphql-yoga
 //       "graphql-yoga/typings/plugins/use-graphiql.js" is an illegal path
@@ -137,15 +137,15 @@ export function createGatewayRuntime<
   let fetchAPI = config.fetchAPI;
   let logger: Logger;
   if (config.logging == null) {
-    logger = new JSONLogger();
+    logger = getDefaultLogger();
   } else if (typeof config.logging === 'boolean') {
     logger = config.logging
-      ? new JSONLogger()
-      : new JSONLogger({
+      ? getDefaultLogger()
+      : getDefaultLogger({
           level: LogLevel.silent,
         });
   } else if (typeof config.logging === 'number') {
-    logger = new JSONLogger({
+    logger = getDefaultLogger({
       level: config.logging,
     });
   } /*  if (typeof config.logging === 'object') */ else {

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -78,6 +78,7 @@ import {
 } from 'graphql-yoga';
 import type { GraphiQLOptions, PromiseOrValue } from 'graphql-yoga';
 import { createGraphOSFetcher } from './fetchers/graphos';
+import { getDefaultLogger } from './getDefaultLogger';
 import { getProxyExecutor } from './getProxyExecutor';
 import { getReportingPlugin } from './getReportingPlugin';
 import {
@@ -110,7 +111,6 @@ import {
   defaultQueryText,
   getExecuteFnFromExecutor,
 } from './utils';
-import { getDefaultLogger } from './getDefaultLogger';
 
 // TODO: this type export is not properly accessible from graphql-yoga
 //       "graphql-yoga/typings/plugins/use-graphiql.js" is an illegal path

--- a/packages/runtime/src/fetchers/graphos.ts
+++ b/packages/runtime/src/fetchers/graphos.ts
@@ -27,7 +27,7 @@ export function createGraphOSFetcher({
     graphosOpts.upLink || process.env['APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT'];
   const uplinks =
     uplinksParam?.split(',').map((uplink) => uplink.trim()) || DEFAULT_UPLINKS;
-  const graphosLogger = configContext.logger.child('GraphOS');
+  const graphosLogger = configContext.logger.child({ source: 'GraphOS' });
   graphosLogger.info('Using Managed Federation with uplinks: ', ...uplinks);
   const maxRetries = graphosOpts.maxRetries || Math.max(3, uplinks.length);
   let supergraphLoadedPlace = defaultLoadedPlacePrefix;
@@ -57,9 +57,10 @@ export function createGraphOSFetcher({
         }
         retries--;
         const uplinkToUse = uplinksToUse.pop();
-        const attemptLogger = graphosLogger.child(
-          `Attempt ${maxRetries - retries} - UpLink: ${uplinkToUse}`,
-        );
+        const attemptLogger = graphosLogger.child({
+          attempt: maxRetries - retries,
+          uplink: uplinkToUse || 'none',
+        });
         attemptLogger.debug(`Fetching supergraph`);
         return fetchSupergraphSdlFromManagedFederation({
           graphRef: graphosOpts.graphRef,

--- a/packages/runtime/src/getDefaultLogger.ts
+++ b/packages/runtime/src/getDefaultLogger.ts
@@ -1,0 +1,39 @@
+import { JSONLogger } from '@graphql-hive/logger-json';
+import { process } from '@graphql-mesh/cross-helpers';
+import { LogLevel } from '@graphql-mesh/utils';
+// eslint-disable-next-line import/no-nodejs-modules
+import { Console } from 'node:console';
+import pinoPretty from 'pino-pretty';
+
+export function getDefaultLogger(opts?: { name?: string; level?: LogLevel; }) {
+    const logFormat = process.env['LOG_FORMAT'] || (globalThis as any).LOG_FORMAT;
+    if (logFormat) {
+        if (logFormat.toLowerCase() === 'json') {
+            return new JSONLogger(opts);
+        } else if (logFormat.toLowerCase() === 'pretty') {
+            return createPrettyLogger(opts);
+        }
+    }
+    const nodeEnv = process.env['NODE_ENV'] || (globalThis as any).NODE_ENV;
+    if (nodeEnv === 'production') {
+        return new JSONLogger(opts);
+    }
+    return createPrettyLogger(opts);
+}
+
+function createPrettyLogger(opts?: { name?: string; level?: LogLevel; }) {
+    const stdOut = pinoPretty({
+        levelFirst: true,
+        colorize: true,
+        destination: process.stdout,
+    });
+    const stdErr = pinoPretty({
+        levelFirst: true,
+        colorize: true,
+        destination: process.stdout,
+    });
+    return new JSONLogger({
+        ...opts,
+        console: new Console(stdOut, stdErr)
+    });
+}

--- a/packages/runtime/src/getDefaultLogger.ts
+++ b/packages/runtime/src/getDefaultLogger.ts
@@ -1,39 +1,39 @@
+// eslint-disable-next-line import/no-nodejs-modules
+import { Console } from 'node:console';
 import { JSONLogger } from '@graphql-hive/logger-json';
 import { process } from '@graphql-mesh/cross-helpers';
 import { LogLevel } from '@graphql-mesh/utils';
-// eslint-disable-next-line import/no-nodejs-modules
-import { Console } from 'node:console';
 import pinoPretty from 'pino-pretty';
 
-export function getDefaultLogger(opts?: { name?: string; level?: LogLevel; }) {
-    const logFormat = process.env['LOG_FORMAT'] || (globalThis as any).LOG_FORMAT;
-    if (logFormat) {
-        if (logFormat.toLowerCase() === 'json') {
-            return new JSONLogger(opts);
-        } else if (logFormat.toLowerCase() === 'pretty') {
-            return createPrettyLogger(opts);
-        }
+export function getDefaultLogger(opts?: { name?: string; level?: LogLevel }) {
+  const logFormat = process.env['LOG_FORMAT'] || (globalThis as any).LOG_FORMAT;
+  if (logFormat) {
+    if (logFormat.toLowerCase() === 'json') {
+      return new JSONLogger(opts);
+    } else if (logFormat.toLowerCase() === 'pretty') {
+      return createPrettyLogger(opts);
     }
-    const nodeEnv = process.env['NODE_ENV'] || (globalThis as any).NODE_ENV;
-    if (nodeEnv === 'production') {
-        return new JSONLogger(opts);
-    }
-    return createPrettyLogger(opts);
+  }
+  const nodeEnv = process.env['NODE_ENV'] || (globalThis as any).NODE_ENV;
+  if (nodeEnv === 'production') {
+    return new JSONLogger(opts);
+  }
+  return createPrettyLogger(opts);
 }
 
-function createPrettyLogger(opts?: { name?: string; level?: LogLevel; }) {
-    const stdOut = pinoPretty({
-        levelFirst: true,
-        colorize: true,
-        destination: process.stdout,
-    });
-    const stdErr = pinoPretty({
-        levelFirst: true,
-        colorize: true,
-        destination: process.stdout,
-    });
-    return new JSONLogger({
-        ...opts,
-        console: new Console(stdOut, stdErr)
-    });
+function createPrettyLogger(opts?: { name?: string; level?: LogLevel }) {
+  const stdOut = pinoPretty({
+    levelFirst: true,
+    colorize: true,
+    destination: process.stdout,
+  });
+  const stdErr = pinoPretty({
+    levelFirst: true,
+    colorize: true,
+    destination: process.stdout,
+  });
+  return new JSONLogger({
+    ...opts,
+    console: new Console(stdOut, stdErr),
+  });
 }

--- a/packages/runtime/src/getDefaultLogger.ts
+++ b/packages/runtime/src/getDefaultLogger.ts
@@ -1,9 +1,6 @@
-// eslint-disable-next-line import/no-nodejs-modules
-import { Console } from 'node:console';
 import { JSONLogger } from '@graphql-hive/logger-json';
 import { process } from '@graphql-mesh/cross-helpers';
-import { LogLevel } from '@graphql-mesh/utils';
-import pinoPretty from 'pino-pretty';
+import { DefaultLogger, LogLevel } from '@graphql-mesh/utils';
 
 export function getDefaultLogger(opts?: { name?: string; level?: LogLevel }) {
   const logFormat = process.env['LOG_FORMAT'] || (globalThis as any).LOG_FORMAT;
@@ -11,29 +8,12 @@ export function getDefaultLogger(opts?: { name?: string; level?: LogLevel }) {
     if (logFormat.toLowerCase() === 'json') {
       return new JSONLogger(opts);
     } else if (logFormat.toLowerCase() === 'pretty') {
-      return createPrettyLogger(opts);
+      return new DefaultLogger(opts?.name, opts?.level);
     }
   }
   const nodeEnv = process.env['NODE_ENV'] || (globalThis as any).NODE_ENV;
   if (nodeEnv === 'production') {
     return new JSONLogger(opts);
   }
-  return createPrettyLogger(opts);
-}
-
-function createPrettyLogger(opts?: { name?: string; level?: LogLevel }) {
-  const stdOut = pinoPretty({
-    levelFirst: true,
-    colorize: true,
-    destination: process.stdout,
-  });
-  const stdErr = pinoPretty({
-    levelFirst: true,
-    colorize: true,
-    destination: process.stdout,
-  });
-  return new JSONLogger({
-    ...opts,
-    console: new Console(stdOut, stdErr),
-  });
+  return new DefaultLogger(opts?.name, opts?.level);
 }

--- a/packages/runtime/src/getReportingPlugin.ts
+++ b/packages/runtime/src/getReportingPlugin.ts
@@ -18,7 +18,7 @@ export function getReportingPlugin<TContext extends Record<string, any>>(
       name: 'Hive',
       plugin: useMeshHive({
         ...configContext,
-        logger: configContext.logger.child('Hive'),
+        logger: configContext.logger.child({ reporting: 'Hive' }),
         ...config.reporting,
         ...(config.persistedDocuments &&
         'type' in config.persistedDocuments &&

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,6 @@
 export * from './createGatewayRuntime';
 export { LogLevel, DefaultLogger } from '@graphql-mesh/utils';
+export { JSONLogger } from '@graphql-hive/logger-json';
 export type * from './types';
 export * from './plugins/useCustomFetch';
 export * from './plugins/useStaticFiles';

--- a/packages/runtime/src/plugins/useDelegationPlanDebug.ts
+++ b/packages/runtime/src/plugins/useDelegationPlanDebug.ts
@@ -22,16 +22,16 @@ export function useDelegationPlanDebug<
       info,
       logger = opts.logger,
     }) {
-      logger = logger.child('delegation-plan');
       const planId = fetchAPI.crypto.randomUUID();
-      logger.debug('start', () => {
+      const delegationPlanStartLogger = logger.child('delegation-plan-start');
+      delegationPlanStartLogger.debug(() => {
         const logObj: Record<string, any> = {
           planId,
           subgraph,
           typeName,
         };
         if (variables && Object.keys(variables).length) {
-          logObj['variables'] = JSON.stringify(variables);
+          logObj['variables'] = variables;
         }
         if (fragments && Object.keys(fragments).length) {
           logObj['fragments'] = Object.fromEntries(
@@ -53,7 +53,8 @@ export function useDelegationPlanDebug<
       });
       const start = performance.now();
       return ({ delegationPlan }) => {
-        logger.debug('done', () => ({
+        const delegationPlanDoneLogger = logger.child('delegation-plan-done');
+        delegationPlanDoneLogger.debug(() => ({
           planId,
           plan: delegationPlan.map((plan) => {
             const planObj: Record<string, string> = {};
@@ -78,13 +79,13 @@ export function useDelegationPlanDebug<
       typeName,
       logger = opts.logger,
     }) {
-      logger = logger.child('delegation-stage-execute');
       let stageId: string;
       let contextLog = stageExecuteLogById.get(context);
       if (!contextLog) {
         contextLog = new Set();
         stageExecuteLogById.set(context, contextLog);
       }
+      const delegationStageLogger = logger.child('delegation-stage-execute');
       const log = {
         subgraph,
         typeName,
@@ -98,7 +99,7 @@ export function useDelegationPlanDebug<
       }
       contextLog.add(logStr);
       stageId = fetchAPI.crypto.randomUUID();
-      logger.debug('start', () => {
+      delegationStageLogger.debug('start', () => {
         return {
           stageId,
           ...log,
@@ -107,7 +108,10 @@ export function useDelegationPlanDebug<
       });
       const start = performance.now();
       return ({ result }) => {
-        logger.debug('result', () => ({
+        const delegationStageExecuteDoneLogger = logger.child(
+          'delegation-stage-execute-done',
+        );
+        delegationStageExecuteDoneLogger.debug(() => ({
           stageId,
           result: JSON.stringify(result, null),
           duration: performance.now() - start,

--- a/packages/runtime/src/plugins/useFetchDebug.ts
+++ b/packages/runtime/src/plugins/useFetchDebug.ts
@@ -12,7 +12,13 @@ export function useFetchDebug<TContext extends Record<string, any>>(opts: {
     },
     onFetch({ url, options, logger = opts.logger, requestId }) {
       const fetchId = fetchAPI.crypto.randomUUID();
-      const fetchLogger = logger.child({ fetchId, requestId: requestId! });
+      const loggerMeta: Record<string, string> = {
+        fetchId,
+      }
+      if (requestId) {
+        loggerMeta['requestId'] = requestId;
+      }
+      const fetchLogger = logger.child(loggerMeta);
       const httpFetchRequestLogger = fetchLogger.child('http-fetch-request');
       httpFetchRequestLogger.debug(() => ({
         url,

--- a/packages/runtime/src/plugins/useFetchDebug.ts
+++ b/packages/runtime/src/plugins/useFetchDebug.ts
@@ -14,7 +14,7 @@ export function useFetchDebug<TContext extends Record<string, any>>(opts: {
       const fetchId = fetchAPI.crypto.randomUUID();
       const loggerMeta: Record<string, string> = {
         fetchId,
-      }
+      };
       if (requestId) {
         loggerMeta['requestId'] = requestId;
       }

--- a/packages/runtime/src/plugins/useRequestId.ts
+++ b/packages/runtime/src/plugins/useRequestId.ts
@@ -15,7 +15,7 @@ export function useRequestId<
         const requestId = requestIdByRequest.get(context.request);
         if (requestId && context.logger) {
           // @ts-expect-error - Logger is somehow read-only
-          context.logger = context.logger.child(requestId);
+          context.logger = context.logger.child({ requestId });
         }
       }
     },

--- a/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
+++ b/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
@@ -13,10 +13,13 @@ export function useSubgraphExecuteDebug<
     },
     onSubgraphExecute({ executionRequest, logger = opts.logger, requestId }) {
       const subgraphExecuteId = fetchAPI.crypto.randomUUID();
-      const subgraphExecuteHookLogger = logger.child({
+      const loggerMeta: Record<string, string> = {
         subgraphExecuteId,
-        requestId: requestId!,
-      });
+      }
+      if (requestId) {
+        loggerMeta['requestId'] = requestId;
+      }
+      const subgraphExecuteHookLogger = logger.child(loggerMeta);
       if (executionRequest) {
         const subgraphExecuteStartLogger = subgraphExecuteHookLogger.child(
           'subgraph-execute-start',

--- a/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
+++ b/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
@@ -11,41 +11,53 @@ export function useSubgraphExecuteDebug<
     onYogaInit({ yoga }) {
       fetchAPI = yoga.fetchAPI;
     },
-    onSubgraphExecute({ executionRequest, logger = opts.logger }) {
+    onSubgraphExecute({ executionRequest, logger = opts.logger, requestId }) {
       const subgraphExecuteId = fetchAPI.crypto.randomUUID();
-      logger = logger.child('subgraph-execute');
+      const subgraphExecuteHookLogger = logger.child({
+        subgraphExecuteId,
+        requestId: requestId!,
+      });
       if (executionRequest) {
-        logger.debug('start', () => ({
-          subgraphExecuteId,
-          query:
-            executionRequest.document &&
-            defaultPrintFn(executionRequest.document),
-          variables:
+        const subgraphExecuteStartLogger = subgraphExecuteHookLogger.child(
+          'subgraph-execute-start',
+        );
+        subgraphExecuteStartLogger.debug(() => {
+          const logData: Record<string, any> = {};
+          if (executionRequest.document) {
+            logData['query'] = defaultPrintFn(executionRequest.document);
+          }
+          if (
             executionRequest.variables &&
-            JSON.stringify(executionRequest.variables),
-        }));
+            Object.keys(executionRequest.variables).length
+          ) {
+            logData['variables'] = executionRequest.variables;
+          }
+          return logData;
+        });
       }
       const start = performance.now();
       return function onSubgraphExecuteDone({ result }) {
+        const subgraphExecuteEndLogger = subgraphExecuteHookLogger.child(
+          'subgraph-execute-end',
+        );
         if (isAsyncIterable(result)) {
           return {
             onNext({ result }) {
-              logger.debug('next', () => ({
-                subgraphExecuteId,
-                result: JSON.stringify(result),
-              }));
+              const subgraphExecuteNextLogger = subgraphExecuteHookLogger.child(
+                'subgraph-execute-next',
+              );
+              subgraphExecuteNextLogger.debug(result);
             },
             onEnd() {
-              logger.debug('end', () => ({
-                subgraphExecuteId,
+              subgraphExecuteEndLogger.debug(() => ({
                 duration: performance.now() - start,
               }));
             },
           };
         }
-        logger.debug('result', () => ({
-          subgraphExecuteId,
-          result: JSON.stringify(result),
+        subgraphExecuteEndLogger.debug(() => ({
+          result,
+          duration: performance.now() - start,
         }));
         return void 0;
       };

--- a/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
+++ b/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
@@ -15,7 +15,7 @@ export function useSubgraphExecuteDebug<
       const subgraphExecuteId = fetchAPI.crypto.randomUUID();
       const loggerMeta: Record<string, string> = {
         subgraphExecuteId,
-      }
+      };
       if (requestId) {
         loggerMeta['requestId'] = requestId;
       }

--- a/packages/runtime/tests/graphos.test.ts
+++ b/packages/runtime/tests/graphos.test.ts
@@ -1,6 +1,6 @@
 import { setTimeout } from 'timers/promises';
 import {
-  DefaultLogger,
+  JSONLogger,
   type GatewayConfigContext,
   type GatewayGraphOSManagedFederationOptions,
 } from '@graphql-hive/gateway-runtime';
@@ -131,7 +131,7 @@ function createTestFetcher(
   return createGraphOSFetcher({
     configContext: {
       logger: process.env['DEBUG']
-        ? new DefaultLogger()
+        ? new JSONLogger()
         : {
             child() {
               return this;

--- a/packages/transports/http-callback/src/index.ts
+++ b/packages/transports/http-callback/src/index.ts
@@ -107,7 +107,10 @@ export default {
       executionRequest: ExecutionRequest,
     ) {
       const subscriptionId = crypto.randomUUID();
-      const subscriptionLogger = logger?.child(subscriptionId);
+      const subscriptionLogger = logger?.child({
+        executor: 'http-callback',
+        subscription: subscriptionId,
+      });
       const callbackUrl = `${publicUrl}${callbackPath}/${subscriptionId}`;
       const subscriptionCallbackPath = `${callbackPath}/${subscriptionId}`;
       const serializedParams = serializeExecutionRequest({

--- a/packages/transports/ws/src/index.ts
+++ b/packages/transports/ws/src/index.ts
@@ -76,7 +76,12 @@ export default {
 
       let wsExecutor = wsExecutorMap.get(hash);
       if (!wsExecutor) {
-        const executorLogger = logger?.child('GraphQL WS').child(hash);
+        const executorLogger = logger?.child({
+          executor: 'GraphQL WS',
+          wsUrl,
+          connectionParams,
+          headers,
+        } as Record<string, any>);
         wsExecutor = buildGraphQLWSExecutor({
           headers,
           url: wsUrl,

--- a/packages/transports/ws/tests/ws.spec.ts
+++ b/packages/transports/ws/tests/ws.spec.ts
@@ -1,8 +1,9 @@
+import { JSONLogger } from '@graphql-hive/logger-json';
 import type {
   TransportEntry,
   TransportGetSubgraphExecutorOptions,
 } from '@graphql-mesh/transport-common';
-import { DefaultLogger, dispose } from '@graphql-mesh/utils';
+import { dispose } from '@graphql-mesh/utils';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { createDeferred } from '@graphql-tools/utils';
 import { createDisposableWebSocketServer } from '@internal/testing';
@@ -78,7 +79,7 @@ async function createTServer(
         ...transportEntry,
         options,
       },
-      logger: new DefaultLogger(),
+      logger: new JSONLogger(),
     } as unknown as TransportGetSubgraphExecutorOptions<WSTransportOptions>,
     onClient,
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,7 +58,8 @@
         "./packages/stitching-directives/src/index.ts"
       ],
       "@graphql-tools/wrap": ["./packages/wrap/src/index.ts"],
-      "@graphql-tools/executor-*": ["./packages/executors/*/src/index.ts"]
+      "@graphql-tools/executor-*": ["./packages/executors/*/src/index.ts"],
+      "@graphql-hive/logger-json": ["./packages/logger-json/src/index.ts"]
     }
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3237,6 +3237,7 @@ __metadata:
     "@envelop/disable-introspection": "npm:^6.0.0"
     "@envelop/generic-auth": "npm:^8.0.0"
     "@graphql-hive/core": "npm:^0.9.0"
+    "@graphql-hive/logger-json": "workspace:^"
     "@graphql-mesh/cross-helpers": "npm:^0.4.9"
     "@graphql-mesh/fusion-composition": "npm:^0.7.0"
     "@graphql-mesh/fusion-runtime": "workspace:^"
@@ -3271,6 +3272,7 @@ __metadata:
     graphql-ws: "npm:^6.0.3"
     graphql-yoga: "npm:^5.10.11"
     html-minifier-terser: "npm:7.2.0"
+    pino-pretty: "npm:^13.0.0"
     pkgroll: "npm:2.8.2"
     tslib: "npm:^2.8.1"
     tsx: "npm:4.19.2"
@@ -3291,7 +3293,6 @@ __metadata:
     "@envelop/core": "npm:^5.0.2"
     "@graphql-hive/gateway-runtime": "workspace:^"
     "@graphql-hive/importer": "workspace:^"
-    "@graphql-hive/logger-json": "workspace:^"
     "@graphql-mesh/cache-cfw-kv": "npm:^0.104.12"
     "@graphql-mesh/cache-localforage": "npm:^0.103.13"
     "@graphql-mesh/cache-redis": "npm:^0.103.13"
@@ -8300,6 +8301,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"atomic-sleep@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "atomic-sleep@npm:1.0.0"
+  checksum: 10c0/e329a6665512736a9bbb073e1761b4ec102f7926cce35037753146a9db9c8104f5044c1662e4a863576ce544fb8be27cd2be6bc8c1a40147d03f31eb1cfb6e8a
+  languageName: node
+  linkType: hard
+
 "auto-bind@npm:4.0.0":
   version: 4.0.0
   resolution: "auto-bind@npm:4.0.0"
@@ -9135,6 +9143,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"colorette@npm:^2.0.7":
+  version: 2.0.20
+  resolution: "colorette@npm:2.0.20"
+  checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
+  languageName: node
+  linkType: hard
+
 "combined-stream@npm:^1.0.8":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
@@ -9422,6 +9437,13 @@ __metadata:
   version: 2.2.3
   resolution: "dataloader@npm:2.2.3"
   checksum: 10c0/9b9a056fbc863ca86da87d59e053e871e263b4966aa4d55e40d61a65e96815fae5530ca220629064ca5f8e3000c0c4ec93292e170c38ff393fb34256b4d7c1aa
+  languageName: node
+  linkType: hard
+
+"dateformat@npm:^4.6.3":
+  version: 4.6.3
+  resolution: "dateformat@npm:4.6.3"
+  checksum: 10c0/e2023b905e8cfe2eb8444fb558562b524807a51cdfe712570f360f873271600b5c94aebffaf11efb285e2c072264a7cf243eadb68f3eba0f8cc85fb86cd25df6
   languageName: node
   linkType: hard
 
@@ -10617,6 +10639,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-copy@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "fast-copy@npm:3.0.2"
+  checksum: 10c0/02e8b9fd03c8c024d2987760ce126456a0e17470850b51e11a1c3254eed6832e4733ded2d93316c82bc0b36aeb991ad1ff48d1ba95effe7add7c3ab8d8eb554a
+  languageName: node
+  linkType: hard
+
 "fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -10663,6 +10692,13 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 10c0/111972b37338bcb88f7d9e2c5907862c280ebf4234433b95bc611e518d192ccb2d38119c4ac86e26b668d75f7f3894f4ff5c4982899afced7ca78633b08287c4
+  languageName: node
+  linkType: hard
+
+"fast-safe-stringify@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "fast-safe-stringify@npm:2.1.1"
+  checksum: 10c0/d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
   languageName: node
   linkType: hard
 
@@ -11673,6 +11709,13 @@ __metadata:
     capital-case: "npm:^1.0.4"
     tslib: "npm:^2.0.3"
   checksum: 10c0/c9f295d9d8e38fa50679281fd70d80726962256e888a76c8e72e526453da7a1832dcb427caa716c1ad5d79841d4537301b90156fa30298fefd3d68f4ea2181bb
+  languageName: node
+  linkType: hard
+
+"help-me@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "help-me@npm:5.0.0"
+  checksum: 10c0/054c0e2e9ae2231c85ab5e04f75109b9d068ffcc54e58fb22079822a5ace8ff3d02c66fd45379c902ad5ab825e5d2e1451fcc2f7eab1eb49e7d488133ba4cacb
   languageName: node
   linkType: hard
 
@@ -13010,6 +13053,13 @@ __metadata:
   version: 4.15.9
   resolution: "jose@npm:4.15.9"
   checksum: 10c0/4ed4ddf4a029db04bd167f2215f65d7245e4dc5f36d7ac3c0126aab38d66309a9e692f52df88975d99429e357e5fd8bab340ff20baab544d17684dd1d940a0f4
+  languageName: node
+  linkType: hard
+
+"joycon@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "joycon@npm:3.1.1"
+  checksum: 10c0/131fb1e98c9065d067fd49b6e685487ac4ad4d254191d7aa2c9e3b90f4e9ca70430c43cad001602bdbdabcf58717d3b5c5b7461c1bd8e39478c8de706b3fe6ae
   languageName: node
   linkType: hard
 
@@ -14491,6 +14541,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"on-exit-leak-free@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "on-exit-leak-free@npm:2.1.2"
+  checksum: 10c0/faea2e1c9d696ecee919026c32be8d6a633a7ac1240b3b87e944a380e8a11dc9c95c4a1f8fb0568de7ab8db3823e790f12bda45296b1d111e341aad3922a0570
+  languageName: node
+  linkType: hard
+
 "on-finished@npm:2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -14920,6 +14977,38 @@ __metadata:
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
   checksum: 10c0/6f9d404b0d47a965437403c9b90eca8bb2536407f03de165940e62e72c8c8b75adda5516c6b9b23675a5877cc0bcac6bdfb0ef0e39414cd2476d5495da40e7cf
+  languageName: node
+  linkType: hard
+
+"pino-abstract-transport@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "pino-abstract-transport@npm:2.0.0"
+  dependencies:
+    split2: "npm:^4.0.0"
+  checksum: 10c0/02c05b8f2ffce0d7c774c8e588f61e8b77de8ccb5f8125afd4a7325c9ea0e6af7fb78168999657712ae843e4462bb70ac550dfd6284f930ee57f17f486f25a9f
+  languageName: node
+  linkType: hard
+
+"pino-pretty@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "pino-pretty@npm:13.0.0"
+  dependencies:
+    colorette: "npm:^2.0.7"
+    dateformat: "npm:^4.6.3"
+    fast-copy: "npm:^3.0.2"
+    fast-safe-stringify: "npm:^2.1.1"
+    help-me: "npm:^5.0.0"
+    joycon: "npm:^3.1.1"
+    minimist: "npm:^1.2.6"
+    on-exit-leak-free: "npm:^2.1.0"
+    pino-abstract-transport: "npm:^2.0.0"
+    pump: "npm:^3.0.0"
+    secure-json-parse: "npm:^2.4.0"
+    sonic-boom: "npm:^4.0.1"
+    strip-json-comments: "npm:^3.1.1"
+  bin:
+    pino-pretty: bin.js
+  checksum: 10c0/015dac25006c1b9820b9e01fccb8a392a019e12b30e6bfc3f3f61ecca8dbabcd000a8f3f64410b620b7f5d08579ba85e6ef137f7fbeaad70d46397a97a5f75ea
   languageName: node
   linkType: hard
 
@@ -15875,6 +15964,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"secure-json-parse@npm:^2.4.0":
+  version: 2.7.0
+  resolution: "secure-json-parse@npm:2.7.0"
+  checksum: 10c0/f57eb6a44a38a3eeaf3548228585d769d788f59007454214fab9ed7f01fbf2e0f1929111da6db28cf0bcc1a2e89db5219a59e83eeaec3a54e413a0197ce879e4
+  languageName: node
+  linkType: hard
+
 "semver@npm:^5.6.0":
   version: 5.7.2
   resolution: "semver@npm:5.7.2"
@@ -16271,6 +16367,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sonic-boom@npm:^4.0.1":
+  version: 4.2.0
+  resolution: "sonic-boom@npm:4.2.0"
+  dependencies:
+    atomic-sleep: "npm:^1.0.0"
+  checksum: 10c0/ae897e6c2cd6d3cb7cdcf608bc182393b19c61c9413a85ce33ffd25891485589f39bece0db1de24381d0a38fc03d08c9862ded0c60f184f1b852f51f97af9684
+  languageName: node
+  linkType: hard
+
 "source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
@@ -16336,6 +16441,13 @@ __metadata:
   version: 1.0.1
   resolution: "split-ca@npm:1.0.1"
   checksum: 10c0/f339170b84c6b4706fcf4c60cc84acb36574c0447566bd713301a8d9b4feff7f4627efc8c334bec24944a3e2f35bc596bd58c673c9980d6bfe3137aae1116ba7
+  languageName: node
+  linkType: hard
+
+"split2@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "split2@npm:4.2.0"
+  checksum: 10c0/b292beb8ce9215f8c642bb68be6249c5a4c7f332fc8ecadae7be5cbdf1ea95addc95f0459ef2e7ad9d45fd1064698a097e4eb211c83e772b49bc0ee423e91534
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,7 +3272,6 @@ __metadata:
     graphql-ws: "npm:^6.0.3"
     graphql-yoga: "npm:^5.10.11"
     html-minifier-terser: "npm:7.2.0"
-    pino-pretty: "npm:^13.0.0"
     pkgroll: "npm:2.8.2"
     tslib: "npm:^2.8.1"
     tsx: "npm:4.19.2"
@@ -8301,13 +8300,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"atomic-sleep@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "atomic-sleep@npm:1.0.0"
-  checksum: 10c0/e329a6665512736a9bbb073e1761b4ec102f7926cce35037753146a9db9c8104f5044c1662e4a863576ce544fb8be27cd2be6bc8c1a40147d03f31eb1cfb6e8a
-  languageName: node
-  linkType: hard
-
 "auto-bind@npm:4.0.0":
   version: 4.0.0
   resolution: "auto-bind@npm:4.0.0"
@@ -9143,13 +9135,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colorette@npm:^2.0.7":
-  version: 2.0.20
-  resolution: "colorette@npm:2.0.20"
-  checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
-  languageName: node
-  linkType: hard
-
 "combined-stream@npm:^1.0.8":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
@@ -9437,13 +9422,6 @@ __metadata:
   version: 2.2.3
   resolution: "dataloader@npm:2.2.3"
   checksum: 10c0/9b9a056fbc863ca86da87d59e053e871e263b4966aa4d55e40d61a65e96815fae5530ca220629064ca5f8e3000c0c4ec93292e170c38ff393fb34256b4d7c1aa
-  languageName: node
-  linkType: hard
-
-"dateformat@npm:^4.6.3":
-  version: 4.6.3
-  resolution: "dateformat@npm:4.6.3"
-  checksum: 10c0/e2023b905e8cfe2eb8444fb558562b524807a51cdfe712570f360f873271600b5c94aebffaf11efb285e2c072264a7cf243eadb68f3eba0f8cc85fb86cd25df6
   languageName: node
   linkType: hard
 
@@ -10639,13 +10617,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-copy@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "fast-copy@npm:3.0.2"
-  checksum: 10c0/02e8b9fd03c8c024d2987760ce126456a0e17470850b51e11a1c3254eed6832e4733ded2d93316c82bc0b36aeb991ad1ff48d1ba95effe7add7c3ab8d8eb554a
-  languageName: node
-  linkType: hard
-
 "fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -10692,13 +10663,6 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 10c0/111972b37338bcb88f7d9e2c5907862c280ebf4234433b95bc611e518d192ccb2d38119c4ac86e26b668d75f7f3894f4ff5c4982899afced7ca78633b08287c4
-  languageName: node
-  linkType: hard
-
-"fast-safe-stringify@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "fast-safe-stringify@npm:2.1.1"
-  checksum: 10c0/d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
   languageName: node
   linkType: hard
 
@@ -11709,13 +11673,6 @@ __metadata:
     capital-case: "npm:^1.0.4"
     tslib: "npm:^2.0.3"
   checksum: 10c0/c9f295d9d8e38fa50679281fd70d80726962256e888a76c8e72e526453da7a1832dcb427caa716c1ad5d79841d4537301b90156fa30298fefd3d68f4ea2181bb
-  languageName: node
-  linkType: hard
-
-"help-me@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "help-me@npm:5.0.0"
-  checksum: 10c0/054c0e2e9ae2231c85ab5e04f75109b9d068ffcc54e58fb22079822a5ace8ff3d02c66fd45379c902ad5ab825e5d2e1451fcc2f7eab1eb49e7d488133ba4cacb
   languageName: node
   linkType: hard
 
@@ -13053,13 +13010,6 @@ __metadata:
   version: 4.15.9
   resolution: "jose@npm:4.15.9"
   checksum: 10c0/4ed4ddf4a029db04bd167f2215f65d7245e4dc5f36d7ac3c0126aab38d66309a9e692f52df88975d99429e357e5fd8bab340ff20baab544d17684dd1d940a0f4
-  languageName: node
-  linkType: hard
-
-"joycon@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "joycon@npm:3.1.1"
-  checksum: 10c0/131fb1e98c9065d067fd49b6e685487ac4ad4d254191d7aa2c9e3b90f4e9ca70430c43cad001602bdbdabcf58717d3b5c5b7461c1bd8e39478c8de706b3fe6ae
   languageName: node
   linkType: hard
 
@@ -14541,13 +14491,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-exit-leak-free@npm:^2.1.0":
-  version: 2.1.2
-  resolution: "on-exit-leak-free@npm:2.1.2"
-  checksum: 10c0/faea2e1c9d696ecee919026c32be8d6a633a7ac1240b3b87e944a380e8a11dc9c95c4a1f8fb0568de7ab8db3823e790f12bda45296b1d111e341aad3922a0570
-  languageName: node
-  linkType: hard
-
 "on-finished@npm:2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -14977,38 +14920,6 @@ __metadata:
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
   checksum: 10c0/6f9d404b0d47a965437403c9b90eca8bb2536407f03de165940e62e72c8c8b75adda5516c6b9b23675a5877cc0bcac6bdfb0ef0e39414cd2476d5495da40e7cf
-  languageName: node
-  linkType: hard
-
-"pino-abstract-transport@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "pino-abstract-transport@npm:2.0.0"
-  dependencies:
-    split2: "npm:^4.0.0"
-  checksum: 10c0/02c05b8f2ffce0d7c774c8e588f61e8b77de8ccb5f8125afd4a7325c9ea0e6af7fb78168999657712ae843e4462bb70ac550dfd6284f930ee57f17f486f25a9f
-  languageName: node
-  linkType: hard
-
-"pino-pretty@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "pino-pretty@npm:13.0.0"
-  dependencies:
-    colorette: "npm:^2.0.7"
-    dateformat: "npm:^4.6.3"
-    fast-copy: "npm:^3.0.2"
-    fast-safe-stringify: "npm:^2.1.1"
-    help-me: "npm:^5.0.0"
-    joycon: "npm:^3.1.1"
-    minimist: "npm:^1.2.6"
-    on-exit-leak-free: "npm:^2.1.0"
-    pino-abstract-transport: "npm:^2.0.0"
-    pump: "npm:^3.0.0"
-    secure-json-parse: "npm:^2.4.0"
-    sonic-boom: "npm:^4.0.1"
-    strip-json-comments: "npm:^3.1.1"
-  bin:
-    pino-pretty: bin.js
-  checksum: 10c0/015dac25006c1b9820b9e01fccb8a392a019e12b30e6bfc3f3f61ecca8dbabcd000a8f3f64410b620b7f5d08579ba85e6ef137f7fbeaad70d46397a97a5f75ea
   languageName: node
   linkType: hard
 
@@ -15964,13 +15875,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"secure-json-parse@npm:^2.4.0":
-  version: 2.7.0
-  resolution: "secure-json-parse@npm:2.7.0"
-  checksum: 10c0/f57eb6a44a38a3eeaf3548228585d769d788f59007454214fab9ed7f01fbf2e0f1929111da6db28cf0bcc1a2e89db5219a59e83eeaec3a54e413a0197ce879e4
-  languageName: node
-  linkType: hard
-
 "semver@npm:^5.6.0":
   version: 5.7.2
   resolution: "semver@npm:5.7.2"
@@ -16367,15 +16271,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sonic-boom@npm:^4.0.1":
-  version: 4.2.0
-  resolution: "sonic-boom@npm:4.2.0"
-  dependencies:
-    atomic-sleep: "npm:^1.0.0"
-  checksum: 10c0/ae897e6c2cd6d3cb7cdcf608bc182393b19c61c9413a85ce33ffd25891485589f39bece0db1de24381d0a38fc03d08c9862ded0c60f184f1b852f51f97af9684
-  languageName: node
-  linkType: hard
-
 "source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
@@ -16441,13 +16336,6 @@ __metadata:
   version: 1.0.1
   resolution: "split-ca@npm:1.0.1"
   checksum: 10c0/f339170b84c6b4706fcf4c60cc84acb36574c0447566bd713301a8d9b4feff7f4627efc8c334bec24944a3e2f35bc596bd58c673c9980d6bfe3137aae1116ba7
-  languageName: node
-  linkType: hard
-
-"split2@npm:^4.0.0":
-  version: 4.2.0
-  resolution: "split2@npm:4.2.0"
-  checksum: 10c0/b292beb8ce9215f8c642bb68be6249c5a4c7f332fc8ecadae7be5cbdf1ea95addc95f0459ef2e7ad9d45fd1064698a097e4eb211c83e772b49bc0ee423e91534
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3372,9 +3372,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphql-hive/logger-json@workspace:packages/logger-json"
   dependencies:
-    "@graphql-mesh/cross-helpers": "npm:^0.4.9"
-    "@graphql-mesh/types": "npm:^0.103.6"
-    "@graphql-mesh/utils": "npm:^0.103.6"
+    "@graphql-mesh/cross-helpers": "npm:^0.4.10"
+    "@graphql-mesh/types": "npm:^0.103.16"
+    "@graphql-mesh/utils": "npm:^0.103.16"
+    cross-inspect: "npm:^1.0.1"
     graphql: "npm:^16.9.0"
     pkgroll: "npm:2.8.2"
     tslib: "npm:^2.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3291,6 +3291,7 @@ __metadata:
     "@envelop/core": "npm:^5.0.2"
     "@graphql-hive/gateway-runtime": "workspace:^"
     "@graphql-hive/importer": "workspace:^"
+    "@graphql-hive/logger-json": "workspace:^"
     "@graphql-mesh/cache-cfw-kv": "npm:^0.104.12"
     "@graphql-mesh/cache-localforage": "npm:^0.103.13"
     "@graphql-mesh/cache-redis": "npm:^0.103.13"
@@ -3364,6 +3365,21 @@ __metadata:
     glob: "npm:^11.0.0"
     pkgroll: "npm:2.8.2"
     sucrase: "npm:^3.35.0"
+  languageName: unknown
+  linkType: soft
+
+"@graphql-hive/logger-json@workspace:^, @graphql-hive/logger-json@workspace:packages/logger-json":
+  version: 0.0.0-use.local
+  resolution: "@graphql-hive/logger-json@workspace:packages/logger-json"
+  dependencies:
+    "@graphql-mesh/cross-helpers": "npm:^0.4.9"
+    "@graphql-mesh/types": "npm:^0.103.6"
+    "@graphql-mesh/utils": "npm:^0.103.6"
+    graphql: "npm:^16.9.0"
+    pkgroll: "npm:2.8.2"
+    tslib: "npm:^2.8.1"
+  peerDependencies:
+    graphql: ^15.9.0 || ^16.9.0
   languageName: unknown
   linkType: soft
 
@@ -3811,19 +3827,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/store@npm:^0.103.15":
-  version: 0.103.15
-  resolution: "@graphql-mesh/store@npm:0.103.15"
+"@graphql-mesh/store@npm:0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a":
+  version: 0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a
+  resolution: "@graphql-mesh/store@npm:0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a"
   dependencies:
     "@graphql-inspector/core": "npm:6.2.1"
     "@graphql-mesh/cross-helpers": "npm:^0.4.10"
-    "@graphql-mesh/types": "npm:^0.103.15"
-    "@graphql-mesh/utils": "npm:^0.103.15"
+    "@graphql-mesh/types": "npm:0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a"
+    "@graphql-mesh/utils": "npm:0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a"
     "@graphql-tools/utils": "npm:^10.8.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: "*"
-  checksum: 10c0/d13e3b59f8711224215f396533d1584422cd6bbdaf8991bc4a3bda53f67a188b3c69bf81bdd5dce3bf7e6ddfd941da21175c3473bd439425087ec44cf357330c
+  checksum: 10c0/18289554b6ad038c1a7eadf3613c8e45195ae7e676a6d38366fdeb5ccd0af1ea2a1709f07027242583ff39d724a254cccf5766f0089e2256b478f0fed49f7f98
   languageName: node
   linkType: hard
 
@@ -3965,11 +3981,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@graphql-mesh/types@npm:^0.103.15, @graphql-mesh/types@npm:^0.103.6":
-  version: 0.103.15
-  resolution: "@graphql-mesh/types@npm:0.103.15"
+"@graphql-mesh/types@npm:0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a":
+  version: 0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a
+  resolution: "@graphql-mesh/types@npm:0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a"
   dependencies:
-    "@graphql-mesh/store": "npm:^0.103.15"
+    "@graphql-mesh/store": "npm:0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a"
     "@graphql-tools/batch-delegate": "npm:^9.0.10"
     "@graphql-tools/delegate": "npm:^10.0.28"
     "@graphql-tools/utils": "npm:^10.8.0"
@@ -3977,17 +3993,17 @@ __metadata:
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: "*"
-  checksum: 10c0/61a010e01b2fe79a27ac7da0759bea96bcd95180c12f3bdf9c6d2bdd0798fc24cfa0a1aa5eb9bad0978c1e88272895e58b065fcdb8283e3373cc5d93b90a0203
+  checksum: 10c0/bf9e5ebbe704a7b2881d5efae13db9acfaf7f2c5560196b61ae2661b41b8e0fa14342b4b0c27b99f73affe9be93652d32364ee2183a58ac0c24d0844e73b3219
   languageName: node
   linkType: hard
 
-"@graphql-mesh/utils@npm:^0.103.15, @graphql-mesh/utils@npm:^0.103.6":
-  version: 0.103.15
-  resolution: "@graphql-mesh/utils@npm:0.103.15"
+"@graphql-mesh/utils@npm:0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a":
+  version: 0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a
+  resolution: "@graphql-mesh/utils@npm:0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a"
   dependencies:
     "@graphql-mesh/cross-helpers": "npm:^0.4.10"
     "@graphql-mesh/string-interpolation": "npm:^0.5.8"
-    "@graphql-mesh/types": "npm:^0.103.15"
+    "@graphql-mesh/types": "npm:0.103.16-alpha-20250212125252-6167fff12fe4017202b35363ff2769aafe28f98a"
     "@graphql-tools/batch-delegate": "npm:^9.0.16"
     "@graphql-tools/delegate": "npm:^10.0.28"
     "@graphql-tools/utils": "npm:^10.8.0"
@@ -4002,7 +4018,7 @@ __metadata:
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: "*"
-  checksum: 10c0/aecd81e23f15a5d85221146810f8347787c338639b394b8fecde113ebde3baedef545f75090ab9ac8bb11fe41047c68679e7539f95da5a236fabea2a96c0dc1c
+  checksum: 10c0/16fde4724163b263927bf886eae772fa7f17a2ee3636398d5d18ebaf23959309a1e99745d4d8fd999aa00cb37a1b8d85b076b88c7e6578aec77f35c5671bed12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Blocked by https://github.com/ardatan/graphql-mesh/pull/8375

By default
- It checks NODE_ENV=production and uses pretty if it is not production, otherwise logs in JSON format

According to `LOG_FORMAT=json` or `LOG_FORMAT=pretty`, it chooses the output format.

New JSON based logger compatible with `pino-pretty`;

With pino-pretty;
![image](https://github.com/user-attachments/assets/dccd3799-ae6a-428e-87fc-97d012dade94)

Without pino-pretty;
![image](https://github.com/user-attachments/assets/f3df62b1-3f6d-4baa-9777-c9bd0fa15746)
