### PR TITLE
feat(opentelemetry): add cache events and attributes

### DIFF
--- a/packages/plugins/opentelemetry/src/plugin-utils.ts
+++ b/packages/plugins/opentelemetry/src/plugin-utils.ts
@@ -56,19 +56,23 @@ export function withState<
   function addStateGetters(src: any) {
     const result: any = {};
     for (const [hookName, hook] of Object.entries(src) as any) {
-      result[hookName] =
-        typeof hook !== 'function'
-          ? hook
-          : (payload: any, ...args: any[]) =>
-              hook(
-                {
-                  ...payload,
-                  get state() {
-                    return getState(payload);
-                  },
+      if (typeof hook !== 'function') {
+        result[hookName] = hook;
+      } else {
+        result[hookName] = {
+          [hook.name](payload: any, ...args: any[]) {
+            return hook(
+              {
+                ...payload,
+                get state() {
+                  return getState(payload);
                 },
-                ...args,
-              );
+              },
+              ...args,
+            );
+          },
+        }[hook.name];
+      }
     }
     return result;
   }
@@ -77,6 +81,8 @@ export function withState<
 
   const pluginWithState = addStateGetters(hooks);
   pluginWithState.instrumentation = addStateGetters(instrumentation);
+
+  console.log('plugin hooks: ', Object.entries(pluginWithState));
 
   return pluginWithState as P;
 }

--- a/packages/plugins/opentelemetry/src/plugin-utils.ts
+++ b/packages/plugins/opentelemetry/src/plugin-utils.ts
@@ -82,8 +82,6 @@ export function withState<
   const pluginWithState = addStateGetters(hooks);
   pluginWithState.instrumentation = addStateGetters(instrumentation);
 
-  console.log('plugin hooks: ', Object.entries(pluginWithState));
-
   return pluginWithState as P;
 }
 

--- a/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
+++ b/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
@@ -555,5 +555,59 @@ describe('useOpenTelemetry', () => {
         children.forEach(spanTree.expectChild);
       }
     });
+
+    it.only('should have a response cache attribute', async () => {
+      function checkCacheAttributes(attrs: {
+        http: 'hit' | 'miss';
+        operation?: 'hit' | 'miss';
+      }) {
+        const { span: httpSpan } = spanExporter.assertRoot('POST /graphql');
+        const operationSpan = spanExporter.spans.find(({ name }) =>
+          name.startsWith('graphql.operation'),
+        );
+
+        expect(httpSpan.attributes['gateway.cache.response_cache']).toBe(
+          attrs.http,
+        );
+        if (attrs.operation) {
+          expect(operationSpan).toBeDefined();
+          expect(
+            operationSpan!.attributes['gateway.cache.response_cache'],
+          ).toBe(attrs.operation);
+        }
+      }
+      await using gateway = await buildTestGateway({
+        gatewayOptions: {
+          cache: await import('@graphql-mesh/cache-localforage').then(
+            ({ default: Cache }) => new Cache(),
+          ),
+          responseCaching: {
+            session: () => '1',
+          },
+        },
+      });
+      await gateway.query();
+
+      checkCacheAttributes({ http: 'miss', operation: 'miss' });
+
+      spanExporter.reset();
+      await gateway.query();
+
+      checkCacheAttributes({ http: 'miss', operation: 'hit' });
+
+      spanExporter.reset();
+      const response = await gateway.fetch('http://gateway/graphql', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'If-None-Match':
+            'c2f6fb105ef60ccc99dd6725b55939742e69437d4f85d52bf4664af3799c49fa',
+          'If-Modified-Since': new Date(),
+        },
+      });
+      expect(response.status).toBe(304);
+
+      checkCacheAttributes({ http: 'hit' }); // There is no graphql operation span when cached by HTTP
+    });
   });
 });

--- a/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
+++ b/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
@@ -556,7 +556,7 @@ describe('useOpenTelemetry', () => {
       }
     });
 
-    it.only('should have a response cache attribute', async () => {
+    it('should have a response cache attribute', async () => {
       function checkCacheAttributes(attrs: {
         http: 'hit' | 'miss';
         operation?: 'hit' | 'miss';

--- a/packages/plugins/opentelemetry/tests/utils.ts
+++ b/packages/plugins/opentelemetry/tests/utils.ts
@@ -78,15 +78,19 @@ export async function buildTestGateway(
 
   return {
     otelPlugin: otelPlugin!,
-    query: async (
-      body: GraphQLParams = {
+    query: async ({
+      shouldReturnErrors,
+      body = {
         query: /* GraphQL */ `
           query {
             hello
           }
         `,
       },
-    ) => {
+    }: {
+      body?: GraphQLParams;
+      shouldReturnErrors?: boolean;
+    } = {}) => {
       const response = await gateway.fetch('http://localhost:4000/graphql', {
         method: 'POST',
         headers: {
@@ -94,8 +98,19 @@ export async function buildTestGateway(
         },
         body: JSON.stringify(body),
       });
-      return response.json();
+
+      const result = await response.json();
+      if (shouldReturnErrors) {
+        expect(result.errors).toBeDefined();
+      } else {
+        if (result.errors) {
+          console.error(result.errors);
+        }
+        expect(result.errors).not.toBeDefined();
+      }
+      return result;
     },
+    fetch: gateway.fetch,
     [Symbol.asyncDispose]: () => {
       diag.disable();
       return stack.disposeAsync();


### PR DESCRIPTION
I didn't found any standard cache related attributes, so I've add custom `gateway.cache` prefix.

I also noticed that the operation name is not set when the result is cached (since the execute hook is not called). I don't want to fix this in this PR because it will involve changes in all response cache plugin variants

Related to GW-168