### PR TITLE
fix(gateway-runtime): Add `subgraphName` to `ExecutionRequest`

### DIFF
--- a/.changeset/big-dolls-invent.md
+++ b/.changeset/big-dolls-invent.md
@@ -1,0 +1,10 @@
+---
+'@graphql-mesh/fusion-runtime': minor
+---
+
+Breaking Change: Removed `subgraphNameByExecutionRequest` weak map. Subgraph name is now stored in the execution request itself.
+
+```diff
+- const subgraphName = subgraphNameByExecutionRequest.get(executionRequest)
++ const subgraphName = executionRequest.subgraphName
+```

--- a/.changeset/lovely-turtles-sing.md
+++ b/.changeset/lovely-turtles-sing.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/delegate': minor
+'@graphql-hive/gateway-runtime': minor
+---
+
+Added `subgraphName` to `ExecutionRequest` for easier plugin developpment.

--- a/.changeset/red-teachers-love.md
+++ b/.changeset/red-teachers-love.md
@@ -1,0 +1,10 @@
+---
+'@graphql-hive/plugin-aws-sigv4': patch
+'@graphql-mesh/fusion-runtime': patch
+'@graphql-tools/batch-execute': patch
+'@graphql-tools/delegate': patch
+'@graphql-hive/gateway-runtime': patch
+'@graphql-tools/wrap': patch
+---
+
+Fixed subgraph name being lost when execution requests get batched together.

