### PR TITLE
Run leak tests after unit tests in the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
           - 23
           - 24
     name: Leaks / Node v${{matrix.node-version}}
+    needs: [unit] # leak tests run unit tests but check for leaks; if unit tests fail, leaks will fail too - avoid confusion by running them in series
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Leak tests run unit tests but check for leaks, but they will also fail of the unit tests themselves fail. This can cause confusion seeing the CI all red in both unit and leak tests - while only unit tests are actually failing. (It also wastes resources)