### PR TITLE
enhance(runtime/debug/log): log debug info after all other plugins are invoked

### DIFF
--- a/.changeset/tame-bulldogs-march.md
+++ b/.changeset/tame-bulldogs-march.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Log Fetch calls, subgraph execution and delegation plan generation after all other plugins are invoked

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -926,15 +926,6 @@ export function createGatewayRuntime<
     useRequestId(),
   ];
 
-  logger.debug(() => {
-    basePlugins.push(
-      useSubgraphExecuteDebug(configContext),
-      useFetchDebug(configContext),
-      useDelegationPlanDebug(configContext),
-    );
-    return 'Debug mode enabled';
-  });
-
   const extraPlugins = [];
 
   if (config.webhooks) {
@@ -1015,6 +1006,15 @@ export function createGatewayRuntime<
   if (config.upstreamRetry) {
     extraPlugins.push(useUpstreamRetry(config.upstreamRetry));
   }
+
+  logger.debug(() => {
+    extraPlugins.push(
+      useSubgraphExecuteDebug(configContext),
+      useFetchDebug(configContext),
+      useDelegationPlanDebug(configContext),
+    );
+    return 'Debug mode enabled';
+  });
 
   const yoga = createYoga<any, GatewayContext & TContext>({
     // @ts-expect-error Types???


### PR DESCRIPTION
Log Fetch calls, subgraph execution and delegation plan generation after all other plugins are invoked

Previously the modification to HTTP headers with header propagation plugin was never seen in debug logs because debug plugins were invoked before all other plugins.