### PR TITLE
[@graphql-tools/executor-http] - GraphQL subscriptions over SSE do not receive a GraphQL error response from the server

### DIFF
--- a/packages/federation/tests/never-receive-graphql-error/fixtures/SseClient.ts
+++ b/packages/federation/tests/never-receive-graphql-error/fixtures/SseClient.ts
@@ -1,0 +1,88 @@
+import { EventEmitter } from 'events';
+import { Client, createClient, ExecutionResult } from 'graphql-sse';
+import { getTestPort } from './TestEnvironment';
+
+interface Subscribe<T> {
+  waitForNext: () => Promise<ExecutionResult<T>>;
+  waitForComplete: () => Promise<void>;
+  dispose: () => void;
+}
+
+export class SseClient {
+  private readonly client: Client;
+
+  constructor() {
+    this.client = createClient({
+      url: `http://localhost:${getTestPort()}/graphql`,
+      retryAttempts: 0,
+    });
+  }
+
+  public async subscribe<T extends Record<string, any> = Record<string, any>>(
+    query: string,
+  ): Promise<Subscribe<T>> {
+    const emitter = new EventEmitter();
+    const results: ExecutionResult<T>[] = [];
+    let completed = false;
+
+    emitter.once('next', () => emitter.emit('connected'));
+
+    const dispose = this.client.subscribe<T, Record<string, unknown>>(
+      { query },
+      {
+        next: (value) => {
+          results.push(value);
+          emitter.emit('next');
+        },
+        error: (error) => {
+          console.error(error);
+          emitter.emit('error', error);
+          emitter.removeAllListeners();
+        },
+        complete: () => {
+          completed = true;
+          emitter.emit('complete');
+          emitter.removeAllListeners();
+        },
+      },
+      {
+        connected: () => {
+          emitter.emit('connected');
+        },
+      },
+    );
+
+    const subscribe: Subscribe<T> = {
+      waitForNext: async () => {
+        return new Promise((resolve) => {
+          const done = () => resolve(results.shift()!);
+          if (results.length) {
+            done();
+          } else {
+            emitter.once('next', done);
+          }
+        });
+      },
+      waitForComplete: async () => {
+        return new Promise((resolve) => {
+          const done = () => resolve();
+          if (completed) {
+            done();
+          } else {
+            emitter.once('complete', done);
+          }
+        });
+      },
+      dispose,
+    };
+
+    return new Promise((resolve, reject) => {
+      emitter.once('connected', () => resolve(subscribe));
+      emitter.once('error', (error) => reject(error));
+    });
+  }
+
+  public dispose(): void {
+    return this.client.dispose();
+  }
+}

