### PR TITLE
Fixes on Demand Control

### DIFF
--- a/.changeset/cold-monkeys-approve.md
+++ b/.changeset/cold-monkeys-approve.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/batch-execute': patch
+---
+
+Spread sync errors into an array with the same size of the requests to satisfy underlying DataLoader implementation to throw the error correctly

--- a/.changeset/giant-paws-battle.md
+++ b/.changeset/giant-paws-battle.md
@@ -2,4 +2,4 @@
 '@graphql-hive/gateway-runtime': patch
 ---
 
-If metadata is included the result with `includeExtensionMetadata`, `cost.esimated` should always be added to the result extensions even if no cost is calculated.
+If metadata is included the result with `includeExtensionMetadata`, `cost.estimated` should always be added to the result extensions even if no cost is calculated.

--- a/.changeset/giant-paws-battle.md
+++ b/.changeset/giant-paws-battle.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+If metadata is included the result with `includeExtensionMetadata`, `cost.esimated` should always be added to the result extensions even if no cost is calculated.

--- a/packages/batch-execute/src/createBatchingExecutor.ts
+++ b/packages/batch-execute/src/createBatchingExecutor.ts
@@ -49,7 +49,7 @@ function createLoadFn(
   ): PromiseLike<Array<ExecutionResult>> {
     if (requests.length === 1 && requests[0]) {
       const request = requests[0];
-      return fakePromise<any>(
+      return fakePromise(
         handleMaybePromise(
           () => executor(request),
           (result) => [result],
@@ -58,7 +58,7 @@ function createLoadFn(
       );
     }
     const mergedRequests = mergeRequests(requests, extensionsReducer);
-    return fakePromise<any>(
+    return fakePromise(
       handleMaybePromise(
         () => executor(mergedRequests),
         (resultBatches) => {
@@ -69,6 +69,7 @@ function createLoadFn(
           }
           return splitResult(resultBatches, requests.length);
         },
+        (err) => requests.map(() => err),
       ),
     );
   };

--- a/packages/runtime/src/plugins/useDemandControl.ts
+++ b/packages/runtime/src/plugins/useDemandControl.ts
@@ -104,33 +104,31 @@ export function useDemandControl<TContext extends Record<string, any>>({
     },
     onExecutionResult({ result, setResult, context }) {
       if (includeExtensionMetadata) {
-        const costByContext = costByContextMap.get(context);
-        if (costByContext) {
-          if (isAsyncIterable(result)) {
-            setResult(
-              mapAsyncIterator(result, (value) => ({
-                ...value,
-                extensions: {
-                  ...(value.extensions || {}),
-                  cost: {
-                    estimated: costByContext,
-                    max: maxCost,
-                  },
-                },
-              })),
-            );
-          } else {
-            setResult({
-              ...(result || {}),
+        const costByContext = costByContextMap.get(context) || 0;
+        if (isAsyncIterable(result)) {
+          setResult(
+            mapAsyncIterator(result, (value) => ({
+              ...value,
               extensions: {
-                ...(result?.extensions || {}),
+                ...(value.extensions || {}),
                 cost: {
                   estimated: costByContext,
                   max: maxCost,
                 },
               },
-            });
-          }
+            })),
+          );
+        } else {
+          setResult({
+            ...(result || {}),
+            extensions: {
+              ...(result?.extensions || {}),
+              cost: {
+                estimated: costByContext,
+                max: maxCost,
+              },
+            },
+          });
         }
       }
     },


### PR DESCRIPTION
Ref GW-300

- If metadata is included the result with `includeExtensionMetadata`, `cost.esTimated` should always be added to the result extensions even if no cost is calculated. So the estimated cost will be 0 in this case. For example `{ __typename }` never hits any subgraph or QP, then it should be 0.
- When multiple root fields are requested from a subgraph(batched execution), and the cost error is thrown as sync then this causes a sync error in DataLoader, and this causes a cryptic error which is masked unexpectedly. In the batching executor, the sync errors are handled and returned in an array that has the same size of the batched requests.