### PR TITLE
enhance(cli): serve graphiql offline by default

### DIFF
--- a/.changeset/@graphql-hive_gateway-1172-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-1172-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+dependencies updates: 
+
+- Added dependency [`@graphql-yoga/render-graphiql@^5.13.5` ↗︎](https://www.npmjs.com/package/@graphql-yoga/render-graphiql/v/5.13.5) (to `dependencies`)

--- a/.changeset/fresh-squids-visit.md
+++ b/.changeset/fresh-squids-visit.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway': minor
+---
+
+Serve GraphiQL offline by default instead of fetching it from CDN

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -81,6 +81,7 @@
     "@graphql-tools/graphql-file-loader": "^8.0.14",
     "@graphql-tools/load": "^8.0.14",
     "@graphql-tools/utils": "^10.8.1",
+    "@graphql-yoga/render-graphiql": "^5.13.5",
     "commander": "^13.1.0",
     "dotenv": "^16.4.7",
     "graphql-ws": "^6.0.4",

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -22,6 +22,7 @@ import type { JWTAuthPluginOptions } from '@graphql-mesh/plugin-jwt-auth';
 import type { OpenTelemetryMeshPluginOptions } from '@graphql-mesh/plugin-opentelemetry';
 import type { PrometheusPluginOptions } from '@graphql-mesh/plugin-prometheus';
 import type { KeyValueCache, Logger, YamlConfig } from '@graphql-mesh/types';
+import { renderGraphiQL } from '@graphql-yoga/render-graphiql';
 import parseDuration from 'parse-duration';
 import { getDefaultLogger } from '../../runtime/src/getDefaultLogger';
 import { addCommands } from './commands/index';
@@ -262,6 +263,7 @@ export const defaultOptions = {
       : '0.0.0.0',
   port: 4000,
   pollingInterval: 10_000,
+  renderGraphiQL,
 };
 
 /** Root cli for the gateway. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -4041,6 +4041,7 @@ __metadata:
     "@graphql-tools/graphql-file-loader": "npm:^8.0.14"
     "@graphql-tools/load": "npm:^8.0.14"
     "@graphql-tools/utils": "npm:^10.8.1"
+    "@graphql-yoga/render-graphiql": "npm:^5.13.5"
     "@rollup/plugin-commonjs": "npm:^28.0.0"
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-node-resolve": "npm:^16.0.0"
@@ -5348,6 +5349,15 @@ __metadata:
     graphql: ^15.2.0 || ^16.0.0
     graphql-yoga: ^5.13.4
   checksum: 10c0/022979d5f19119d281fab581e4782a67f9cdfb951bdb189da0efe25e6abf58dbb6424a1f72fb9a1c552e744d7a5d9c9dec5db8b0bd341a66d7d6927ca9981738
+  languageName: node
+  linkType: hard
+
+"@graphql-yoga/render-graphiql@npm:^5.13.5":
+  version: 5.13.5
+  resolution: "@graphql-yoga/render-graphiql@npm:5.13.5"
+  peerDependencies:
+    graphql-yoga: ^5.13.5
+  checksum: 10c0/c9c008291e2c27a33cae8cd70bd64b1cd07310f5fb70ce98be3307317a100dcc57f5bbabd2e953ce5196f4ca765bf1cb69b87d078746a838c678037e312e8013
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In the CLI package, bundle size is not important so CLI can include the offline bundled version of GraphiQL, while runtime will still use the online version from CDN.

Related feature from the underlying Yoga Server;
https://the-guild.dev/graphql/yoga-server/docs/features/graphiql#offline-usage