--- a/packages/federation/tests/never-receive-graphql-error/fixtures/TestEnvironment.ts
+++ b/packages/federation/tests/never-receive-graphql-error/fixtures/TestEnvironment.ts
@@ -1,0 +1,141 @@
+import { createServer, Server } from 'http';
+import { getStitchedSchemaFromSupergraphSdl } from '@graphql-tools/federation';
+import type { execute, ExecutionArgs, GraphQLError, subscribe } from 'graphql';
+import { Disposable as GraphqlWsServer } from 'graphql-ws';
+import { useServer } from 'graphql-ws/use/ws';
+import { createPubSub, createYoga, YogaServerInstance } from 'graphql-yoga';
+import { WebSocketServer } from 'ws';
+import { TestSubgraph1 } from './TestSubgraph1';
+import { TestSubgraph2 } from './TestSubgraph2';
+
+type EnvelopedExecutionArgs = ExecutionArgs & {
+  rootValue: {
+    execute: typeof execute;
+    subscribe: typeof subscribe;
+  };
+};
+
+export const pubSub = createPubSub();
+export function getTestPort(): number {
+  return parseInt(process.env['JEST_WORKER_ID'] ?? '1') + 3000;
+}
+
+export class TestEnvironment {
+  public readonly subgraph1: TestSubgraph1 = new TestSubgraph1();
+  public readonly subgraph2: TestSubgraph2 = new TestSubgraph2();
+  private graphqlWsServer?: GraphqlWsServer;
+  private yogaGateway?: Server;
+  #yoga?: YogaServerInstance<Record<string, unknown>, Record<string, unknown>>;
+  public get yoga() {
+    if (!this.#yoga) {
+      throw Error('You have to start test environment first!');
+    }
+
+    return this.#yoga;
+  }
+
+  public async start(): Promise<void> {
+    // start subgraphs
+    await Promise.all([this.subgraph1.start(), this.subgraph2.start()]);
+
+    // dynamic import is used only due to incompatibility with graphql@15
+    const { IntrospectAndCompose, RemoteGraphQLDataSource } = await import(
+      '@apollo/gateway'
+    );
+    const { supergraphSdl } = await new IntrospectAndCompose({
+      subgraphs: [
+        {
+          name: 'subgraph1',
+          url: `http://localhost:${this.subgraph1.port}/graphql`,
+        },
+        {
+          name: 'subgraph2',
+          url: `http://localhost:${this.subgraph2.port}/graphql`,
+        },
+      ],
+    }).initialize({
+      healthCheck: async () => Promise.resolve(),
+      update: () => undefined,
+      getDataSource: ({ url }) => new RemoteGraphQLDataSource({ url }),
+    });
+
+    // compose stitched schema
+    const schema = getStitchedSchemaFromSupergraphSdl({
+      supergraphSdl,
+      httpExecutorOpts: {
+        // fetch: globalThis.fetch,
+        method: 'POST',
+      },
+    });
+
+    // start yoga geteway
+    this.#yoga = createYoga({ schema, maskedErrors: false });
+    this.yogaGateway = createServer(this.yoga);
+    this.graphqlWsServer = this.createGraphqlWsServer(this.yogaGateway);
+
+    await new Promise<void>((resolve) =>
+      this.yogaGateway?.listen(getTestPort(), () => resolve()),
+    );
+  }
+
+  public async stop(): Promise<void> {
+    // stop yoga geteway
+    await new Promise<void>((resolve, reject) =>
+      this.yogaGateway?.close((error) => (error ? reject(error) : resolve())),
+    );
+    // stop subgraphs
+    await Promise.all([this.subgraph1.stop(), this.subgraph2.stop()]);
+    // stop websocket server
+    await this.graphqlWsServer?.dispose();
+  }
+
+  private createGraphqlWsServer(server: Server): GraphqlWsServer {
+    const wsServer = new WebSocketServer({
+      server,
+      path: this.yoga.graphqlEndpoint,
+    });
+
+    return useServer(
+      {
+        execute: async (args) =>
+          (<EnvelopedExecutionArgs>args).rootValue.execute(args),
+        subscribe: async (args) =>
+          (<EnvelopedExecutionArgs>args).rootValue.subscribe(args),
+        onSubscribe: async (ctx, _id, payload) => {
+          const {
+            schema,
+            execute,
+            subscribe,
+            contextFactory,
+            parse,
+            validate,
+          } = this.yoga.getEnveloped({
+            params: payload,
+            req: ctx.extra.request,
+            socket: ctx.extra.socket,
+          });
+
+          const args: EnvelopedExecutionArgs = {
+            schema,
+            operationName: payload.operationName,
+            document: parse(payload.query),
+            variableValues: payload.variables,
+            contextValue: await contextFactory(),
+            rootValue: {
+              execute,
+              subscribe,
+            },
+          };
+
+          const errors: GraphQLError[] = validate(args.schema, args.document);
+          if (errors.length) {
+            return errors;
+          }
+
+          return args;
+        },
+      },
+      wsServer,
+    );
+  }
+}

