### PR TITLE
fix(otel): handle outgoing HTTP requests that do not have GraphQL context

### DIFF
--- a/.changeset/thick-cars-work.md
+++ b/.changeset/thick-cars-work.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/plugin-opentelemetry': patch
+---
+
+Handle outgoing HTTP requests that do not have GraphQL Context

--- a/e2e/graphos-polling/gateway.config.ts
+++ b/e2e/graphos-polling/gateway.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@graphql-hive/gateway';
+import { createOtlpHttpExporter, defineConfig } from '@graphql-hive/gateway';
 import { boolEnv, Opts } from '@internal/testing';
 
 const uplinkHost = String(process.env['E2E_GATEWAY_RUNNER']).includes('docker')
@@ -23,5 +23,17 @@ export const gatewayConfig = defineConfig({
     apiKey: 'my-api-key',
     graphRef: 'my-graph-ref@my-variant',
     endpoint: `${upLink}/usage`,
+  },
+  openTelemetry: {
+    exporters: [
+      createOtlpHttpExporter(
+        {
+          url: process.env['OTLP_EXPORTER_URL'],
+        },
+        {
+          scheduledDelayMillis: 1,
+        },
+      ),
+    ],
   },
 });

--- a/e2e/graphos-polling/graphos-polling.e2e.ts
+++ b/e2e/graphos-polling/graphos-polling.e2e.ts
@@ -15,7 +15,7 @@ beforeAll(async () => {
     name: `jaeger-http`,
     image:
       platform().toLowerCase() === 'win32'
-        ? 'johnnyhuy/jaeger-windows:1809'
+        ? 'johnnyhuy/jaeger-windows:latest'
         : 'jaegertracing/all-in-one:1.56',
     env: {
       COLLECTOR_OTLP_ENABLED: 'true',

--- a/e2e/graphos-polling/graphos-polling.e2e.ts
+++ b/e2e/graphos-polling/graphos-polling.e2e.ts
@@ -15,7 +15,7 @@ beforeAll(async () => {
     name: `jaeger-http`,
     image:
       platform().toLowerCase() === 'win32'
-        ? 'johnnyhuy/jaeger-windows:latest'
+        ? 'johnnyhuy/jaeger-windows:1809'
         : 'jaegertracing/all-in-one:1.56',
     env: {
       COLLECTOR_OTLP_ENABLED: 'true',

--- a/packages/plugins/opentelemetry/src/plugin.ts
+++ b/packages/plugins/opentelemetry/src/plugin.ts
@@ -263,7 +263,10 @@ export function useOpenTelemetry(
 
             const otelContextToSet = trace.setSpan(otelContext, httpSpan);
             requestContextMapping.set(request, otelContextToSet);
-            contextMapping.set(onRequestPayload.serverContext, otelContextToSet);
+            contextMapping.set(
+              onRequestPayload.serverContext,
+              otelContextToSet,
+            );
           }
         },
       );

--- a/packages/plugins/opentelemetry/src/plugin.ts
+++ b/packages/plugins/opentelemetry/src/plugin.ts
@@ -263,7 +263,7 @@ export function useOpenTelemetry(
 
             const otelContextToSet = trace.setSpan(otelContext, httpSpan);
             requestContextMapping.set(request, otelContextToSet);
-            contextMapping.set(onRequestPayload.serverContext, otelContext);
+            contextMapping.set(onRequestPayload.serverContext, otelContextToSet);
           }
         },
       );

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -455,6 +455,8 @@ interface GatewayConfigBase<TContext extends Record<string, any>> {
   batching?: BatchingOptions;
   /**
    * WHATWG compatible Fetch implementation.
+   *
+   * @warning Do not use this option unless you know what you are doing.
    */
   fetchAPI?: Partial<
     Omit<FetchAPI, 'fetch'> & {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -456,6 +456,9 @@ interface GatewayConfigBase<TContext extends Record<string, any>> {
   /**
    * WHATWG compatible Fetch implementation.
    *
+   * If you want to change the fetch function implementation, use `useCustomFetch` plugin.
+   * But we do not recommend changing the fetch implementation unless you know what you are doing.
+   *
    * @warning Do not use this option unless you know what you are doing.
    */
   fetchAPI?: Partial<
@@ -467,6 +470,7 @@ interface GatewayConfigBase<TContext extends Record<string, any>> {
    * Enable, disable or implement a custom logger for logging.
    *
    * @default true
+   * @see https://the-guild.dev/graphql/hive/docs/gateway/logging-and-error-handling
    */
   logging?: boolean | Logger | LogLevel | keyof typeof LogLevel | undefined;
   /**

--- a/vitest.projects.ts
+++ b/vitest.projects.ts
@@ -24,6 +24,7 @@ export default defineWorkspace([
               '!**/e2e/soap-demo',
               '!**/e2e/mysql-employees',
               '!**/e2e/opentelemetry',
+              '!**/e2e/graphos-polling',
             ]
           : []),
       ],


### PR DESCRIPTION
Do not throw when there is no context in `onFetch` because not all fetch requests happen in GraphQL pipeline

Found while working on GW-232
Still waiting for their confirmation but this was still an issue

Related GW-232