### PR TITLE
feat(opentelemetry): Allow to use the plugin in Yoga

### DIFF
--- a/.changeset/real-zoos-relate.md
+++ b/.changeset/real-zoos-relate.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/plugin-opentelemetry': minor
+---
+
+Add support of Yoga. This plugin is now usable in Yoga too, which allows for better opentelemetry traces in subgraphs.

--- a/packages/plugins/opentelemetry/tests/utils.ts
+++ b/packages/plugins/opentelemetry/tests/utils.ts
@@ -1,11 +1,14 @@
 import { GatewayConfigProxy, GatewayPlugin } from '@graphql-hive/gateway';
 import { MeshFetch } from '@graphql-mesh/types';
 import { diag, TraceState } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { ExportResultCode, type ExportResult } from '@opentelemetry/core';
 import {
+  SimpleSpanProcessor,
   type ReadableSpan,
   type SpanExporter,
 } from '@opentelemetry/sdk-trace-base';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { AsyncDisposableStack } from '@whatwg-node/disposablestack';
 import { createSchema, createYoga, type GraphQLParams } from 'graphql-yoga';
 import { expect } from 'vitest';
@@ -208,3 +211,11 @@ export type Span = ReadableSpan & {
   traceState?: TraceState;
   id: string;
 };
+
+export const spanExporter = new MockSpanExporter();
+const traceProvider = new WebTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+});
+traceProvider.register({
+  contextManager: new AsyncLocalStorageContextManager(),
+});

--- a/packages/plugins/opentelemetry/tests/yoga.spec.ts
+++ b/packages/plugins/opentelemetry/tests/yoga.spec.ts
@@ -1,0 +1,180 @@
+import { useOpenTelemetry } from '@graphql-mesh/plugin-opentelemetry';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import {
+  SimpleSpanProcessor,
+  WebTracerProvider,
+} from '@opentelemetry/sdk-trace-web';
+import { createSchema, createYoga, Plugin as YogaPlugin } from 'graphql-yoga';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { MockSpanExporter } from './utils';
+
+let mockModule = vi.mock;
+if (globalThis.Bun) {
+  mockModule = require('bun:test').mock.module;
+}
+const mockRegisterProvider = vi.fn();
+
+describe('useOpenTelemetry', () => {
+  // WORKAROUND: Bun does replace already imported modules instances. We make a copy to have the real implementation
+  const TracerProvider = WebTracerProvider;
+  mockModule('@opentelemetry/sdk-trace-web', () => ({
+    WebTracerProvider: vi.fn(() => ({ register: mockRegisterProvider })),
+  }));
+
+  let traceProvider: WebTracerProvider;
+  const spanExporter = new MockSpanExporter();
+
+  beforeAll(async () => {
+    traceProvider = new TracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+    });
+    traceProvider.register({
+      contextManager: new AsyncLocalStorageContextManager(),
+    });
+  });
+  afterAll(async () => {
+    traceProvider.shutdown?.();
+  });
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spanExporter.reset();
+  });
+
+  describe('usage with Yoga', () => {
+    describe.each([
+      { name: 'with context manager', contextManager: undefined },
+      { name: 'without context manager', contextManager: false as const },
+    ])('$name', ({ contextManager }) => {
+      function buildTest(
+        options: {
+          plugins?: (
+            otelPlugin: ReturnType<typeof useOpenTelemetry>,
+          ) => YogaPlugin[];
+        } = {},
+      ) {
+        const otelPlugin = useOpenTelemetry({
+          initializeNodeSDK: false,
+          contextManager,
+        });
+
+        const yoga = createYoga({
+          schema: createSchema({
+            typeDefs: /* GraphQL */ `
+              type Query {
+                hello: String
+              }
+            `,
+            resolvers: {
+              Query: {
+                hello: () => 'World',
+              },
+            },
+          }),
+          logging: false,
+          maskedErrors: false,
+          plugins: [otelPlugin, ...(options.plugins?.(otelPlugin) ?? [])],
+        });
+
+        return {
+          query: async () => {
+            const response = await yoga.fetch('http://yoga/graphql', {
+              method: 'POST',
+              headers: {
+                'content-type': 'application/json',
+              },
+              body: JSON.stringify({ query: '{ hello }' }),
+            });
+            expect(response.status).toBe(200);
+          },
+          [Symbol.asyncDispose]: async () => {
+            await yoga.dispose();
+          },
+        };
+      }
+
+      const expected = {
+        http: {
+          root: 'POST /graphql',
+          children: ['graphql.operation Anonymous'],
+        },
+        graphql: {
+          root: 'graphql.operation Anonymous',
+          children: [
+            'graphql.parse',
+            'graphql.validate',
+            'graphql.context',
+            'graphql.execute',
+          ],
+        },
+      };
+
+      describe('span parenting', () => {
+        it('should register a complete span tree $name', async () => {
+          await using gateway = buildTest();
+          await gateway.query();
+
+          for (const { root, children } of Object.values(expected)) {
+            const spanTree = spanExporter.assertRoot(root);
+            children.forEach(spanTree.expectChild);
+          }
+        });
+
+        it('should allow to report custom spans', async () => {
+          const expectedCustomSpans = {
+            http: { root: 'POST /graphql', children: ['custom.request'] },
+            graphql: {
+              root: 'graphql.operation Anonymous',
+              children: ['custom.operation'],
+            },
+            parse: { root: 'graphql.parse', children: ['custom.parse'] },
+            validate: {
+              root: 'graphql.validate',
+              children: ['custom.validate'],
+            },
+            context: { root: 'graphql.context', children: ['custom.context'] },
+            execute: { root: 'graphql.execute', children: ['custom.execute'] },
+          };
+
+          await using yoga = buildTest({
+            plugins: (otelPlugin) => {
+              const createSpan =
+                (name: string) =>
+                (
+                  matcher: Parameters<(typeof otelPlugin)['getOtelContext']>[0],
+                ) =>
+                  otelPlugin
+                    .getTracer()
+                    .startSpan(name, {}, otelPlugin.getOtelContext(matcher))
+                    .end();
+
+              return [
+                {
+                  onRequest: createSpan('custom.request'),
+                  onParams: createSpan('custom.operation'),
+                  onParse: createSpan('custom.parse'),
+                  onValidate: createSpan('custom.validate'),
+                  onContextBuilding: createSpan('custom.context'),
+                  onExecute: createSpan('custom.execute'),
+                },
+              ];
+            },
+          });
+          await yoga.query();
+
+          for (const { root, children } of Object.values(expectedCustomSpans)) {
+            const spanTree = spanExporter.assertRoot(root);
+            children.forEach(spanTree.expectChild);
+          }
+        });
+      });
+    });
+  });
+});