--- a/packages/federation/tests/never-receive-graphql-error/fixtures/TestSubgraph1.ts
+++ b/packages/federation/tests/never-receive-graphql-error/fixtures/TestSubgraph1.ts
@@ -1,0 +1,99 @@
+import { createServer, Server } from 'http';
+import { parse } from 'graphql';
+import { createGraphQLError, createYoga } from 'graphql-yoga';
+import { getTestPort, pubSub } from './TestEnvironment';
+
+export const userMock1 = {
+  id: 'user1',
+  email: 'user1@example.com',
+};
+
+const typeDefs = parse(/* GraphQL */ `
+  type Query {
+    testNestedField: TestNestedField
+  }
+
+  type Subscription {
+    testSuccessSubscription: TestUser1
+    testErrorSubscription: TestUser1
+  }
+
+  type TestNestedField {
+    subgraph1: TestSubgraph1Query
+  }
+
+  type TestSubgraph1Query {
+    testSuccessQuery: TestUser1
+    testErrorQuery: TestUser1
+  }
+
+  type TestUser1 {
+    id: String!
+    email: String!
+  }
+`);
+
+const resolvers = {
+  Query: {
+    testNestedField: () => ({
+      subgraph1: () => ({
+        testSuccessQuery: () => {
+          return userMock1;
+        },
+        testErrorQuery: () => {
+          throw createGraphQLError('My subgraph1 error!', {
+            extensions: {
+              code: 'BAD_REQUEST',
+            },
+          });
+        },
+      }),
+    }),
+  },
+  Subscription: {
+    testSuccessSubscription: {
+      subscribe: () => {
+        return pubSub.subscribe('test-topic');
+      },
+      resolve: (data: Record<string, any>) => {
+        return data;
+      },
+    },
+    testErrorSubscription: {
+      subscribe: () => {
+        throw createGraphQLError('My subgraph1 error!', {
+          extensions: {
+            code: 'BAD_REQUEST',
+          },
+        });
+      },
+      resolve: (data: Record<string, any>) => {
+        return data;
+      },
+    },
+  },
+};
+
+export class TestSubgraph1 {
+  public readonly port: number = getTestPort() + 1000;
+  private subgraph?: Server;
+
+  public async start(): Promise<void> {
+    // dynamic import is used only due to incompatibility with graphql@15
+    const { buildSubgraphSchema } = await import('@apollo/subgraph');
+    const yoga = createYoga({
+      schema: buildSubgraphSchema({ typeDefs, resolvers }),
+    });
+    this.subgraph = createServer(yoga);
+
+    return new Promise<void>((resolve) => {
+      this.subgraph?.listen(this.port, () => resolve());
+    });
+  }
+
+  public async stop(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.subgraph?.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}

--- a/packages/federation/tests/never-receive-graphql-error/fixtures/TestSubgraph2.ts
+++ b/packages/federation/tests/never-receive-graphql-error/fixtures/TestSubgraph2.ts
@@ -1,0 +1,72 @@
+import { createServer, Server } from 'http';
+import { parse } from 'graphql';
+import { createGraphQLError, createYoga } from 'graphql-yoga';
+import { getTestPort } from './TestEnvironment';
+
+export const userMock2 = {
+  id: 'user2',
+  email: 'user2@example.com',
+};
+
+const typeDefs = parse(/* GraphQL */ `
+  type Query {
+    testNestedField: TestNestedField
+  }
+
+  type TestNestedField {
+    subgraph2: TestSubgraph2Query
+  }
+
+  type TestSubgraph2Query {
+    testSuccessQuery: TestUser2
+    testErrorQuery: TestUser2
+  }
+
+  type TestUser2 {
+    id: String!
+    email: String!
+  }
+`);
+
+const resolvers = {
+  Query: {
+    testNestedField: () => ({
+      subgraph2: () => ({
+        testSuccessQuery: () => {
+          return userMock2;
+        },
+        testErrorQuery: () => {
+          throw createGraphQLError('My original subgraph2 error!', {
+            extensions: {
+              code: 'BAD_REQUEST',
+            },
+          });
+        },
+      }),
+    }),
+  },
+};
+
+export class TestSubgraph2 {
+  public readonly port: number = getTestPort() + 2000;
+  private subgraph?: Server;
+
+  public async start(): Promise<void> {
+    // dynamic import is used only due to incompatibility with graphql@15
+    const { buildSubgraphSchema } = await import('@apollo/subgraph');
+    const yoga = createYoga({
+      schema: buildSubgraphSchema({ typeDefs, resolvers }),
+    });
+    this.subgraph = createServer(yoga);
+
+    return new Promise<void>((resolve) => {
+      this.subgraph?.listen(this.port, () => resolve());
+    });
+  }
+
+  public async stop(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.subgraph?.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}

--- a/packages/federation/tests/never-receive-graphql-error/fixtures/WsClient.ts
+++ b/packages/federation/tests/never-receive-graphql-error/fixtures/WsClient.ts
@@ -1,0 +1,94 @@
+import { EventEmitter } from 'events';
+import { setTimeout } from 'timers/promises';
+import { Client, createClient, FormattedExecutionResult } from 'graphql-ws';
+import { WebSocket } from 'ws';
+import { getTestPort } from './TestEnvironment';
+
+interface Subscribe<T> {
+  waitForNext: () => Promise<FormattedExecutionResult<T>>;
+  waitForComplete: () => Promise<void>;
+  dispose: () => void;
+}
+
+export class WsClient {
+  private readonly client: Client;
+
+  constructor() {
+    this.client = createClient({
+      url: `ws://localhost:${getTestPort()}/graphql`,
+      webSocketImpl: WebSocket,
+      retryAttempts: 0,
+    });
+  }
+
+  public async subscribe<T extends Record<string, any> = Record<string, any>>(
+    query: string,
+  ): Promise<Subscribe<T>> {
+    const emitter = new EventEmitter();
+    const results: FormattedExecutionResult<T>[] = [];
+    let completed = false;
+
+    emitter.once('next', () => emitter.emit('connected'));
+    this.client.on('connected', async () => {
+      /**
+       * 'connected' event is just information about establishing a websocket connection,
+       * so we adds a small delay to make sure that graphql subscription is really ready
+       */
+      await setTimeout(30);
+      emitter.emit('connected');
+    });
+
+    const dispose = this.client.subscribe<T, Record<string, unknown>>(
+      { query },
+      {
+        next: (value) => {
+          results.push(value);
+          emitter.emit('next');
+        },
+        error: (error) => {
+          console.error(error);
+          emitter.emit('error', error);
+          emitter.removeAllListeners();
+        },
+        complete: () => {
+          completed = true;
+          emitter.emit('complete');
+          emitter.removeAllListeners();
+        },
+      },
+    );
+
+    const subscribe: Subscribe<T> = {
+      waitForNext: async () => {
+        return new Promise((resolve) => {
+          const done = () => resolve(results.shift()!);
+          if (results.length) {
+            done();
+          } else {
+            emitter.once('next', done);
+          }
+        });
+      },
+      waitForComplete: async () => {
+        return new Promise((resolve) => {
+          const done = () => resolve();
+          if (completed) {
+            done();
+          } else {
+            emitter.once('complete', done);
+          }
+        });
+      },
+      dispose,
+    };
+
+    return new Promise((resolve, reject) => {
+      emitter.once('connected', () => resolve(subscribe));
+      emitter.once('error', (error) => reject(error));
+    });
+  }
+
+  public async dispose(): Promise<void> {
+    return this.client.dispose();
+  }
+}

--- a/packages/federation/tests/never-receive-graphql-error/yoga.gateway.subscriptions.test.ts
+++ b/packages/federation/tests/never-receive-graphql-error/yoga.gateway.subscriptions.test.ts
@@ -1,0 +1,111 @@
+import { versionInfo } from 'graphql';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { SseClient } from './fixtures/SseClient';
+import { pubSub, TestEnvironment } from './fixtures/TestEnvironment';
+import { userMock1 } from './fixtures/TestSubgraph1';
+import { WsClient } from './fixtures/WsClient';
+
+const describeIf = (condition: boolean) =>
+  condition ? describe : describe.skip;
+
+describeIf(versionInfo.major >= 16)('Yoga gateway - subscriptions test', () => {
+  let ctx: TestEnvironment;
+  const sseClient: SseClient = new SseClient();
+  const wsClient: WsClient = new WsClient();
+
+  beforeAll(async () => {
+    ctx = new TestEnvironment();
+    await ctx.start();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await ctx.stop();
+  });
+
+  const successSubscription = /* GraphQL */ `
+    subscription {
+      testSuccessSubscription {
+        id
+        email
+      }
+    }
+  `;
+
+  const expectedResult = {
+    data: {
+      testSuccessSubscription: userMock1,
+    },
+  };
+
+  const errorSubscription = /* GraphQL */ `
+    subscription {
+      testErrorSubscription {
+        id
+      }
+    }
+  `;
+
+  const expectedErrorResult = {
+    data: { testErrorSubscription: null },
+    errors: [
+      {
+        message: 'My subgraph1 error!',
+        extensions: {
+          code: 'BAD_REQUEST',
+        },
+      },
+    ],
+  };
+
+  it('subscribes and returns valid subscription mock for TestUser1 - SseClient', async () => {
+    const subscribe = await sseClient.subscribe(successSubscription);
+
+    pubSub.publish('test-topic', userMock1);
+
+    const result = await subscribe.waitForNext();
+    expect(result).toMatchObject(expectedResult);
+
+    subscribe.dispose();
+  });
+
+  it('should receive GraphQLError if subgraph throw an error - SseClient', async () => {
+    const subscribe = await sseClient.subscribe(errorSubscription);
+
+    const result = await subscribe.waitForNext();
+    expect(result).toMatchObject(expectedErrorResult);
+
+    subscribe.dispose();
+  });
+
+  it('subscribes and returns valid subscription mock for TestUser1 - WsClient', async () => {
+    const subscribe = await wsClient.subscribe(successSubscription);
+
+    pubSub.publish('test-topic', userMock1);
+
+    const result = await subscribe.waitForNext();
+    expect(result).toMatchObject(expectedResult);
+
+    subscribe.dispose();
+  });
+
+  it('should receive GraphQLError if subgraph throw an error - WsClient', async () => {
+    const subscribe = await wsClient.subscribe(errorSubscription);
+
+    const result = await subscribe.waitForNext();
+    expect(result).toMatchObject(expectedErrorResult);
+
+    subscribe.dispose();
+  });
+});


### PR DESCRIPTION
This is a test reproducing the issue described here https://github.com/graphql-hive/gateway/issues/1120