### PR TITLE
feat(runtime): new cache related hooks

### DIFF
--- a/.changeset/tasty-actors-marry.md
+++ b/.changeset/tasty-actors-marry.md
@@ -1,0 +1,18 @@
+---
+'@graphql-hive/gateway-runtime': minor
+---
+
+New Cache related hooks;
+
+`onCacheGet`: invoked when a cache get operation is performed.
+`onCacheMiss`: invoked when the performed get operation does not find a cache entry.
+`onCacheHit`: invoked when the performed get operation finds a cache entry.
+`onCacheGetError`: invoked when an error occurs during a cache get operation.
+
+`onCacheSet`: invoked when a cache set operation is performed.
+`onCacheSetDone`: invoked when the performed set operation is completed.
+`onCacheSetError`: invoked when an error occurs during a cache set operation.
+
+`onCacheDelete`: invoked when a cache delete operation is performed.
+`onCacheDeleteDone`: invoked when the performed delete operation is completed.
+`onCacheDeleteError`: invoked when an error occurs during a cache delete operation.

--- a/packages/runtime/src/plugins/useCacheDebug.ts
+++ b/packages/runtime/src/plugins/useCacheDebug.ts
@@ -12,36 +12,37 @@ export function useCacheDebug<TContext extends Record<string, any>>(opts: {
           cacheGetErrorLogger.error({ key, error });
         },
         onCacheHit({ value }) {
-            const cacheHitLogger = opts.logger.child('cache-hit');
-            cacheHitLogger.debug({ key, value });
+          const cacheHitLogger = opts.logger.child('cache-hit');
+          cacheHitLogger.debug({ key, value });
         },
         onCacheMiss() {
-            const cacheMissLogger = opts.logger.child('cache-miss');
-            cacheMissLogger.debug({ key });
+          const cacheMissLogger = opts.logger.child('cache-miss');
+          cacheMissLogger.debug({ key });
         },
       };
     },
     onCacheSet({ key, value, ttl }) {
       return {
         onCacheSetError({ error }) {
-            const cacheSetErrorLogger = opts.logger.child('cache-set-error');
-            cacheSetErrorLogger.error({ key, value, ttl, error });
+          const cacheSetErrorLogger = opts.logger.child('cache-set-error');
+          cacheSetErrorLogger.error({ key, value, ttl, error });
         },
         onCacheSetDone() {
-            const cacheSetDoneLogger = opts.logger.child('cache-set-done');
-            cacheSetDoneLogger.debug({ key, value, ttl });
+          const cacheSetDoneLogger = opts.logger.child('cache-set-done');
+          cacheSetDoneLogger.debug({ key, value, ttl });
         },
       };
     },
     onCacheDelete({ key }) {
       return {
         onCacheDeleteError({ error }) {
-            const cacheDeleteErrorLogger = opts.logger.child('cache-delete-error');
-            cacheDeleteErrorLogger.error({ key, error });
+          const cacheDeleteErrorLogger =
+            opts.logger.child('cache-delete-error');
+          cacheDeleteErrorLogger.error({ key, error });
         },
         onCacheDeleteDone() {
-            const cacheDeleteDoneLogger = opts.logger.child('cache-delete-done');
-            cacheDeleteDoneLogger.debug({ key });
+          const cacheDeleteDoneLogger = opts.logger.child('cache-delete-done');
+          cacheDeleteDoneLogger.debug({ key });
         },
       };
     },

--- a/packages/runtime/src/plugins/useCacheDebug.ts
+++ b/packages/runtime/src/plugins/useCacheDebug.ts
@@ -1,0 +1,62 @@
+import { Logger } from '@graphql-mesh/types';
+import { GatewayPlugin } from '../types';
+
+export function useCacheDebug<TContext extends Record<string, any>>(opts: {
+  logger: Logger;
+}): GatewayPlugin<TContext> {
+  return {
+    onCacheGet({ key }) {
+      const cacheGetLogger = opts.logger.child('cache-get');
+      const keyLogger = cacheGetLogger.child({
+        key,
+      });
+      return {
+        onCacheGetError({ error }) {
+          keyLogger.error({ error });
+        },
+        onCacheHit({ value }) {
+          keyLogger.debug({ cacheHit: value });
+        },
+        onCacheMiss() {
+          keyLogger.debug('cache-miss');
+        },
+      };
+    },
+    onCacheSet({ key, value, ttl }) {
+      const cacheSetLogger = opts.logger.child('cache-set');
+      const keyLogger = cacheSetLogger.child({
+        key,
+      });
+      return {
+        onCacheSetError({ error }) {
+          keyLogger.error({
+            error,
+            value,
+            ttl,
+          });
+        },
+        onCacheSetDone() {
+          keyLogger.debug({
+            value,
+            ttl,
+            success: true,
+          });
+        },
+      };
+    },
+    onCacheDelete({ key }) {
+      const cacheDeleteLogger = opts.logger.child('cache-delete');
+      const keyLogger = cacheDeleteLogger.child({
+        key,
+      });
+      return {
+        onCacheDeleteError({ error }) {
+          keyLogger.error({ error });
+        },
+        onCacheDeleteDone() {
+          keyLogger.debug({ success: true });
+        },
+      };
+    },
+  };
+}

