### PR TITLE
fix(runtime): correct the version property

### DIFF
--- a/.changeset/thirty-radios-reply.md
+++ b/.changeset/thirty-radios-reply.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Fix the version property in the gateway runtime instance

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -1153,6 +1153,11 @@ export function createGatewayRuntime<
   fetchAPI ||= yoga.fetchAPI;
 
   Object.defineProperties(yoga, {
+    version: {
+      get() {
+        return globalThis.__VERSION__;
+      },
+    },
     invalidateUnifiedGraph: {
       value: schemaInvalidator,
       configurable: true,


### PR DESCRIPTION
Previously both `yoga.version` in `onYogaInit` and `gwRuntime.version` gives the incorrect version number.
This PR sets the version number correctly.