### PR TITLE
Add response log under tmp/codegen when JSON parsing failed

### DIFF
--- a/packages/executors/http/src/index.ts
+++ b/packages/executors/http/src/index.ts
@@ -30,6 +30,7 @@ import {
   createResultForAbort,
   hashSHA256,
 } from './utils.js';
+import * as fs from 'fs';
 
 export type SyncFetchFn = (
   url: string,
@@ -439,6 +440,14 @@ export function buildHTTPExecutor(
                       }
                       return parsedResult;
                     } catch (e: any) {
+                      const currentTime = new Date().toISOString().replace(/[-:Z]/g, '');
+                      const logDir = `tmp/codegen`;
+                      const logFile = `${logDir}/${currentTime}_graphql_codegen_response.log`;
+                      if (!fs.existsSync(logDir)) {
+                        fs.mkdirSync(logDir, { recursive: true });
+                      }
+                      console.log(`Writing response to ${logFile}`);
+                      fs.writeFileSync(logFile, result);
                       return {
                         errors: [
                           createGraphQLError(


### PR DESCRIPTION
Hey!

Here's suggestion on improving logging experience for error, server response might have HTML response or anything else what is not possible to read in console and requires accessing with editor.

I would like to participate in the discussion how to make it better, do we need a configuration variable here for debugging purposes only so that it does not create files without conditionals.

Thank you!