### PR TITLE
Environment variables for E2E log piping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-.DS_Store
 node_modules/
+.DS_Store
 dist/
 bundle/
 .yarn/*
@@ -17,4 +17,5 @@ hive-gateway
 /e2e/**/*/memtest-memory-usage_*.svg
 /e2e/**/*/*.heapsnapshot
 /e2e/**/*/*.heapprofile
-/e2e/**/*/loadtest.out
+/e2e/**/*/*.out
+/internal/**/*/*.out

--- a/internal/e2e/src/tenv.ts
+++ b/internal/e2e/src/tenv.ts
@@ -366,7 +366,9 @@ export function createTenv(cwd: string): Tenv {
         port = await getAvailablePort(),
         supergraph: supergraphOpt,
         subgraph: subgraphOpt,
-        pipeLogs = isDebug(),
+        pipeLogs = isDebug() || boolEnv('E2E_PIPE_LOGS')
+          ? 'gateway.out'
+          : false,
         env,
         runner,
         args = [],
@@ -635,7 +637,7 @@ export function createTenv(cwd: string): Tenv {
         services = [],
         trimHostPaths,
         maskServicePorts,
-        pipeLogs = isDebug(),
+        pipeLogs = isDebug() || boolEnv('E2E_PIPE_LOGS') ? 'mesh.out' : false,
         env,
         args = [],
       } = opts || {};
@@ -715,7 +717,9 @@ export function createTenv(cwd: string): Tenv {
       {
         port,
         gatewayPort,
-        pipeLogs = isDebug(),
+        pipeLogs = isDebug() || boolEnv('E2E_PIPE_LOGS')
+          ? `${name}.out`
+          : false,
         args = [],
         protocol = 'http',
         env,
@@ -774,7 +778,7 @@ export function createTenv(cwd: string): Tenv {
       hostPort,
       additionalContainerPorts: containerAdditionalPorts,
       healthcheck,
-      pipeLogs = boolEnv('DEBUG'),
+      pipeLogs = isDebug() || boolEnv('E2E_PIPE_LOGS') ? `${name}.out` : false,
       cmd = [],
       volumes = [],
       args = [],
@@ -1004,7 +1008,10 @@ export function createTenv(cwd: string): Tenv {
       }
       return container;
     },
-    async composeWithApollo({ services = [], pipeLogs = isDebug() }) {
+    async composeWithApollo({
+      services = [],
+      pipeLogs = isDebug() || boolEnv('E2E_PIPE_LOGS') ? 'rover.out' : false,
+    }) {
       const subgraphs: ServiceEndpointDefinition[] = [];
       for (const service of services) {
         const hostname = await getLocalhost(service.port, service.protocol);


### PR DESCRIPTION
### `E2E_PIPE_LOGS=1` 

Run the composition, services, containers and the gateway, and pipe logs to their output files.

### `DEBUG=1` 

Run the composition, services, containers and the gateway in debug mode and pipe logs to their output files.

### Output files

The output files of the logs are relative to each of the E2E's test folder. In the folder, the filenames are:
- `gateway.out` for the gateway
- `${name}.out` for each service
- `${name}.out` for each container
- `mesh.out` for mesh composition
- `rover.out` for apollo composition with rover