### PR TITLE
Handle multi-error execution results in delegated requests

### DIFF
--- a/.changeset/fast-tomatoes-search.md
+++ b/.changeset/fast-tomatoes-search.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+Relocate each error in multi-error ExecutionResult
+
+Handling errors now works the same for both single-error and multi-error ExecutionResults.

--- a/.changeset/sour-news-reflect.md
+++ b/.changeset/sour-news-reflect.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+Call onLocatedError hook from delegation context for each error in multi-error ExecutionResult


### PR DESCRIPTION
Ref GW-419

Includes two fixes, stated in the changesets.

Furthermore, fixed the errors testing suite because some tests were passing without any assertions being performed.

### TODO

- [ ] Write exact reproduction test that client had