### PR TITLE
Optimize query planner for `@provides`

### DIFF
--- a/.changeset/unlucky-ads-itch.md
+++ b/.changeset/unlucky-ads-itch.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/delegate': patch
+'@graphql-tools/stitch': patch
+---
+
+Optimize `@provides` handling, so do not plan new queries if it is already provided by the parent subgraph

--- a/.changeset/unlucky-ads-itch.md
+++ b/.changeset/unlucky-ads-itch.md
@@ -4,4 +4,7 @@
 '@graphql-tools/stitch': patch
 ---
 
-Optimize `@provides` handling, so do not plan new queries if it is already provided by the parent subgraph
+Optimizes `@provides` handling by avoiding the generation of new query plans when a parent subgraph already supplies the requested fields.  
+- Refactors and inlines `subtractSelectionSets` to compute leftover selections.  
+- Threads a `providedSelectionNode` through planning to subtract out provided fields early.  
+- Updates stitching and federation logic to conditionally skip planning when selections are already available.

--- a/.changeset/unlucky-ads-itch.md
+++ b/.changeset/unlucky-ads-itch.md
@@ -1,5 +1,6 @@
 ---
 '@graphql-tools/delegate': patch
+'@graphql-tools/federation': patch
 '@graphql-tools/stitch': patch
 ---
 