--- a/packages/plugins/opentelemetry/tests/yoga.spec.ts
+++ b/packages/plugins/opentelemetry/tests/yoga.spec.ts
@@ -1,20 +1,7 @@
 import { useOpenTelemetry } from '@graphql-mesh/plugin-opentelemetry';
-import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
-import {
-  SimpleSpanProcessor,
-  WebTracerProvider,
-} from '@opentelemetry/sdk-trace-web';
 import { createSchema, createYoga, Plugin as YogaPlugin } from 'graphql-yoga';
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
-import { MockSpanExporter } from './utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { spanExporter } from './utils';
 
 let mockModule = vi.mock;
 if (globalThis.Bun) {
@@ -23,26 +10,10 @@ if (globalThis.Bun) {
 const mockRegisterProvider = vi.fn();
 
 describe('useOpenTelemetry', () => {
-  // WORKAROUND: Bun does replace already imported modules instances. We make a copy to have the real implementation
-  const TracerProvider = WebTracerProvider;
   mockModule('@opentelemetry/sdk-trace-web', () => ({
     WebTracerProvider: vi.fn(() => ({ register: mockRegisterProvider })),
   }));
 
-  let traceProvider: WebTracerProvider;
-  const spanExporter = new MockSpanExporter();
-
-  beforeAll(async () => {
-    traceProvider = new TracerProvider({
-      spanProcessors: [new SimpleSpanProcessor(spanExporter)],
-    });
-    traceProvider.register({
-      contextManager: new AsyncLocalStorageContextManager(),
-    });
-  });
-  afterAll(async () => {
-    traceProvider.shutdown?.();
-  });
   beforeEach(() => {
     vi.clearAllMocks();
     spanExporter.reset();


### PR DESCRIPTION
This PR removes the necessity of passing the HiveGateway logger. This way, the plugin is now usable in Yoga too.

The goal is to improve our subgraphs traces while maintaining only one version of the plugin.

I didn't push the thing up to Envelop only usage, but that's something that should be doable with a bit of effort if we want to.

Related to GW-94