### PR TITLE
Fix non-nullable field error in batch execution

### DIFF
--- a/packages/batch-execute/src/splitResult.ts
+++ b/packages/batch-execute/src/splitResult.ts
@@ -10,7 +10,10 @@ export function splitResult(
   { data, errors }: ExecutionResult,
   numResults: number,
 ): Array<ExecutionResult> {
-  const splitResults = new Array<ExecutionResult>(numResults);
+  const splitResults: ExecutionResult[] = Array.from(
+    { length: numResults },
+    () => ({ data: null }),
+  );
 
   if (data) {
     for (const prefixedKey in data) {


### PR DESCRIPTION
I'm attempting to fix #1288 and as described in the discussion it seemed to be an issue with the mapping in batch execution. However after some debugging I noticed that the executor is failing within a try-catch and returning the error from `completeValue` so I'm not sure we can fix this at the batch execution level only.

One additional issue I found was within the results in DataLoader, so I had to change `splitResults` to match the number of expected results. This could potentially be removed if we find a way to better map the results before it gets there.

I added a couple of tests for both a single and multiple executions. The only way I could simulate an early exit with a null result within the executable schema was to add the type def without the resolver for it.

Let me know if you have any idea on the best way to move forward with this.