### PR TITLE
Docs: Fix stitch link to 404

### DIFF
--- a/packages/stitch/README.md
+++ b/packages/stitch/README.md
@@ -1,5 +1,2 @@
-Check API Reference for more information about this package;
-https://www.graphql-tools.com/docs/api/modules/stitch_src
-
-You can also learn more about Schema Stitching in this chapter;
-https://www.graphql-tools.com/docs/stitch-combining-schemas
+For more information about this package:
+https://the-guild.dev/graphql/stitching


### PR DESCRIPTION
Fixes https://github.com/the-guild-org/website/issues/1802

Was 404.
Now links to correct page.