### PR TITLE
Use Hive Yoga plugin itself instead of creating a Hive Client instance

### DIFF
--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -641,6 +641,8 @@ export function createGatewayRuntime<
           endpoint,
           key,
           logger: configContext.logger.child({ source: 'Hive CDN' }),
+          // @ts-expect-error - MeshFetch is not compatible with `typeof fetch`
+          fetchImplementation: configContext.fetch,
         });
         unifiedGraphFetcher = () =>
           fetcher().then(({ supergraphSdl }) => supergraphSdl);

--- a/packages/runtime/src/plugins/useHiveConsole.ts
+++ b/packages/runtime/src/plugins/useHiveConsole.ts
@@ -1,5 +1,4 @@
 import type { HivePluginOptions } from '@graphql-hive/core';
-import { createHive } from '@graphql-hive/core';
 import { useHive } from '@graphql-hive/yoga';
 import { process } from '@graphql-mesh/cross-helpers';
 import type { Logger } from '@graphql-mesh/types';
@@ -67,34 +66,16 @@ export default function useHiveConsole<
   if (enabled && !token) {
     throw new Error('Hive plugin is enabled but the token is not provided');
   }
-  const hive = createHive(
-    enabled
-      ? {
-          debug: ['1', 'y', 'yes', 't', 'true'].includes(
-            String(process.env['DEBUG']),
-          ),
-          ...options,
-          enabled: true,
-          token: token!,
-          agent,
-          usage,
-        }
-      : {
-          debug: ['1', 'y', 'yes', 't', 'true'].includes(
-            String(process.env['DEBUG']),
-          ),
-          ...options,
-          enabled: false,
-          token,
-          agent,
-          usage,
-        },
-  );
-  const hivePlugin = useHive(hive);
 
   // @ts-expect-error TODO: useHive plugin should inhert the TContext
-  return {
-    ...hivePlugin,
-    onDispose: () => hive.dispose(),
-  };
+  return useHive({
+    debug: ['1', 'y', 'yes', 't', 'true'].includes(
+      String(process.env['DEBUG']),
+    ),
+    ...options,
+    enabled: !!enabled,
+    token: token!,
+    agent,
+    usage,
+  });
 }

--- a/packages/runtime/tests/hive.spec.ts
+++ b/packages/runtime/tests/hive.spec.ts
@@ -120,10 +120,8 @@ describe('Hive CDN', () => {
       plugins: () => [
         useCustomFetch((url, opts): MaybePromise<Response> => {
           if (url === 'http://upstream/graphql') {
-            return upstreamServer.fetch(
-              url,
-              opts as RequestInit,
-            );
+            // @ts-expect-error - Fetch signature is not compatible
+            return upstreamServer.fetch(url, opts);
           }
           return gateway.fetchAPI.Response.error();
         }),

--- a/packages/runtime/tests/hive.spec.ts
+++ b/packages/runtime/tests/hive.spec.ts
@@ -1,7 +1,7 @@
 import { setTimeout } from 'timers/promises';
 import { useDisableIntrospection } from '@envelop/disable-introspection';
 import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
-import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import { MaybePromise, printSchemaWithDirectives } from '@graphql-tools/utils';
 import {
   createDeferredPromise,
   createDisposableServer,
@@ -118,12 +118,11 @@ describe('Hive CDN', () => {
         key: hiveKey,
       },
       plugins: () => [
-        useCustomFetch((url, opts): any => {
+        useCustomFetch((url, opts): MaybePromise<Response> => {
           if (url === 'http://upstream/graphql') {
             return upstreamServer.fetch(
-              // @ts-expect-error TODO: url can be a string, not only an instance of URL
               url,
-              opts,
+              opts as RequestInit,
             );
           }
           return gateway.fetchAPI.Response.error();


### PR DESCRIPTION
- Hive Plugin already does disposal;
  https://github.com/graphql-hive/console/blob/main/packages/libraries/yoga/src/index.ts#L251
- Hive Plugin sets logger and fetch function
  https://github.com/graphql-hive/console/blob/main/packages/libraries/yoga/src/index.ts#L182
- Also pass the fetch implementation to CDN Schema fetcher