### PR TITLE
fix(delegate): handle when a field marked with `@skip` and `@include` throws

### DIFF
--- a/.changeset/fair-mugs-tap.md
+++ b/.changeset/fair-mugs-tap.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+When a field with `@skip` and `@include` directives in a selection set throws, show the correct error

--- a/.changeset/fair-mugs-tap.md
+++ b/.changeset/fair-mugs-tap.md
@@ -3,3 +3,21 @@
 ---
 
 When a field with `@skip` and `@include` directives in a selection set throws, show the correct error
+
+```
+// Query
+query myQuery($toInclude: Boolean! = false) {
+    user(id: 1) {
+        id
+        name
+        username
+        totalReviews @include(if: $toInclude) 
+        # If this throws, show the actual error instead of `Argument \"if\" of required type \"Boolean!\" was provided the variable` error
+    }
+}
+
+// Variables
+{
+    "toInclude": true
+}
+```

--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -139,8 +139,8 @@ export function handleResolverResult(
     const type = schema.getType(object.__typename) as GraphQLObjectType;
     const { fields } = collectFields(
       schema,
-      EMPTY_OBJECT,
-      EMPTY_OBJECT,
+      info.fragments,
+      info.variableValues,
       type,
       selectionSet,
     );


### PR DESCRIPTION
Fixes https://github.com/ardatan/graphql-tools/issues/6939

When a field with `@skip` and `@include` directives in a selection set throws, show the correct error

```
// Query
query myQuery($toInclude: Boolean! = false) {
    user(id: 1) {
        id
        name
        username
        totalReviews @include(if: $toInclude) 
        # If this throws, show the actual error instead of `Argument \"if\" of required type \"Boolean!\" was provided the variable` error
    }
}

// Variables
{
    "toInclude": true
}
```