### PR TITLE
Seperate vitest from the renovate group PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,7 @@
         "!/opentelemetry/",
         "!/graphql-mesh/",
         "!/bun/",
+        "!/vitest/",
         "*"
       ]
     },


### PR DESCRIPTION
Because it blocks other packages to be updated. And vitest updates need to be taken care of seperately due to the patches.