### PR TITLE
Fix Vulnerability Alert coming from a dev dependency

### DIFF
--- a/e2e/cloudflare-workers/package.json
+++ b/e2e/cloudflare-workers/package.json
@@ -8,6 +8,6 @@
     "@cloudflare/workers-types": "^4.20241112.0",
     "@graphql-hive/gateway-runtime": "workspace:*",
     "graphql": "^16.9.0",
-    "wrangler": "^3.88.0"
+    "wrangler": "^3.108.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@opentelemetry/otlp-exporter-base": "patch:@opentelemetry/otlp-exporter-base@npm%3A0.56.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.56.0-ba3dc5f5c5.patch",
     "@opentelemetry/resources": "patch:@opentelemetry/resources@npm%3A1.29.0#~/.yarn/patches/@opentelemetry-resources-npm-1.29.0-112f89f0c5.patch",
     "@vitest/snapshot@npm:3.0.5": "patch:@vitest/snapshot@npm%3A3.0.5#~/.yarn/patches/@vitest-snapshot-npm-3.0.0-d5b381862b.patch",
+    "cookie": "^0.7.0",
     "cross-spawn": "7.0.6",
     "esbuild": "0.25.0",
     "graphql": "16.10.0",
@@ -75,7 +76,6 @@
     "jest-leak-detector": "patch:jest-leak-detector@npm%3A29.7.0#~/.yarn/patches/jest-leak-detector+29.7.0.patch",
     "pkgroll": "patch:pkgroll@npm%3A2.5.1#~/.yarn/patches/pkgroll-npm-2.5.1-9b062c22ca.patch",
     "tsx": "patch:tsx@npm%3A4.19.2#~/.yarn/patches/tsx-npm-4.19.2-a8f2312a2f.patch",
-    "vite": "^6.0.0",
-    "cookie": "^0.7.0"
+    "vite": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "jest-leak-detector": "patch:jest-leak-detector@npm%3A29.7.0#~/.yarn/patches/jest-leak-detector+29.7.0.patch",
     "pkgroll": "patch:pkgroll@npm%3A2.5.1#~/.yarn/patches/pkgroll-npm-2.5.1-9b062c22ca.patch",
     "tsx": "patch:tsx@npm%3A4.19.2#~/.yarn/patches/tsx-npm-4.19.2-a8f2312a2f.patch",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "cookie": "^0.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2372,7 +2372,7 @@ __metadata:
     "@cloudflare/workers-types": "npm:^4.20241112.0"
     "@graphql-hive/gateway-runtime": "workspace:*"
     graphql: "npm:^16.9.0"
-    wrangler: "npm:^3.88.0"
+    wrangler: "npm:^3.108.1"
   languageName: unknown
   linkType: soft
 
@@ -9347,17 +9347,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.7.1":
-  version: 0.7.1
-  resolution: "cookie@npm:0.7.1"
-  checksum: 10c0/5de60c67a410e7c8dc8a46a4b72eb0fe925871d057c9a5d2c0e8145c4270a4f81076de83410c4d397179744b478e33cd80ccbcc457abf40a9409ad27dcd21dde
-  languageName: node
-  linkType: hard
-
-"cookie@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "cookie@npm:0.5.0"
-  checksum: 10c0/c01ca3ef8d7b8187bae434434582288681273b5a9ed27521d4d7f9f7928fe0c920df0decd9f9d3bbd2d14ac432b8c8cf42b98b3bdd5bfe0e6edddeebebe8b61d
+"cookie@npm:^0.7.0":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
   languageName: node
   linkType: hard
 
@@ -18151,7 +18144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrangler@npm:^3.88.0":
+"wrangler@npm:^3.108.1":
   version: 3.108.1
   resolution: "wrangler@npm:3.108.1"
   dependencies:


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/gateway/security/dependabot/25

cookie@^0.5.0 is used by `wrangler` and we don't have a direct dependency affected by runtime.
So this PR forces to install the fixes this alert

Completes GW-185