--- a/e2e/header-propagation/gateway.config.ts
+++ b/e2e/header-propagation/gateway.config.ts
@@ -2,7 +2,11 @@ import { defineConfig } from '@graphql-hive/gateway';
 
 export const gatewayConfig = defineConfig({
   propagateHeaders: {
-    fromClientToSubgraphs({ request }) {
+    fromClientToSubgraphs({ request, subgraphName }) {
+      if (subgraphName !== 'upstream') {
+        return;
+      }
+
       return {
         authorization: request.headers.get('authorization') ?? 'default',
         'session-cookie-id':

--- a/e2e/header-propagation/header-propagation.e2e.ts
+++ b/e2e/header-propagation/header-propagation.e2e.ts
@@ -34,6 +34,41 @@ it('propagates headers to subgraphs', async () => {
   });
 });
 
+it('propagates headers to subgraphs with batching', async () => {
+  await using gw = await gateway({
+    supergraph: {
+      with: 'apollo',
+      services: [await service('upstream')],
+    },
+  });
+  const result = await gw.execute({
+    query: /* GraphQL */ `
+      query {
+        h1: headers {
+          sessionCookieId
+        }
+        h2: headers {
+          authorization
+        }
+      }
+    `,
+    headers: {
+      authorization: 'Bearer token',
+      'session-cookie-id': 'session-cookie',
+    },
+  });
+  expect(result).toEqual({
+    data: {
+      h1: {
+        sessionCookieId: 'session-cookie',
+      },
+      h2: {
+        authorization: 'Bearer token',
+      },
+    },
+  });
+});
+
 it('sends default headers to subgraphs', async () => {
   await using gw = await gateway({
     supergraph: {

--- a/e2e/header-propagation/services/upstream.ts
+++ b/e2e/header-propagation/services/upstream.ts
@@ -31,8 +31,8 @@ const server = new ApolloServer<ExpressContextFunctionArgument>({
       }
 
       type Headers {
-        authorization: String!
-        sessionCookieId: String!
+        authorization: String
+        sessionCookieId: String
       }
     `),
     resolvers: resolvers as GraphQLResolverMap<unknown>,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@graphql-mesh/types": "0.104.6",
     "@graphql-mesh/utils": "0.104.6",
     "@graphql-tools/delegate": "workspace:^",
+    "@graphql-tools/utils": "10.9.0-alpha-20250710200000-fde1c74a0c2fa4f651cbeed5b2091aeda7afb162",
     "@opentelemetry/otlp-exporter-base@npm:0.202.0": "patch:@opentelemetry/otlp-exporter-base@npm%3A0.202.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.202.0-f6f29c2eeb.patch",
     "@rollup/plugin-node-resolve@npm:^15.2.3": "patch:@rollup/plugin-node-resolve@npm%3A16.0.1#~/.yarn/patches/@rollup-plugin-node-resolve-npm-16.0.1-2936474bab.patch",
     "@vitest/snapshot": "patch:@vitest/snapshot@npm:3.1.2#~/.yarn/patches/@vitest-snapshot-npm-3.1.1-4d18cf86dc.patch",

--- a/packages/batch-execute/src/mergeRequests.ts
+++ b/packages/batch-execute/src/mergeRequests.ts
@@ -61,6 +61,7 @@ export function mergeRequests(
     request: ExecutionRequest,
   ) => Record<string, any>,
 ): ExecutionRequest {
+  const subgraphName = requests[0]!.subgraphName;
   const mergedVariables: Record<string, any> = Object.create(null);
   const mergedVariableDefinitions: Array<VariableDefinitionNode> = [];
   const mergedSelections: Array<SelectionNode> = [];
@@ -114,6 +115,7 @@ export function mergeRequests(
   }
 
   return {
+    subgraphName,
     document: {
       kind: Kind.DOCUMENT,
       definitions: [mergedOperationDefinition, ...mergedFragmentDefinitions],

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -37,6 +37,7 @@ export function getDelegatingOperation(
 }
 
 export function createRequest({
+  subgraphName,
   sourceSchema,
   sourceParentType,
   sourceFieldName,
@@ -167,6 +168,7 @@ export function createRequest({
   };
 
   return {
+    subgraphName,
     document,
     variables: newVariables,
     rootValue: targetRootValue,

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -54,6 +54,7 @@ export function delegateToSchema<
   } = options;
 
   const request = createRequest({
+    subgraphName: (schema as SubschemaConfig).name,
     sourceSchema: info.schema,
     sourceParentType: info.parentType,
     sourceFieldName: info.fieldName,

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -99,6 +99,7 @@ export interface IDelegateRequestOptions<
 }
 
 export interface ICreateRequest {
+  subgraphName: string | undefined;
   sourceSchema?: GraphQLSchema;
   sourceParentType?: GraphQLObjectType;
   sourceFieldName?: string;

--- a/packages/delegate/tests/batchExecution.test.ts
+++ b/packages/delegate/tests/batchExecution.test.ts
@@ -47,9 +47,17 @@ describe('batch execution', () => {
       resolvers: {
         Query: {
           field1: (_parent, _args, context, info) =>
-            delegateToSchema({ schema: innerSubschemaConfig, context, info }),
+            delegateToSchema({
+              schema: innerSubschemaConfig,
+              context,
+              info,
+            }),
           field2: (_parent, _args, context, info) =>
-            delegateToSchema({ schema: innerSubschemaConfig, context, info }),
+            delegateToSchema({
+              schema: innerSubschemaConfig,
+              context,
+              info,
+            }),
         },
       },
     });

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -39,6 +39,7 @@ describe('bare requests', () => {
         Query: {
           delegate: (_root, args, _context, info) => {
             const request = createRequest({
+              subgraphName: 'inner',
               fieldNodes: [
                 {
                   kind: Kind.FIELD,
@@ -139,6 +140,7 @@ describe('bare requests', () => {
         Query: {
           delegate: (_root, args, _context, info) => {
             const request = createRequest({
+              subgraphName: 'inner',
               fieldNodes: [
                 {
                   kind: Kind.FIELD,
@@ -220,6 +222,7 @@ describe('bare requests', () => {
         Query: {
           delegate: (_source, _args, _context, info) => {
             const request = createRequest({
+              subgraphName: 'inner',
               fieldNodes: [
                 {
                   kind: Kind.FIELD,

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -171,11 +171,6 @@ function getTransportExecutor({
   );
 }
 
-export const subgraphNameByExecutionRequest = new WeakMap<
-  ExecutionRequest,
-  string
->();
-
 /**
  * This function creates a executor factory that uses the transport packages,
  * and wraps them with the hooks
@@ -206,7 +201,6 @@ export function getOnSubgraphExecute({
     subgraphName: string,
     executionRequest: ExecutionRequest,
   ) {
-    subgraphNameByExecutionRequest.set(executionRequest, subgraphName);
     let executor: Executor | undefined = subgraphExecutorMap.get(subgraphName);
     // If the executor is not initialized yet, initialize it
     if (executor == null) {

--- a/packages/plugins/aws-sigv4/src/plugin.ts
+++ b/packages/plugins/aws-sigv4/src/plugin.ts
@@ -1,7 +1,6 @@
 import { BinaryLike, createHash, createHmac, KeyObject } from 'node:crypto';
 import { STS } from '@aws-sdk/client-sts';
 import type { GatewayPlugin } from '@graphql-hive/gateway-runtime';
-import { subgraphNameByExecutionRequest } from '@graphql-mesh/fusion-runtime';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import { getEnvStr } from '~internal/env';
 import aws4, { type Request as AWS4Request } from 'aws4';
@@ -358,8 +357,7 @@ export function useAWSSigv4<TContext extends Record<string, any>>(
     },
     // Handle outgoing requests
     onFetch({ url, options, setURL, setOptions, executionRequest }) {
-      const subgraphName = (executionRequest &&
-        subgraphNameByExecutionRequest.get(executionRequest))!;
+      const subgraphName = executionRequest?.subgraphName!;
       if (!isBufferOrString(options.body)) {
         return;
       }

--- a/packages/runtime/src/plugins/usePropagateHeaders.ts
+++ b/packages/runtime/src/plugins/usePropagateHeaders.ts
@@ -1,4 +1,3 @@
-import { subgraphNameByExecutionRequest } from '@graphql-mesh/fusion-runtime';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import type { GatewayPlugin, OnFetchHookDone } from '../types';
 
@@ -38,8 +37,7 @@ export function usePropagateHeaders<TContext extends Record<string, any>>(
           ? context?.request || executionRequest?.context?.request
           : undefined;
       if (request) {
-        const subgraphName = (executionRequest &&
-          subgraphNameByExecutionRequest.get(executionRequest))!;
+        const subgraphName = executionRequest?.subgraphName!;
         return handleMaybePromise(
           () =>
             handleMaybePromise(

--- a/packages/runtime/src/plugins/useUpstreamTimeout.ts
+++ b/packages/runtime/src/plugins/useUpstreamTimeout.ts
@@ -1,5 +1,4 @@
 import { abortSignalAny } from '@graphql-hive/signal';
-import { subgraphNameByExecutionRequest } from '@graphql-mesh/fusion-runtime';
 import { UpstreamErrorExtensions } from '@graphql-mesh/transport-common';
 import { getHeadersObj } from '@graphql-mesh/utils';
 import {
@@ -127,9 +126,7 @@ export function useUpstreamTimeout<TContext extends Record<string, any>>(
       return undefined;
     },
     onFetch({ url, executionRequest, options, setOptions }) {
-      const subgraphName =
-        executionRequest &&
-        subgraphNameByExecutionRequest.get(executionRequest);
+      const subgraphName = executionRequest?.subgraphName;
       if (
         !executionRequest ||
         !timeoutSignalsByExecutionRequest.has(executionRequest)

--- a/packages/wrap/tests/requests.test.ts
+++ b/packages/wrap/tests/requests.test.ts
@@ -28,6 +28,7 @@ describe('requests', () => {
   test('should create requests', () => {
     const request = removeLocations(
       createRequest({
+        subgraphName: undefined,
         targetOperation: 'query' as OperationTypeNode,
         targetFieldName: 'version',
         selectionSet: parseSelectionSet(`{

--- a/yarn.lock
+++ b/yarn.lock
@@ -5323,9 +5323,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@graphql-tools/utils@npm:10.8.6, @graphql-tools/utils@npm:^10.0.0, @graphql-tools/utils@npm:^10.0.3, @graphql-tools/utils@npm:^10.5.1, @graphql-tools/utils@npm:^10.5.4, @graphql-tools/utils@npm:^10.6.1, @graphql-tools/utils@npm:^10.6.2, @graphql-tools/utils@npm:^10.6.4, @graphql-tools/utils@npm:^10.7.2, @graphql-tools/utils@npm:^10.8.0, @graphql-tools/utils@npm:^10.8.1, @graphql-tools/utils@npm:^10.8.6":
-  version: 10.8.6
-  resolution: "@graphql-tools/utils@npm:10.8.6"
+"@graphql-tools/utils@npm:10.9.0-alpha-20250710200000-fde1c74a0c2fa4f651cbeed5b2091aeda7afb162":
+  version: 10.9.0-alpha-20250710200000-fde1c74a0c2fa4f651cbeed5b2091aeda7afb162
+  resolution: "@graphql-tools/utils@npm:10.9.0-alpha-20250710200000-fde1c74a0c2fa4f651cbeed5b2091aeda7afb162"
   dependencies:
     "@graphql-typed-document-node/core": "npm:^3.1.1"
     "@whatwg-node/promise-helpers": "npm:^1.0.0"
@@ -5334,30 +5334,7 @@ __metadata:
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10c0/17f727eb85415c15c5920ab9ef4648e0d205e1ca8b7d8539ac84f55da04ed60464313792456ebbde30bb883c0abde8df81919fd22f2ed5096b873920e84bef4b
-  languageName: node
-  linkType: hard
-
-"@graphql-tools/utils@npm:^8.5.2":
-  version: 8.13.1
-  resolution: "@graphql-tools/utils@npm:8.13.1"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10c0/f9bab1370aa91e706abec4c8ea980e15293cb78bd4effba53ad2365dc39d81148db7667b3ef89b35f0a0b0ad58081ffdac4264b7125c69fa8393590ae5025745
-  languageName: node
-  linkType: hard
-
-"@graphql-tools/utils@npm:^9.2.1":
-  version: 9.2.1
-  resolution: "@graphql-tools/utils@npm:9.2.1"
-  dependencies:
-    "@graphql-typed-document-node/core": "npm:^3.1.1"
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10c0/37a7bd7e14d28ff1bacc007dca84bc6cef2d7d7af9a547b5dbe52fcd134afddd6d4a7b2148cfbaff5ddba91a868453d597da77bd0457fb0be15928f916901606
+  checksum: 10c0/550a50fcfa9142dc7e40a96f69526be56efdb8ac4ba64b5dfe52400eeaaa40ea0e3724ead6c3248f811ac2cc8ceee59e9e0635349844242c1118e89d2b3033db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes a bug preventing `subgraphName` to be passed correctly to `fromClientToSubgraphs` when subgraph requests gets batched into a single execution request.

The root cause is more global: the gateway is using a weak map to keep track of the request execution's subgraph name. Which is why it breaks when the execution request is overriden. It was probably also impacting retry logic.

The fix is to move subgraph name directly to the `ExecutionRequest` type. This way, it is easier to track and discover for newcomers.

Related to #1311.