### PR TITLE
enhance(batch): use promise helpers more efficient

### DIFF
--- a/.changeset/smart-islands-hug.md
+++ b/.changeset/smart-islands-hug.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/batch-delegate': patch
+'@graphql-tools/batch-execute': patch
+---
+
+Small improvements on usage of promise helpers

--- a/packages/batch-execute/src/splitResult.ts
+++ b/packages/batch-execute/src/splitResult.ts
@@ -1,38 +1,37 @@
 // adapted from https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-graphql/src/batching/merge-queries.js
 
 import { ExecutionResult, relocatedError } from '@graphql-tools/utils';
-import { GraphQLError } from 'graphql';
 import { parseKey, parseKeyFromPath } from './prefix.js';
 
 /**
  * Split and transform result of the query produced by the `merge` function
  */
 export function splitResult(
-  { data, errors }: ExecutionResult,
+  mergedResult: ExecutionResult,
   numResults: number,
 ): Array<ExecutionResult> {
-  const splitResults: Array<ExecutionResult> = [];
-  for (let i = 0; i < numResults; i++) {
-    splitResults.push({});
-  }
+  const splitResults = new Array<ExecutionResult>(numResults);
 
-  if (data) {
-    for (const prefixedKey in data) {
+  if (mergedResult.data) {
+    for (const prefixedKey in mergedResult.data) {
       const { index, originalKey } = parseKey(prefixedKey);
       const result = splitResults[index];
       if (result == null) {
-        continue;
-      }
-      if (result.data == null) {
-        result.data = { [originalKey]: data[prefixedKey] };
+        splitResults[index] = {
+          data: {
+            [originalKey]: mergedResult.data[prefixedKey],
+          },
+        };
+      } else if (result.data == null) {
+        result.data = { [originalKey]: mergedResult.data[prefixedKey] };
       } else {
-        result.data[originalKey] = data[prefixedKey];
+        result.data[originalKey] = mergedResult.data[prefixedKey];
       }
     }
   }
 
-  if (errors) {
-    for (const error of errors) {
+  if (mergedResult.errors) {
+    for (const error of mergedResult.errors) {
       if (error.path) {
         const { index, originalKey, keyOffset } = parseKeyFromPath(error.path);
         const newError = relocatedError(error, [
@@ -40,15 +39,30 @@ export function splitResult(
           ...error.path.slice(keyOffset),
         ]);
         const splittedResult = splitResults[index];
-        if (splittedResult) {
-          const resultErrors = (splittedResult.errors ||= []) as GraphQLError[];
-          resultErrors.push(newError);
+        if (splittedResult == null) {
+          splitResults[index] = { errors: [newError] };
+          continue;
+        } else if (splittedResult.errors == null) {
+          splittedResult.errors = [newError];
+          continue;
+        } else {
+          // @ts-expect-error - We know it is not readonly
+          splittedResult.errors.push(newError);
         }
       } else {
-        splitResults.forEach((result) => {
-          const resultErrors = (result.errors ||= []) as GraphQLError[];
-          resultErrors.push(error);
-        });
+        for (let i = 0; i < numResults; i++) {
+          const splittedResult = splitResults[i];
+          if (splittedResult == null) {
+            splitResults[i] = { errors: [error] };
+            continue;
+          } else if (splittedResult.errors == null) {
+            splittedResult.errors = [error];
+            continue;
+          } else {
+            // @ts-expect-error - We know it is not readonly
+            splittedResult.errors.push(error);
+          }
+        }
       }
     }
   }

--- a/packages/batch-execute/src/splitResult.ts
+++ b/packages/batch-execute/src/splitResult.ts
@@ -7,31 +7,31 @@ import { parseKey, parseKeyFromPath } from './prefix.js';
  * Split and transform result of the query produced by the `merge` function
  */
 export function splitResult(
-  mergedResult: ExecutionResult,
+  { data, errors }: ExecutionResult,
   numResults: number,
 ): Array<ExecutionResult> {
   const splitResults = new Array<ExecutionResult>(numResults);
 
-  if (mergedResult.data) {
-    for (const prefixedKey in mergedResult.data) {
+  if (data) {
+    for (const prefixedKey in data) {
       const { index, originalKey } = parseKey(prefixedKey);
       const result = splitResults[index];
       if (result == null) {
         splitResults[index] = {
           data: {
-            [originalKey]: mergedResult.data[prefixedKey],
+            [originalKey]: data[prefixedKey],
           },
         };
       } else if (result.data == null) {
-        result.data = { [originalKey]: mergedResult.data[prefixedKey] };
+        result.data = { [originalKey]: data[prefixedKey] };
       } else {
-        result.data[originalKey] = mergedResult.data[prefixedKey];
+        result.data[originalKey] = data[prefixedKey];
       }
     }
   }
 
-  if (mergedResult.errors) {
-    for (const error of mergedResult.errors) {
+  if (errors) {
+    for (const error of errors) {
       if (error.path) {
         const { index, originalKey, keyOffset } = parseKeyFromPath(error.path);
         const newError = relocatedError(error, [


### PR DESCRIPTION
Micro optimizations on usage of promise helpers and batching

- Avoid extra `handleMaybePromise` call
- Avoid object manipulation and extra `Error` instanceof