### PR TITLE
fix(gateway): Update docker image to fix CVE related to passwd

### DIFF
--- a/.changeset/weak-starfishes-begin.md
+++ b/.changeset/weak-starfishes-begin.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+**Security Update:** The Docker image have been updated to fix a CVE affecting `passwd` command. This CVE was not directly affecting Hive Gateway software, since it's not using impacted components.

--- a/packages/gateway/node.Dockerfile
+++ b/packages/gateway/node.Dockerfile
@@ -10,7 +10,10 @@ RUN npm i graphql@^16.9.0
 
 FROM node:24-slim
 
-RUN apt-get update && apt-get install -y \
+# `passwd` is vulnerable out of the bax, updating for a fix.
+RUN apt-get update && apt-get upgrade -y passwd
+
+RUN apt-get install -y \
   # for healthchecks
   wget curl \
   # for proper signal propagation


### PR DESCRIPTION
This PR is manually upgrading `passwd` because the current version contains a CVE.
This should not be necessary once the upstream image will be updated.

Related to GW-328