### PR TITLE
feat(runtime/GraphOS): expose `agentVersion`, `clientName` and `clientVersion` options

### DIFF
--- a/.changeset/quiet-rules-hunt.md
+++ b/.changeset/quiet-rules-hunt.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Expose `agentVersion`, `clientName` and `clientVersion` options for GraphOS reporting
+
+And set `hive-gateway@VERSION` by default for `agentVersion`

--- a/packages/runtime/src/getReportingPlugin.ts
+++ b/packages/runtime/src/getReportingPlugin.ts
@@ -61,10 +61,14 @@ export function getReportingPlugin<TContext extends Record<string, any>>(
         config.reporting.graphRef ||= config.supergraph.graphRef;
       }
     }
+
     return {
       name: 'GraphOS',
       // @ts-expect-error - TODO: Fix types
-      plugin: useApolloUsageReport(config.reporting),
+      plugin: useApolloUsageReport({
+        agentVersion: `hive-gateway@${globalThis.__VERSION__}`,
+        ...config.reporting,
+      }),
     };
   }
   return {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -19,6 +19,7 @@ import type { LogLevel } from '@graphql-mesh/utils';
 import type { HTTPExecutorOptions } from '@graphql-tools/executor-http';
 import type {
   IResolvers,
+  MaybePromise,
   TypeSource,
   ValidationRule,
 } from '@graphql-tools/utils';
@@ -234,6 +235,24 @@ export interface GatewayGraphOSManagedFederationOptions
    * Alternative: 'https://aws.uplink.api.apollographql.com/' (Apollo's managed federation up link on AWS)
    */
   upLink?: string;
+  /**
+   * Agent Version to report to the usage reporting API
+   *
+   * @default "hive-gateway@VERSION_OF_GW"
+   */
+  agentVersion?: string;
+  /**
+   * Client name to report to the usage reporting API
+   *
+   * @default incoming `apollo-graphql-client-name` HTTP header
+   */
+  clientName?(req: Request): MaybePromise<string>;
+  /**
+   * Client version to report to the usage reporting API
+   *
+   * @default incoming `apollo-graphql-client-version` HTTP header
+   */
+  clientVersion?(req: Request): MaybePromise<string>;
 }
 
 export interface GatewayGraphOSReportingOptions extends GatewayGraphOSOptions {


### PR DESCRIPTION
Expose `agentVersion`, `clientName` and `clientVersion` options for GraphOS reporting

And set `hive-gateway@VERSION` by default for `agentVersion`

Fixes https://github.com/graphql-hive/gateway/issues/655
Completes GW-186