### PR TITLE
Increase timeout for mem tests

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,6 +18,8 @@ jobs:
       matrix:
         e2e_runner: [node, bun]
         products_size:
+          # The results don't change that much based on the list size,
+          # But later we might want them back
           # - 10
           # - 100
           - 1000

--- a/.github/workflows/memtest.yml
+++ b/.github/workflows/memtest.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           E2E_GATEWAY_RUNNER: ${{matrix.e2e_runner}}
         with:
-          timeout_minutes: 10
+          timeout_minutes: 15
           max_attempts: 5
           command: yarn test:mem ${{matrix.test_name}}
           # TODO: publish heap allocation sampling profile to artifact


### PR DESCRIPTION
From @enisdenjo here;
> This is right on the edge. The tests run 3x 3min loadtests + 3x 30s calmdown + 10s idling + all of the setup and whatnot.
> 
> Lets do 15mins instead.

https://github.com/graphql-hive/gateway/pull/846#discussion_r1995645765