### PR TITLE
fix(runtime): support aliased demand control directive imports

### DIFF
--- a/.changeset/@graphql-hive_gateway-1007-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-1007-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/cache-localforage@^0.105.3` ↗︎](https://www.npmjs.com/package/@graphql-mesh/cache-localforage/v/0.105.3) (from `^0.105.0`, in `dependencies`)

--- a/.changeset/@graphql-hive_gateway-1007-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-1007-dependencies.md
@@ -1,7 +1,0 @@
----
-'@graphql-hive/gateway': patch
----
-
-dependencies updates: 
-
-- Updated dependency [`@graphql-mesh/cache-localforage@^0.105.3` ↗︎](https://www.npmjs.com/package/@graphql-mesh/cache-localforage/v/0.105.3) (from `^0.105.0`, in `dependencies`)

--- a/.changeset/five-kings-sneeze.md
+++ b/.changeset/five-kings-sneeze.md
@@ -1,0 +1,11 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Support aliased imports for Demand Control directives such as;
+
+```graphql
+extend schema @link(url: "...", import: [{ name: "@cost", as: "@myCost" }])
+```
+
+So in this case, `@myCost` will be available in the schema as `@myCost` instead of `@cost`.

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -317,7 +317,7 @@ export function getDirectiveNameForFederationDirective({
               const normalizedImportDirective = normalizeDirectiveName(
                 importDirective.name,
               );
-              if (normalizedImportDirective === directiveName) {
+              if (normalizedImportDirective === normalizedDirectiveName) {
                 const normalizedAlias = normalizeDirectiveName(
                   importDirective.as,
                 );


### PR DESCRIPTION
Ref GW-271
Fixes https://github.com/graphql-hive/gateway/pull/745/files#r2010264968

Support aliased imports for Demand Control directives such as;

```graphql
extend schema @link(url: "...", import: [{ name: "@cost", as: "@myCost" }])
```

So in this case, `@myCost` will be available in the schema as `@myCost` instead of `@cost`.