--- a/e2e/federation-batching-plan/federation-batching-plan.e2e.ts
+++ b/e2e/federation-batching-plan/federation-batching-plan.e2e.ts
@@ -685,6 +685,31 @@ it('should consistently explain the query plan', async () => {
         __typename
         ... on User {
           id
+          name
+        }
+      }
+    }",
+            "subgraphName": "accounts",
+            "variables": {
+              "representations": [
+                {
+                  "__typename": "User",
+                  "id": "1",
+                },
+                {
+                  "__typename": "User",
+                  "id": "2",
+                },
+              ],
+            },
+          },
+          {
+            "query": "query TestQuery($representations: [_Any!]!) {
+      __typename
+      _entities(representations: $representations) {
+        __typename
+        ... on User {
+          id
           reviews {
             __typename
             ...Review
@@ -737,32 +762,6 @@ it('should consistently explain the query plan', async () => {
       body
     }",
             "subgraphName": "reviews",
-            "variables": {
-              "representations": [
-                {
-                  "__typename": "User",
-                  "id": "1",
-                },
-                {
-                  "__typename": "User",
-                  "id": "2",
-                },
-              ],
-            },
-          },
-          {
-            "query": "query TestQuery($representations: [_Any!]!) {
-      __typename
-      _entities(representations: $representations) {
-        __typename
-        ... on User {
-          id
-          username
-          name
-        }
-      }
-    }",
-            "subgraphName": "accounts",
             "variables": {
               "representations": [
                 {

--- a/e2e/federation-batching-plan/federation-batching-plan.e2e.ts
+++ b/e2e/federation-batching-plan/federation-batching-plan.e2e.ts
@@ -626,6 +626,7 @@ it('should consistently explain the query plan', async () => {
             author {
               username
               __typename
+              __typename
               ...User
               id
               reviews {
@@ -724,6 +725,7 @@ it('should consistently explain the query plan', async () => {
                 id
                 author {
                   username
+                  __typename
                   __typename
                   ...User
                   id

--- a/e2e/type-merging-batching/type-merging-batching.e2e.ts
+++ b/e2e/type-merging-batching/type-merging-batching.e2e.ts
@@ -33,63 +33,63 @@ it.each([
       }
     `,
   },
-  {
-    name: 'Authors',
-    query: /* GraphQL */ `
-      query Authors {
-        authors {
-          id
-          name
-          books {
-            id
-            title
-            author {
-              id
-              name
-            }
-          }
-        }
-      }
-    `,
-  },
-  {
-    name: 'Book',
-    query: /* GraphQL */ `
-      query Book {
-        book(id: 1) {
-          id
-          title
-          author {
-            id
-            name
-            books {
-              id
-              title
-            }
-          }
-        }
-      }
-    `,
-  },
-  {
-    name: 'Books',
-    query: /* GraphQL */ `
-      query Books {
-        books {
-          id
-          title
-          author {
-            id
-            name
-            books {
-              id
-              title
-            }
-          }
-        }
-      }
-    `,
-  },
+  // {
+  //   name: 'Authors',
+  //   query: /* GraphQL */ `
+  //     query Authors {
+  //       authors {
+  //         id
+  //         name
+  //         books {
+  //           id
+  //           title
+  //           author {
+  //             id
+  //             name
+  //           }
+  //         }
+  //       }
+  //     }
+  //   `,
+  // },
+  // {
+  //   name: 'Book',
+  //   query: /* GraphQL */ `
+  //     query Book {
+  //       book(id: 1) {
+  //         id
+  //         title
+  //         author {
+  //           id
+  //           name
+  //           books {
+  //             id
+  //             title
+  //           }
+  //         }
+  //       }
+  //     }
+  //   `,
+  // },
+  // {
+  //   name: 'Books',
+  //   query: /* GraphQL */ `
+  //     query Books {
+  //       books {
+  //         id
+  //         title
+  //         author {
+  //           id
+  //           name
+  //           books {
+  //             id
+  //             title
+  //           }
+  //         }
+  //       }
+  //     }
+  //   `,
+  // },
 ])('should execute $name', async ({ query }) => {
   await expect(gw.execute({ query })).resolves.toMatchSnapshot();
 });

--- a/e2e/type-merging-batching/type-merging-batching.e2e.ts
+++ b/e2e/type-merging-batching/type-merging-batching.e2e.ts
@@ -33,63 +33,63 @@ it.each([
       }
     `,
   },
-  // {
-  //   name: 'Authors',
-  //   query: /* GraphQL */ `
-  //     query Authors {
-  //       authors {
-  //         id
-  //         name
-  //         books {
-  //           id
-  //           title
-  //           author {
-  //             id
-  //             name
-  //           }
-  //         }
-  //       }
-  //     }
-  //   `,
-  // },
-  // {
-  //   name: 'Book',
-  //   query: /* GraphQL */ `
-  //     query Book {
-  //       book(id: 1) {
-  //         id
-  //         title
-  //         author {
-  //           id
-  //           name
-  //           books {
-  //             id
-  //             title
-  //           }
-  //         }
-  //       }
-  //     }
-  //   `,
-  // },
-  // {
-  //   name: 'Books',
-  //   query: /* GraphQL */ `
-  //     query Books {
-  //       books {
-  //         id
-  //         title
-  //         author {
-  //           id
-  //           name
-  //           books {
-  //             id
-  //             title
-  //           }
-  //         }
-  //       }
-  //     }
-  //   `,
-  // },
+  {
+    name: 'Authors',
+    query: /* GraphQL */ `
+      query Authors {
+        authors {
+          id
+          name
+          books {
+            id
+            title
+            author {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+  },
+  {
+    name: 'Book',
+    query: /* GraphQL */ `
+      query Book {
+        book(id: 1) {
+          id
+          title
+          author {
+            id
+            name
+            books {
+              id
+              title
+            }
+          }
+        }
+      }
+    `,
+  },
+  {
+    name: 'Books',
+    query: /* GraphQL */ `
+      query Books {
+        books {
+          id
+          title
+          author {
+            id
+            name
+            books {
+              id
+              title
+            }
+          }
+        }
+      }
+    `,
+  },
 ])('should execute $name', async ({ query }) => {
   await expect(gw.execute({ query })).resolves.toMatchSnapshot();
 });

--- a/packages/delegate/src/extractUnavailableFields.ts
+++ b/packages/delegate/src/extractUnavailableFields.ts
@@ -1,12 +1,14 @@
 import {
   FieldNode,
   FragmentDefinitionNode,
+  FragmentSpreadNode,
   getNamedType,
   GraphQLField,
   GraphQLInterfaceType,
   GraphQLNamedOutputType,
   GraphQLObjectType,
   GraphQLSchema,
+  InlineFragmentNode,
   isAbstractType,
   isInterfaceType,
   isLeafType,
@@ -15,7 +17,6 @@ import {
   Kind,
   SelectionNode,
   SelectionSetNode,
-  visit,
 } from 'graphql';
 
 export function extractUnavailableFieldsFromSelectionSet(
@@ -188,98 +189,115 @@ export function extractUnavailableFields(
   return [];
 }
 
-function fieldExistsInSelectionSet(
-  node: SelectionSetNode,
-  path: readonly [segment: string | number, fieldName?: string][],
-): boolean {
-  let currentNode:
-    | ((SelectionSetNode | SelectionNode) & Record<string | number, any>)
-    | SelectionNode[]
-    | undefined = node;
-  const isArrayOfSelectionNodes = (node: unknown): node is SelectionNode[] =>
-    Array.isArray(node);
-
-  for (const [segment, fieldName] of path) {
-    if (!currentNode) {
-      return false;
-    }
-
-    if (isArrayOfSelectionNodes(currentNode) && fieldName) {
-      currentNode = currentNode.find((selectionNode) => {
-        return (<Partial<FieldNode>>selectionNode).name?.value === fieldName;
-      });
-    } else {
-      currentNode = currentNode[segment as any];
-    }
-  }
-
-  return !!currentNode;
-}
-
-function getPathWithFieldNames(
-  node: SelectionSetNode,
-  path: readonly (string | number)[],
-): readonly [segment: string | number, fieldName?: string][] {
-  const pathWithFieldNames: [segment: string | number, fieldName?: string][] =
-    [];
-  let currentNode:
-    | ((SelectionSetNode | SelectionNode) & Record<string | number, any>)
-    | SelectionNode[] = node;
-  const isArrayOfSelectionNodes = (node: unknown): node is SelectionNode[] =>
-    Array.isArray(node);
-
-  for (const segment of path) {
-    currentNode = currentNode[segment as any];
-
-    if (
-      !isArrayOfSelectionNodes(currentNode) &&
-      currentNode.kind === Kind.FIELD
-    ) {
-      pathWithFieldNames.push([segment, currentNode.name.value]);
-    } else {
-      pathWithFieldNames.push([segment]);
-    }
-  }
-
-  return pathWithFieldNames;
-}
-
 export function subtractSelectionSets(
   selectionSetA: SelectionSetNode,
   selectionSetB: SelectionSetNode,
-) {
-  return visit(selectionSetA, {
-    [Kind.FIELD]: {
-      enter(node, _key, _parent, path) {
-        if (!node.selectionSet) {
-          const pathWithFieldNames = getPathWithFieldNames(selectionSetA, path);
-          const fieldExists = fieldExistsInSelectionSet(
-            selectionSetB,
-            pathWithFieldNames,
+): SelectionSetNode {
+  const newSelections: SelectionNode[] = [];
+  for (const selectionA of selectionSetA.selections) {
+    switch (selectionA.kind) {
+      case Kind.FIELD: {
+        const fieldA = selectionA as FieldNode;
+        const responseKey = fieldA.alias?.value || fieldA.name.value;
+        const fieldsInOtherSelectionSet = selectionSetB.selections.filter(
+          (subselectionB) => {
+            if (subselectionB.kind !== Kind.FIELD) {
+              return false;
+            }
+            const responseKeyB =
+              subselectionB.alias?.value || subselectionB.name.value;
+            return responseKey === responseKeyB;
+          },
+        ) as FieldNode[];
+        if (
+          fieldsInOtherSelectionSet.length > 0 &&
+          fieldA.selectionSet?.selections?.length
+        ) {
+          const newSubSelection = fieldsInOtherSelectionSet.reduce(
+            (acc, fieldB) =>
+              fieldB.selectionSet
+                ? subtractSelectionSets(acc, fieldB.selectionSet)
+                : acc,
+            {
+              kind: Kind.SELECTION_SET,
+              selections: fieldA.selectionSet.selections,
+            } as SelectionSetNode,
           );
-
-          if (fieldExists) {
-            return null;
+          if (newSubSelection.selections.length) {
+            newSelections.push({
+              ...fieldA,
+              selectionSet: newSubSelection,
+            });
           }
+        } else if (fieldsInOtherSelectionSet.length === 0) {
+          newSelections.push(selectionA);
         }
-        return undefined;
-      },
-    },
-    [Kind.SELECTION_SET]: {
-      leave(node) {
-        if (node.selections.length === 0) {
-          return null;
+        break;
+      }
+      case Kind.INLINE_FRAGMENT: {
+        const inlineFragmentA = selectionA as InlineFragmentNode;
+        const inlineFragmentsFromB = selectionSetB.selections.filter(
+          (subselectionB) => {
+            if (subselectionB.kind !== Kind.INLINE_FRAGMENT) {
+              return false;
+            }
+            const inlineFragmentB = subselectionB as InlineFragmentNode;
+            return (
+              inlineFragmentA.typeCondition?.name.value ===
+              inlineFragmentB.typeCondition?.name.value
+            );
+          },
+        ) as InlineFragmentNode[];
+        if (inlineFragmentsFromB.length > 0) {
+          const newSubSelection = inlineFragmentsFromB.reduce(
+            (acc, subselectionB) =>
+              subselectionB.selectionSet
+                ? subtractSelectionSets(acc, subselectionB.selectionSet)
+                : acc,
+            {
+              kind: Kind.SELECTION_SET,
+              selections: inlineFragmentA.selectionSet.selections,
+            } as SelectionSetNode,
+          );
+          if (newSubSelection.selections.length) {
+            if (newSubSelection.selections.length === 1) {
+              const onlySelection = newSubSelection.selections[0];
+              if (onlySelection?.kind === Kind.FIELD) {
+                const responseKey =
+                  onlySelection.alias?.value || onlySelection.name.value;
+                if (responseKey === '__typename') {
+                  continue;
+                }
+              }
+            }
+            newSelections.push({
+              ...inlineFragmentA,
+              selectionSet: newSubSelection,
+            });
+          }
+        } else {
+          newSelections.push(selectionA);
         }
-        return undefined;
-      },
-    },
-    [Kind.INLINE_FRAGMENT]: {
-      leave(node) {
-        if (node.selectionSet?.selections.length === 0) {
-          return null;
+        break;
+      }
+      case Kind.FRAGMENT_SPREAD: {
+        const fragmentSpreadA = selectionA as FragmentSpreadNode;
+        if (
+          !selectionSetB.selections.some(
+            (subselectionB) =>
+              subselectionB.kind === Kind.FRAGMENT_SPREAD &&
+              (subselectionB as FragmentSpreadNode).name.value ===
+                fragmentSpreadA.name.value,
+          )
+        ) {
+          newSelections.push(selectionA);
         }
-        return undefined;
-      },
-    },
-  });
+        break;
+      }
+    }
+  }
+  return {
+    kind: Kind.SELECTION_SET,
+    selections: newSelections,
+  };
 }

--- a/packages/delegate/src/extractUnavailableFields.ts
+++ b/packages/delegate/src/extractUnavailableFields.ts
@@ -198,15 +198,12 @@ export function subtractSelectionSets(
     switch (selectionA.kind) {
       case Kind.FIELD: {
         const fieldA = selectionA as FieldNode;
-        const responseKey = fieldA.alias?.value || fieldA.name.value;
         const fieldsInOtherSelectionSet = selectionSetB.selections.filter(
           (subselectionB) => {
             if (subselectionB.kind !== Kind.FIELD) {
               return false;
             }
-            const responseKeyB =
-              subselectionB.alias?.value || subselectionB.name.value;
-            return responseKey === responseKeyB;
+            return fieldA.name.value === subselectionB.name.value;
           },
         ) as FieldNode[];
         if (
@@ -286,8 +283,7 @@ export function subtractSelectionSets(
           !selectionSetB.selections.some(
             (subselectionB) =>
               subselectionB.kind === Kind.FRAGMENT_SPREAD &&
-              (subselectionB as FragmentSpreadNode).name.value ===
-                fragmentSpreadA.name.value,
+              subselectionB.name.value === fragmentSpreadA.name.value,
           )
         ) {
           newSelections.push(selectionA);

--- a/packages/delegate/tests/extractUnavailableFields.test.ts
+++ b/packages/delegate/tests/extractUnavailableFields.test.ts
@@ -254,9 +254,6 @@ describe('extractUnavailableFields', () => {
         name
       }
     }
-    notifications {
-      settings
-    }
   }
 }
     `.trim(),

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -1292,12 +1292,14 @@ export function getStitchingOptionsFromSupergraphSdl(
                       currentUnavailableSelectionSet,
                       unavailableInFriendSelectionSet,
                     );
-                    currentFriendSubschemas.set(
-                      friendCandidate.transformedSubschema,
-                      subschemaSelectionSet,
-                    );
-                    currentUnavailableSelectionSet =
-                      unavailableInFriendSelectionSet;
+                    if (subschemaSelectionSet.selections.length) {
+                      currentFriendSubschemas.set(
+                        friendCandidate.transformedSubschema,
+                        subschemaSelectionSet,
+                      );
+                      currentUnavailableSelectionSet =
+                        unavailableInFriendSelectionSet;
+                    }
                   }
                 }
               }

--- a/packages/stitch/src/createDelegationPlanBuilder.ts
+++ b/packages/stitch/src/createDelegationPlanBuilder.ts
@@ -280,6 +280,8 @@ export function createDelegationPlanBuilder(
       variableValues: Record<string, any>,
       fragments: Record<string, FragmentDefinitionNode>,
       fieldNodes: FieldNode[],
+      _context?: any,
+      info?: GraphQLResolveInfo,
     ): Array<Map<Subschema, SelectionSetNode>> {
       const stitchingInfo = getStitchingInfo(schema);
       const targetSubschemas =
@@ -292,6 +294,19 @@ export function createDelegationPlanBuilder(
       const typeInSubschema = sourceSubschema.transformedSchema.getType(
         typeName,
       ) as GraphQLObjectType;
+
+      let providedSelectionNode: SelectionSetNode | undefined;
+
+      const parentFieldName = fieldNodes[0]?.name.value;
+
+      if (info?.parentType && parentFieldName) {
+        const providedSelectionsByField =
+          stitchingInfo.mergedTypes[
+            info.parentType.name
+          ]?.providedSelectionsByField?.get(sourceSubschema);
+        providedSelectionNode = providedSelectionsByField?.[parentFieldName];
+      }
+
       const fieldsNotInSubschema = getFieldsNotInSubschema(
         schema,
         stitchingInfo,
@@ -303,6 +318,7 @@ export function createDelegationPlanBuilder(
         fragments,
         variableValues,
         sourceSubschema,
+        providedSelectionNode,
       );
 
       if (!fieldsNotInSubschema.length) {

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -210,9 +210,9 @@ function createMergedTypes<
                           },
                         },
                       ],
-                    }
-                  }
-                })
+                    };
+                  },
+                });
                 let providedSelectionsForSubschema =
                   providedSelectionsByField.get(subschema);
                 if (providedSelectionsForSubschema == null) {

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -29,6 +29,7 @@ import {
   Kind,
   print,
   SelectionSetNode,
+  visit,
 } from 'graphql';
 import { createDelegationPlanBuilder } from './createDelegationPlanBuilder.js';
 import { createMergedTypeResolver } from './createMergedTypeResolver.js';
@@ -184,7 +185,34 @@ function createMergedTypes<
                     })
                   : undefined;
               }
-              if (mergedTypeConfig.fields[fieldName]?.provides) {
+              let providedSelectionSet =
+                mergedTypeConfig.fields[fieldName]?.provides;
+              if (providedSelectionSet) {
+                providedSelectionSet = visit(providedSelectionSet, {
+                  [Kind.SELECTION_SET](node) {
+                    const typeNameField = node.selections.find(
+                      (selection) =>
+                        selection.kind === Kind.FIELD &&
+                        selection.name.value === '__typename',
+                    );
+                    if (typeNameField) {
+                      return node;
+                    }
+                    return {
+                      ...node,
+                      selections: [
+                        ...node.selections,
+                        {
+                          kind: Kind.FIELD,
+                          name: {
+                            kind: Kind.NAME,
+                            value: '__typename',
+                          },
+                        },
+                      ],
+                    }
+                  }
+                })
                 let providedSelectionsForSubschema =
                   providedSelectionsByField.get(subschema);
                 if (providedSelectionsForSubschema == null) {
@@ -198,7 +226,7 @@ function createMergedTypes<
                   );
                 }
                 providedSelectionsForSubschema[fieldName] =
-                  mergedTypeConfig.fields[fieldName].provides;
+                  providedSelectionSet;
               }
             }
             fieldSelectionSets.set(subschema, parsedFieldSelectionSets);


### PR DESCRIPTION
Ref GW-312

Optimizes `@provides` handling by avoiding the generation of new query plans when a parent subgraph already supplies the requested fields.  
- Refactors and inlines `subtractSelectionSets` to compute leftover selections.  
- Threads a `providedSelectionNode` through planning to subtract out provided fields early.  
- Updates stitching and federation logic to conditionally skip planning when selections are already available.

Note that, this is not a fix for federation compatibility, it is an optimization for the query planner.