### PR TITLE
Add missing `cookies` option in the configuration

### DIFF
--- a/.changeset/@graphql-hive_gateway-runtime-1139-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-runtime-1139-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+dependencies updates: 
+
+- Added dependency [`@whatwg-node/server-plugin-cookies@^1.0.5` ↗︎](https://www.npmjs.com/package/@whatwg-node/server-plugin-cookies/v/1.0.5) (to `dependencies`)

--- a/.changeset/tall-terms-relate.md
+++ b/.changeset/tall-terms-relate.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': minor
+---
+
+Add `cookies` property to the configuration for cookies processing which is already documented in [here](https://the-guild.dev/graphql/hive/docs/gateway/authorization-authentication#token-lookup)

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -75,6 +75,7 @@
     "@whatwg-node/disposablestack": "^0.0.6",
     "@whatwg-node/promise-helpers": "^1.3.0",
     "@whatwg-node/server": "^0.10.8",
+    "@whatwg-node/server-plugin-cookies": "^1.0.5",
     "graphql-ws": "^6.0.4",
     "graphql-yoga": "^5.13.4",
     "tslib": "^2.8.1"

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -61,6 +61,7 @@ import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { usePersistedOperations } from '@graphql-yoga/plugin-persisted-operations';
 import { AsyncDisposableStack } from '@whatwg-node/disposablestack';
 import { handleMaybePromise, MaybePromise } from '@whatwg-node/promise-helpers';
+import { useCookies } from '@whatwg-node/server-plugin-cookies';
 import {
   buildASTSchema,
   buildSchema,
@@ -1125,6 +1126,10 @@ export function createGatewayRuntime<
 
   if (config.demandControl) {
     extraPlugins.push(useDemandControl(config.demandControl));
+  }
+
+  if (config.cookies) {
+    extraPlugins.push(useCookies());
   }
 
   let isDebug: boolean = false;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -673,7 +673,7 @@ interface GatewayConfigBase<TContext extends Record<string, any>> {
    *
    * Now [`request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object in the GraphQL Context will have [`cookieStore`](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore).
    *
-   * This feature flag needs to be enabled for the plugins like;
+   * This feature flag needs to be enabled for plugins such as:
    * [JWT Plugin with cookies](https://the-guild.dev/graphql/hive/docs/gateway/authorization-authentication#token-lookup)
    *
    * You can learn more about the underlying GraphQL Yoga plugin [here](https://the-guild.dev/graphql/yoga-server/docs/features/cookies)

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -667,6 +667,18 @@ interface GatewayConfigBase<TContext extends Record<string, any>> {
    * Subgraph error handling
    */
   subgraphErrors?: SubgraphErrorPluginOptions | false;
+
+  /**
+   * Process cookie headers
+   *
+   * Now [`request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object in the GraphQL Context will have [`cookieStore`](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore).
+   *
+   * This feature flag needs to be enabled for the plugins like;
+   * [JWT Plugin with cookies](https://the-guild.dev/graphql/hive/docs/gateway/authorization-authentication#token-lookup)
+   *
+   * You can learn more about the underlying GraphQL Yoga plugin [here](https://the-guild.dev/graphql/yoga-server/docs/features/cookies)
+   */
+  cookies?: boolean;
 }
 
 interface DisableIntrospectionOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3975,6 +3975,7 @@ __metadata:
     "@whatwg-node/fetch": "npm:^0.10.6"
     "@whatwg-node/promise-helpers": "npm:^1.3.0"
     "@whatwg-node/server": "npm:^0.10.8"
+    "@whatwg-node/server-plugin-cookies": "npm:^1.0.5"
     fets: "npm:^0.8.4"
     graphql: "npm:^16.9.0"
     graphql-sse: "npm:^2.5.3"
@@ -8917,7 +8918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@whatwg-node/server-plugin-cookies@npm:^1.0.3":
+"@whatwg-node/server-plugin-cookies@npm:^1.0.3, @whatwg-node/server-plugin-cookies@npm:^1.0.5":
   version: 1.0.5
   resolution: "@whatwg-node/server-plugin-cookies@npm:1.0.5"
   dependencies:


### PR DESCRIPTION
Adds `cookies` property to the configuration for cookies processing which is already documented in [here](https://the-guild.dev/graphql/hive/docs/gateway/authorization-authentication#token-lookup)

Ref GW-350