--- a/packages/runtime/src/plugins/useCacheDebug.ts
+++ b/packages/runtime/src/plugins/useCacheDebug.ts
@@ -6,55 +6,42 @@ export function useCacheDebug<TContext extends Record<string, any>>(opts: {
 }): GatewayPlugin<TContext> {
   return {
     onCacheGet({ key }) {
-      const cacheGetLogger = opts.logger.child('cache-get');
-      const keyLogger = cacheGetLogger.child({
-        key,
-      });
       return {
         onCacheGetError({ error }) {
-          keyLogger.error({ error });
+          const cacheGetErrorLogger = opts.logger.child('cache-get-error');
+          cacheGetErrorLogger.error({ key, error });
         },
         onCacheHit({ value }) {
-          keyLogger.debug({ cacheHit: value });
+            const cacheHitLogger = opts.logger.child('cache-hit');
+            cacheHitLogger.debug({ key, value });
         },
         onCacheMiss() {
-          keyLogger.debug('cache-miss');
+            const cacheMissLogger = opts.logger.child('cache-miss');
+            cacheMissLogger.debug({ key });
         },
       };
     },
     onCacheSet({ key, value, ttl }) {
-      const cacheSetLogger = opts.logger.child('cache-set');
-      const keyLogger = cacheSetLogger.child({
-        key,
-      });
       return {
         onCacheSetError({ error }) {
-          keyLogger.error({
-            error,
-            value,
-            ttl,
-          });
+            const cacheSetErrorLogger = opts.logger.child('cache-set-error');
+            cacheSetErrorLogger.error({ key, value, ttl, error });
         },
         onCacheSetDone() {
-          keyLogger.debug({
-            value,
-            ttl,
-            success: true,
-          });
+            const cacheSetDoneLogger = opts.logger.child('cache-set-done');
+            cacheSetDoneLogger.debug({ key, value, ttl });
         },
       };
     },
     onCacheDelete({ key }) {
-      const cacheDeleteLogger = opts.logger.child('cache-delete');
-      const keyLogger = cacheDeleteLogger.child({
-        key,
-      });
       return {
         onCacheDeleteError({ error }) {
-          keyLogger.error({ error });
+            const cacheDeleteErrorLogger = opts.logger.child('cache-delete-error');
+            cacheDeleteErrorLogger.error({ key, error });
         },
         onCacheDeleteDone() {
-          keyLogger.debug({ success: true });
+            const cacheDeleteDoneLogger = opts.logger.child('cache-delete-done');
+            cacheDeleteDoneLogger.debug({ key });
         },
       };
     },

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -92,7 +92,68 @@ export type GatewayPlugin<
 > = YogaPlugin<Partial<TPluginContext> & GatewayContext & TContext> &
   UnifiedGraphPlugin<Partial<TPluginContext> & GatewayContext & TContext> & {
     onFetch?: OnFetchHook<Partial<TPluginContext> & GatewayContext & TContext>;
+    onCacheGet?: OnCacheGetHook;
+    onCacheSet?: OnCacheSetHook;
+    onCacheDelete?: OnCacheDeleteHook;
   } & Partial<Disposable | AsyncDisposable>;
+
+export type OnCacheGetHook = (
+  payload: OnCacheGetHookEventPayload,
+) => MaybePromise<OnCacheGetHookResult | void>;
+
+export interface OnCacheGetHookEventPayload {
+  cache: KeyValueCache;
+  key: string;
+  ttl?: number;
+}
+
+export interface OnCacheGetHookResult {
+  onCacheHit?: OnCacheHitHook;
+  onCacheMiss?: OnCacheMissHook;
+  onCacheGetError?: OnCacheErrorHook;
+}
+
+export type OnCacheErrorHook = (payload: OnCacheErrorHookPayload) => void;
+
+export interface OnCacheErrorHookPayload {
+  error: Error;
+}
+
+export type OnCacheHitHook = (payload: OnCacheHitHookEventPayload) => void;
+export interface OnCacheHitHookEventPayload {
+  value: any;
+}
+export type OnCacheMissHook = () => void;
+
+export type OnCacheSetHook = (
+  payload: OnCacheSetHookEventPayload,
+) => MaybePromise<OnCacheSetHookResult | void>;
+
+export interface OnCacheSetHookResult {
+  onCacheSetDone?: () => void;
+  onCacheSetError?: OnCacheErrorHook;
+}
+
+export interface OnCacheSetHookEventPayload {
+  cache: KeyValueCache;
+  key: string;
+  value: any;
+  ttl?: number;
+}
+
+export type OnCacheDeleteHook = (
+  payload: OnCacheDeleteHookEventPayload,
+) => MaybePromise<OnCacheDeleteHookResult | void>;
+
+export interface OnCacheDeleteHookResult {
+  onCacheDeleteDone?: () => void;
+  onCacheDeleteError?: OnCacheErrorHook;
+}
+
+export interface OnCacheDeleteHookEventPayload {
+  cache: KeyValueCache;
+  key: string;
+}
 
 export interface GatewayConfigSupergraph<
   TContext extends Record<string, any> = Record<string, any>,


### PR DESCRIPTION
Closes https://github.com/ardatan/graphql-mesh/pull/8355

New Cache related hooks;

`onCacheGet`: invoked when a cache get operation is performed.
`onCacheMiss`: invoked when the performed get operation does not find a cache entry.
`onCacheHit`: invoked when the performed get operation finds a cache entry.
`onCacheGetError`: invoked when an error occurs during a cache get operation.

`onCacheSet`: invoked when a cache set operation is performed.
`onCacheSetDone`: invoked when the performed set operation is completed.
`onCacheSetError`: invoked when an error occurs during a cache set operation.

`onCacheDelete`: invoked when a cache delete operation is performed.
`onCacheDeleteDone`: invoked when the performed delete operation is completed.
`onCacheDeleteError`: invoked when an error occurs during a cache delete operation.