### PR TITLE
feat(opentelemetry): Add getters for root spans contexts

### DIFF
--- a/.changeset/@graphql-hive_gateway-runtime-1360-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-runtime-1360-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+dependencies updates: 
+
+- Added dependency [`@opentelemetry/api@^1.9.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/api/v/1.9.0) (to `dependencies`)

--- a/.changeset/@graphql-mesh_plugin-opentelemetry-1360-dependencies.md
+++ b/.changeset/@graphql-mesh_plugin-opentelemetry-1360-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/plugin-opentelemetry': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@opentelemetry/auto-instrumentations-node@^0.62.1` ↗︎](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node/v/0.62.1) (from `^0.62.0`, in `dependencies`)

--- a/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch
+++ b/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch
@@ -1,5 +1,5 @@
 diff --git a/build/esnext/transport/http-exporter-transport.js b/build/esnext/transport/http-exporter-transport.js
-index 7977489487a2236fbd0e4c2273ef53fd3c7b93a8..93e9701d10f6aea530f38330daea87199e514452 100644
+index e63fda75feb67686bad9b692a046ebb1af2bd8a0..93e9701d10f6aea530f38330daea87199e514452 100644
 --- a/build/esnext/transport/http-exporter-transport.js
 +++ b/build/esnext/transport/http-exporter-transport.js
 @@ -20,7 +20,7 @@ class HttpExporterTransport {
@@ -21,7 +21,7 @@ index 7977489487a2236fbd0e4c2273ef53fd3c7b93a8..93e9701d10f6aea530f38330daea8719
          if (utils === null) {
              // Lazy require to ensure that http/https is not required before instrumentations can wrap it.
 -            const { sendWithHttp, createHttpAgent,
--            // eslint-disable-next-line @typescript-eslint/no-var-requires
+-            // eslint-disable-next-line @typescript-eslint/no-require-imports
 -             } = require('./http-transport-utils');
 +            const { sendWithHttp, createHttpAgent } = await import('./http-transport-utils');
              utils = this._utils = {

--- a/e2e/opentelemetry/opentelemetry.e2e.ts
+++ b/e2e/opentelemetry/opentelemetry.e2e.ts
@@ -60,7 +60,7 @@ type JaegerTraceSpan = {
 };
 
 describe('OpenTelemetry', () => {
-  (['grpc', 'http'] as const).forEach((OTLP_EXPORTER_TYPE) => {
+  (['http'] as const).forEach((OTLP_EXPORTER_TYPE) => {
     describe(`exporter > ${OTLP_EXPORTER_TYPE}`, () => {
       let jaeger: Container;
       beforeAll(async () => {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@graphql-mesh/utils": "0.104.6",
     "@graphql-tools/delegate": "workspace:^",
     "@graphql-tools/utils": "10.9.0-alpha-20250710200000-fde1c74a0c2fa4f651cbeed5b2091aeda7afb162",
+    "@opentelemetry/otlp-exporter-base@npm:0.203.0": "patch:@opentelemetry/otlp-exporter-base@npm%3A0.203.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch",
     "@rollup/plugin-node-resolve@npm:^15.2.3": "patch:@rollup/plugin-node-resolve@npm%3A16.0.1#~/.yarn/patches/@rollup-plugin-node-resolve-npm-16.0.1-2936474bab.patch",
     "@vitest/snapshot": "patch:@vitest/snapshot@npm:3.1.2#~/.yarn/patches/@vitest-snapshot-npm-3.1.1-4d18cf86dc.patch",
     "ansi-color@npm:^0.2.1": "patch:ansi-color@npm%3A0.2.1#~/.yarn/patches/ansi-color-npm-0.2.1-f7243d10a4.patch",
@@ -80,7 +81,6 @@
     "pkgroll": "patch:pkgroll@npm:2.5.1#~/.yarn/patches/pkgroll-npm-2.5.1-9b062c22ca.patch",
     "tar-fs": "3.0.10",
     "tsx": "patch:tsx@npm%3A4.20.3#~/.yarn/patches/tsx-npm-4.20.3-7de67a623f.patch",
-    "vite": "6.3.5",
-    "@opentelemetry/otlp-exporter-base@npm:0.203.0": "patch:@opentelemetry/otlp-exporter-base@npm%3A0.203.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch"
+    "vite": "6.3.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@graphql-mesh/utils": "0.104.6",
     "@graphql-tools/delegate": "workspace:^",
     "@graphql-tools/utils": "10.9.0-alpha-20250710200000-fde1c74a0c2fa4f651cbeed5b2091aeda7afb162",
-    "@opentelemetry/otlp-exporter-base@npm:0.202.0": "patch:@opentelemetry/otlp-exporter-base@npm%3A0.202.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.202.0-f6f29c2eeb.patch",
     "@rollup/plugin-node-resolve@npm:^15.2.3": "patch:@rollup/plugin-node-resolve@npm%3A16.0.1#~/.yarn/patches/@rollup-plugin-node-resolve-npm-16.0.1-2936474bab.patch",
     "@vitest/snapshot": "patch:@vitest/snapshot@npm:3.1.2#~/.yarn/patches/@vitest-snapshot-npm-3.1.1-4d18cf86dc.patch",
     "ansi-color@npm:^0.2.1": "patch:ansi-color@npm%3A0.2.1#~/.yarn/patches/ansi-color-npm-0.2.1-f7243d10a4.patch",
@@ -81,6 +80,7 @@
     "pkgroll": "patch:pkgroll@npm:2.5.1#~/.yarn/patches/pkgroll-npm-2.5.1-9b062c22ca.patch",
     "tar-fs": "3.0.10",
     "tsx": "patch:tsx@npm%3A4.20.3#~/.yarn/patches/tsx-npm-4.20.3-7de67a623f.patch",
-    "vite": "6.3.5"
+    "vite": "6.3.5",
+    "@opentelemetry/otlp-exporter-base@npm:0.203.0": "patch:@opentelemetry/otlp-exporter-base@npm%3A0.203.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch"
   }
 }

--- a/packages/plugins/opentelemetry/package.json
+++ b/packages/plugins/opentelemetry/package.json
@@ -62,7 +62,7 @@
     "@graphql-tools/utils": "^10.9.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.203.0",
-    "@opentelemetry/auto-instrumentations-node": "^0.62.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.62.1",
     "@opentelemetry/context-async-hooks": "^2.0.1",
     "@opentelemetry/core": "^2.0.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0",

--- a/packages/plugins/opentelemetry/src/index.ts
+++ b/packages/plugins/opentelemetry/src/index.ts
@@ -3,6 +3,7 @@ import {
   useOpenTelemetry,
   type OpenTelemetryGatewayPluginOptions,
   type OpenTelemetryPlugin,
+  type OpenTelemetryPluginUtils,
 } from './plugin';
 
 export * from './attributes';
@@ -13,4 +14,5 @@ export {
   useOpenTelemetry,
   OpenTelemetryPlugin,
   OpenTelemetryGatewayPluginOptions,
+  OpenTelemetryPluginUtils,
 };

--- a/packages/plugins/opentelemetry/src/plugin.ts
+++ b/packages/plugins/opentelemetry/src/plugin.ts
@@ -1,5 +1,6 @@
 import {
   Attributes,
+  GatewayConfigContext,
   getRetryInfo,
   isRetryExecutionRequest,
   Logger,
@@ -214,15 +215,30 @@ const HeadersTextMapGetter: TextMapGetter<Headers> = {
   },
 };
 
+export type ContextMatcher = {
+  request?: Request;
+  context?: any;
+  executionRequest?: ExecutionRequest;
+};
+
+export type OpenTelemetryPluginUtils = {
+  tracer?: Tracer;
+  getActiveContext: (payload: ContextMatcher) => Context;
+  getHttpContext: (request: Request) => Context | undefined;
+  getOperationContext: (context: any) => Context | undefined;
+  getExecutionRequestContext: (
+    ExecutionRequest: ExecutionRequest,
+  ) => Context | undefined;
+};
+
 export type OpenTelemetryContextExtension = {
-  openTelemetry: {
+  openTelemetry: Omit<
+    OpenTelemetryPluginUtils,
+    'getActiveContext' | 'tracer' | 'register'
+  > & {
     tracer: Tracer;
-    activeContext: () => Context;
-    httpContext: (request?: Request) => Context | undefined;
-    operationContext: (context?: any) => Context | undefined;
-    executionRequestContext: (
-      ExecutionRequest: ExecutionRequest,
-    ) => Context | undefined;
+    getActiveContext: (payload?: ContextMatcher) => Context;
+    register?: never;
   };
 };
 
@@ -234,25 +250,13 @@ type State = Partial<
   HttpState<OtelState> & GraphQLState<OtelState> & GatewayState<OtelState>
 >;
 
-export type OpenTelemetryPlugin =
-  GatewayPlugin<OpenTelemetryContextExtension> & {
-    getActiveContext: (payload: {
-      request?: Request;
-      context?: any;
-      executionRequest?: ExecutionRequest;
-    }) => Context;
-    getTracer(): Tracer;
-    getHttpContext: (request: Request) => Context | undefined;
-    getOperationContext: (context: any) => Context | undefined;
-    getExecutionRequestContext: (
-      ExecutionRequest: ExecutionRequest,
-    ) => Context | undefined;
-  };
+export type OpenTelemetryPlugin = GatewayPlugin<OpenTelemetryContextExtension> &
+  OpenTelemetryPluginUtils;
 
 export function useOpenTelemetry(
-  options: OpenTelemetryGatewayPluginOptions & {
-    log: Logger;
-  },
+  options: OpenTelemetryGatewayPluginOptions &
+    // We ask for a Partial context to still allow the usage as a Yoga plugin
+    Partial<GatewayConfigContext>,
 ): OpenTelemetryPlugin {
   const inheritContext = options.inheritContext ?? true;
   const propagateContext = options.propagateContext ?? true;
@@ -260,8 +264,11 @@ export function useOpenTelemetry(
   const traces = typeof options.traces === 'object' ? options.traces : {};
 
   let tracer: Tracer;
-  let pluginLogger: Logger;
   let initSpan: Context | null;
+
+  // TODO: Make it const once Yoga has the Hive Logger
+  let pluginLogger: Logger | undefined =
+    options.log && options.log.child('[OpenTelemetry] ');
 
   function isParentEnabled(state: State): boolean {
     const parentState = getMostSpecificState(state);
@@ -314,7 +321,7 @@ export function useOpenTelemetry(
 
     if (!useContextManager) {
       if (traces.spans?.schema) {
-        pluginLogger.warn(
+        pluginLogger?.warn(
           'Schema loading spans are disabled because no context manager is available',
         );
       }
@@ -324,13 +331,15 @@ export function useOpenTelemetry(
     }
   }
 
-  return withState<
+  const plugin = withState<
     OpenTelemetryPlugin,
     OtelState,
     OtelState & { skipExecuteSpan?: true; subgraphNames: string[] },
     OtelState
   >((getState) => ({
-    getTracer: () => tracer,
+    get tracer() {
+      return tracer;
+    },
     getActiveContext: ({ state }) => getContext(state),
     getHttpContext: (request) => {
       return getState({ request }).forRequest.otel?.root;
@@ -667,21 +676,17 @@ export function useOpenTelemetry(
     },
 
     onYogaInit({ yoga }) {
-      const log =
-        options.log ??
-        //TODO remove this when Yoga will also use the new Logger API
-        new Logger({
-          writers: [
-            {
-              write(level, attrs, msg) {
-                level = level === 'trace' ? 'debug' : level;
-                yoga.logger[level](msg, attrs);
-              },
+      //TODO remove this when Yoga will also use the new Logger API
+      pluginLogger ??= new Logger({
+        writers: [
+          {
+            write(level, attrs, msg) {
+              level = level === 'trace' ? 'debug' : level;
+              yoga.logger[level](msg, attrs);
             },
-          ],
-        });
-
-      pluginLogger = log.child('[OpenTelemetry] ');
+          },
+        ],
+      }).child('[OpenTelemetry] ');
 
       if (options.configureDiagLogger !== false) {
         const logLevel = diagLogLevelFromEnv(); // We enable the diag only if it is explicitly enabled, as NodeSDK does
@@ -704,7 +709,9 @@ export function useOpenTelemetry(
       try {
         const requestId = requestIdByRequest.get(request);
         if (requestId) {
-          loggerForRequest(options.log.child({ requestId }), request);
+          if (options.log) {
+            loggerForRequest(options.log.child({ requestId }), request);
+          }
 
           // When running in a runtime without a context manager, we have to keep track of the
           // span correlated to a log manually. For now, we just link all logs for a request to
@@ -714,7 +721,7 @@ export function useOpenTelemetry(
           }
         }
       } catch (error) {
-        pluginLogger.error(
+        pluginLogger!.error(
           { error },
           'Error while setting up logger for request',
         );
@@ -725,19 +732,19 @@ export function useOpenTelemetry(
       extendContext({
         openTelemetry: {
           tracer,
-          httpContext: (request) => {
+          getHttpContext: (request) => {
             const { forRequest } = request ? getState({ request }) : state;
             return forRequest.otel?.root;
           },
-          operationContext: (context) => {
+          getOperationContext: (context) => {
             const { forOperation } = context ? getState({ context }) : state;
             return forOperation.otel?.root;
           },
-          executionRequestContext: (executionRequest) => {
+          getExecutionRequestContext: (executionRequest) => {
             return getState({ executionRequest }).forSubgraphExecution.otel
               ?.root;
           },
-          activeContext: (contextMatcher?: Parameters<typeof getState>[0]) =>
+          getActiveContext: (contextMatcher?: Parameters<typeof getState>[0]) =>
             getContext(contextMatcher ? getState(contextMatcher) : state),
         },
       });
@@ -935,6 +942,16 @@ export function useOpenTelemetry(
       }
     },
   }));
+
+  if (options.openTelemetry) {
+    if (options.openTelemetry.register) {
+      options.openTelemetry?.register?.(plugin);
+    } else {
+      options.log?.warn('An OpenTelemetry plugin is already registered');
+    }
+  }
+
+  return plugin;
 }
 
 function shouldTrace<Args>(

--- a/packages/plugins/opentelemetry/src/plugin.ts
+++ b/packages/plugins/opentelemetry/src/plugin.ts
@@ -232,13 +232,14 @@ export type OpenTelemetryPluginUtils = {
 };
 
 export type OpenTelemetryContextExtension = {
-  openTelemetry: Omit<
-    OpenTelemetryPluginUtils,
-    'getActiveContext' | 'tracer' | 'register'
-  > & {
+  openTelemetry: {
     tracer: Tracer;
     getActiveContext: (payload?: ContextMatcher) => Context;
-    register?: never;
+    getHttpContext: (request?: Request) => Context | undefined;
+    getOperationContext: (context?: any) => Context | undefined;
+    getExecutionRequestContext: (
+      ExecutionRequest: ExecutionRequest,
+    ) => Context | undefined;
   };
 };
 

--- a/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
+++ b/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
@@ -481,7 +481,9 @@ describe('useOpenTelemetry', () => {
               const createSpan =
                 (name: string) =>
                 (
-                  matcher: Parameters<(typeof otelPlugin)['getActiveContext']>[0],
+                  matcher: Parameters<
+                    (typeof otelPlugin)['getActiveContext']
+                  >[0],
                 ) =>
                   otelPlugin
                     .getTracer()

--- a/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
+++ b/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
@@ -481,11 +481,11 @@ describe('useOpenTelemetry', () => {
               const createSpan =
                 (name: string) =>
                 (
-                  matcher: Parameters<(typeof otelPlugin)['getOtelContext']>[0],
+                  matcher: Parameters<(typeof otelPlugin)['getActiveContext']>[0],
                 ) =>
                   otelPlugin
                     .getTracer()
-                    .startSpan(name, {}, otelPlugin.getOtelContext(matcher))
+                    .startSpan(name, {}, otelPlugin.getActiveContext(matcher))
                     .end();
 
               return [

--- a/packages/plugins/opentelemetry/tests/utils.ts
+++ b/packages/plugins/opentelemetry/tests/utils.ts
@@ -28,17 +28,13 @@ import {
 import { AsyncDisposableStack } from '@whatwg-node/disposablestack';
 import { createSchema, createYoga, type GraphQLParams } from 'graphql-yoga';
 import { expect } from 'vitest';
-import type {
-  OpenTelemetryGatewayPluginOptions,
-  OpenTelemetryPlugin,
-} from '../src/plugin';
+import type { OpenTelemetryGatewayPluginOptions } from '../src/plugin';
 
 export async function buildTestGateway(
   options: {
     gatewayOptions?: Omit<GatewayConfigProxy, 'proxy'>;
     options?: OpenTelemetryGatewayPluginOptions;
     plugins?: (
-      otelPlugin: OpenTelemetryPlugin,
       ctx: GatewayConfigContext,
     ) => GatewayPlugin<OpenTelemetryGatewayPluginOptions>[];
     fetch?: (upstreamFetch: MeshFetch) => MeshFetch;
@@ -85,10 +81,10 @@ export async function buildTestGateway(
             options.fetch ? options.fetch(upstream.fetch) : upstream.fetch,
           ),
           otelPlugin,
-          ...(options.plugins?.(otelPlugin, ctx) ?? []),
+          ...(options.plugins?.(ctx) ?? []),
         ];
       },
-      logging: false,
+      logging: true,
       ...options.gatewayOptions,
     }),
   );

--- a/packages/plugins/opentelemetry/tests/yoga.spec.ts
+++ b/packages/plugins/opentelemetry/tests/yoga.spec.ts
@@ -99,7 +99,7 @@ describe('useOpenTelemetry', () => {
           }
         });
 
-        it.only('should allow to report custom spans', async () => {
+        it('should allow to report custom spans', async () => {
           const expectedCustomSpans = {
             http: { root: 'POST /graphql', children: ['custom.request'] },
             graphql: {

--- a/packages/plugins/opentelemetry/tests/yoga.spec.ts
+++ b/packages/plugins/opentelemetry/tests/yoga.spec.ts
@@ -2,6 +2,7 @@ import { Logger } from '@graphql-hive/logger';
 import { useOpenTelemetry } from '@graphql-mesh/plugin-opentelemetry';
 import { createSchema, createYoga, Plugin as YogaPlugin } from 'graphql-yoga';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { ContextMatcher } from '../src/plugin';
 import { disableAll, setupOtelForTests, spanExporter } from './utils';
 
 describe('useOpenTelemetry', () => {
@@ -59,6 +60,11 @@ describe('useOpenTelemetry', () => {
               body: JSON.stringify({ query: '{ hello }' }),
             });
             expect(response.status).toBe(200);
+            const result = await response.json();
+            if (result.errors) {
+              console.error('Graphql Errors:', result.errors);
+            }
+            expect(result.errors).not.toBeDefined();
           },
           [Symbol.asyncDispose]: async () => {
             await yoga.dispose();
@@ -93,7 +99,7 @@ describe('useOpenTelemetry', () => {
           }
         });
 
-        it('should allow to report custom spans', async () => {
+        it.only('should allow to report custom spans', async () => {
           const expectedCustomSpans = {
             http: { root: 'POST /graphql', children: ['custom.request'] },
             graphql: {
@@ -110,18 +116,11 @@ describe('useOpenTelemetry', () => {
           };
 
           await using yoga = buildTest({
-            plugins: (otelPlugin) => {
-              const createSpan =
-                (name: string) =>
-                (
-                  matcher: Parameters<
-                    (typeof otelPlugin)['getActiveContext']
-                  >[0],
-                ) =>
-                  otelPlugin
-                    .getTracer()
-                    .startSpan(name, {}, otelPlugin.getActiveContext(matcher))
-                    .end();
+            plugins: (openTelemetry) => {
+              const createSpan = (name: string) => (matcher: ContextMatcher) =>
+                openTelemetry.tracer
+                  ?.startSpan(name, {}, openTelemetry.getActiveContext(matcher))
+                  .end();
 
               return [
                 {

--- a/packages/plugins/opentelemetry/tests/yoga.spec.ts
+++ b/packages/plugins/opentelemetry/tests/yoga.spec.ts
@@ -114,11 +114,11 @@ describe('useOpenTelemetry', () => {
               const createSpan =
                 (name: string) =>
                 (
-                  matcher: Parameters<(typeof otelPlugin)['getOtelContext']>[0],
+                  matcher: Parameters<(typeof otelPlugin)['getActiveContext']>[0],
                 ) =>
                   otelPlugin
                     .getTracer()
-                    .startSpan(name, {}, otelPlugin.getOtelContext(matcher))
+                    .startSpan(name, {}, otelPlugin.getActiveContext(matcher))
                     .end();
 
               return [

--- a/packages/plugins/opentelemetry/tests/yoga.spec.ts
+++ b/packages/plugins/opentelemetry/tests/yoga.spec.ts
@@ -114,7 +114,9 @@ describe('useOpenTelemetry', () => {
               const createSpan =
                 (name: string) =>
                 (
-                  matcher: Parameters<(typeof otelPlugin)['getActiveContext']>[0],
+                  matcher: Parameters<
+                    (typeof otelPlugin)['getActiveContext']
+                  >[0],
                 ) =>
                   otelPlugin
                     .getTracer()

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -73,6 +73,7 @@
     "@graphql-yoga/plugin-csrf-prevention": "^3.15.1",
     "@graphql-yoga/plugin-defer-stream": "^3.15.1",
     "@graphql-yoga/plugin-persisted-operations": "^3.15.1",
+    "@opentelemetry/api": "^1.9.0",
     "@types/node": "^22.15.30",
     "@whatwg-node/disposablestack": "^0.0.6",
     "@whatwg-node/promise-helpers": "^1.3.0",

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -1082,7 +1082,7 @@ export function createGatewayRuntime<
       ...extraPlugins,
       ...(config.plugins?.(configContext) || []),
     ],
-    context({ request, params, req, connectionParams }) {
+    context({ request, req, connectionParams, ...ctx }) {
       let headers = // Maybe Node-like environment
         req?.headers
           ? getHeadersObj(req.headers)
@@ -1091,20 +1091,20 @@ export function createGatewayRuntime<
             ? getHeadersObj(request.headers)
             : // Unknown environment
               {};
+
       if (connectionParams) {
         headers = { ...headers, ...connectionParams };
       }
+
       const baseContext = {
         ...configContext,
-        request,
-        params,
+        // Give priority to the openTelemetry API defined by OTEL plugin
+        openTelemetry: ctx['openTelemetry'] ?? configContext.openTelemetry,
         headers,
         connectionParams: headers,
       };
-      if (contextBuilder) {
-        return contextBuilder(baseContext);
-      }
-      return baseContext;
+
+      return contextBuilder?.(baseContext) ?? baseContext;
     },
     cors: config.cors,
     graphiql: graphiqlOptionsOrFactory,

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -173,7 +173,7 @@ export function createGatewayRuntime<
     cwd: config.cwd || (typeof process !== 'undefined' ? process.cwd() : ''),
     cache: wrappedCache,
     pubsub,
-    openTelemetry: createOpenTelemetryAPI()
+    openTelemetry: createOpenTelemetryAPI(),
   };
 
   let unifiedGraphPlugin: GatewayPlugin;

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -125,6 +125,7 @@ import type {
 } from './types';
 import {
   checkIfDataSatisfiesSelectionSet,
+  createOpenTelemetryAPI,
   defaultQueryText,
   getExecuteFnFromExecutor,
   wrapCacheWithHooks,
@@ -172,6 +173,7 @@ export function createGatewayRuntime<
     cwd: config.cwd || (typeof process !== 'undefined' ? process.cwd() : ''),
     cache: wrappedCache,
     pubsub,
+    openTelemetry: createOpenTelemetryAPI()
   };
 
   let unifiedGraphPlugin: GatewayPlugin;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -39,6 +39,7 @@ import type {
   YogaServerOptions,
 } from 'graphql-yoga';
 import { GraphQLResolveInfo } from 'graphql/type';
+import { OpenTelemetryContextExtension } from '../../plugins/opentelemetry/src/plugin';
 import type { UnifiedGraphConfig } from './handleUnifiedGraphConfig';
 import type { UseContentEncodingOpts } from './plugins/useContentEncoding';
 import type { AgentFactory } from './plugins/useCustomAgent';
@@ -89,7 +90,8 @@ export interface GatewayConfigContext {
 }
 
 export interface GatewayContext
-  extends GatewayConfigContext,
+  extends Omit<GatewayConfigContext, 'openTelemetry'>,
+    OpenTelemetryContextExtension,
     YogaInitialContext {
   /**
    * Environment agnostic HTTP headers provided with the request.

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -9,6 +9,7 @@ import type {
   UnifiedGraphPlugin,
 } from '@graphql-mesh/fusion-runtime';
 import type { HMACUpstreamSignatureOptions } from '@graphql-mesh/hmac-upstream-signature';
+import { OpenTelemetryPluginUtils } from '@graphql-mesh/plugin-opentelemetry';
 import type { ResponseCacheConfig } from '@graphql-mesh/plugin-response-cache';
 import type {
   KeyValueCache,
@@ -79,6 +80,12 @@ export interface GatewayConfigContext {
    * Cache Storage
    */
   cache?: KeyValueCache;
+  /**
+   * OpenTelemetry API to get access to OTEL Tracer and Hive Gateway internal OTEL Contexts
+   */
+  openTelemetry: OpenTelemetryPluginUtils & {
+    register?: (plugin: OpenTelemetryPluginUtils) => void;
+  };
 }
 
 export interface GatewayContext

--- a/packages/runtime/tests/graphos.test.ts
+++ b/packages/runtime/tests/graphos.test.ts
@@ -8,6 +8,7 @@ import { TransportContext } from '@graphql-mesh/transport-common';
 import { Response } from '@whatwg-node/fetch';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createGraphOSFetcher } from '../src/fetchers/graphos';
+import { createOpenTelemetryAPI } from '../src/utils';
 
 describe('GraphOS', () => {
   describe('supergraph fetching', () => {
@@ -167,6 +168,7 @@ function createTestFetcher(
     configContext: {
       log,
       cwd: process.cwd(),
+      openTelemetry: createOpenTelemetryAPI(),
       ...configContext,
     },
     graphosOpts: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7758,6 +7758,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/otlp-exporter-base@patch:@opentelemetry/otlp-exporter-base@npm%3A0.203.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch":
+  version: 0.203.0
+  resolution: "@opentelemetry/otlp-exporter-base@patch:@opentelemetry/otlp-exporter-base@npm%3A0.203.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch::version=0.203.0&hash=301c6a"
+  dependencies:
+    "@opentelemetry/core": "npm:2.0.1"
+    "@opentelemetry/otlp-transformer": "npm:0.203.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/c90d352cdf5fa221d9ed185aace3d722a74629670a479153f0315f4824ac6efb9a85a2eb29c9eb6cda23cc912f2c483c3d5ecb100a23606019452836a26a6f88
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/otlp-grpc-exporter-base@npm:0.203.0":
   version: 0.203.0
   resolution: "@opentelemetry/otlp-grpc-exporter-base@npm:0.203.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4698,7 +4698,7 @@ __metadata:
     "@graphql-tools/utils": "npm:^10.9.1"
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/api-logs": "npm:^0.203.0"
-    "@opentelemetry/auto-instrumentations-node": "npm:^0.62.0"
+    "@opentelemetry/auto-instrumentations-node": "npm:^0.62.1"
     "@opentelemetry/context-async-hooks": "npm:^2.0.1"
     "@opentelemetry/core": "npm:^2.0.1"
     "@opentelemetry/exporter-trace-otlp-grpc": "npm:^0.203.0"
@@ -6948,19 +6948,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/auto-instrumentations-node@npm:^0.62.0":
-  version: 0.62.0
-  resolution: "@opentelemetry/auto-instrumentations-node@npm:0.62.0"
+"@opentelemetry/auto-instrumentations-node@npm:^0.62.1":
+  version: 0.62.1
+  resolution: "@opentelemetry/auto-instrumentations-node@npm:0.62.1"
   dependencies:
     "@opentelemetry/instrumentation": "npm:^0.203.0"
     "@opentelemetry/instrumentation-amqplib": "npm:^0.50.0"
     "@opentelemetry/instrumentation-aws-lambda": "npm:^0.54.0"
-    "@opentelemetry/instrumentation-aws-sdk": "npm:^0.56.0"
+    "@opentelemetry/instrumentation-aws-sdk": "npm:^0.57.0"
     "@opentelemetry/instrumentation-bunyan": "npm:^0.49.0"
     "@opentelemetry/instrumentation-cassandra-driver": "npm:^0.49.0"
     "@opentelemetry/instrumentation-connect": "npm:^0.47.0"
-    "@opentelemetry/instrumentation-cucumber": "npm:^0.18.0"
-    "@opentelemetry/instrumentation-dataloader": "npm:^0.21.0"
+    "@opentelemetry/instrumentation-cucumber": "npm:^0.18.1"
+    "@opentelemetry/instrumentation-dataloader": "npm:^0.21.1"
     "@opentelemetry/instrumentation-dns": "npm:^0.47.0"
     "@opentelemetry/instrumentation-express": "npm:^0.52.0"
     "@opentelemetry/instrumentation-fastify": "npm:^0.48.0"
@@ -6971,7 +6971,7 @@ __metadata:
     "@opentelemetry/instrumentation-hapi": "npm:^0.50.0"
     "@opentelemetry/instrumentation-http": "npm:^0.203.0"
     "@opentelemetry/instrumentation-ioredis": "npm:^0.51.0"
-    "@opentelemetry/instrumentation-kafkajs": "npm:^0.12.0"
+    "@opentelemetry/instrumentation-kafkajs": "npm:^0.13.0"
     "@opentelemetry/instrumentation-knex": "npm:^0.48.0"
     "@opentelemetry/instrumentation-koa": "npm:^0.51.0"
     "@opentelemetry/instrumentation-lru-memoizer": "npm:^0.48.0"
@@ -6979,20 +6979,20 @@ __metadata:
     "@opentelemetry/instrumentation-mongodb": "npm:^0.56.0"
     "@opentelemetry/instrumentation-mongoose": "npm:^0.50.0"
     "@opentelemetry/instrumentation-mysql": "npm:^0.49.0"
-    "@opentelemetry/instrumentation-mysql2": "npm:^0.49.0"
+    "@opentelemetry/instrumentation-mysql2": "npm:^0.50.0"
     "@opentelemetry/instrumentation-nestjs-core": "npm:^0.49.0"
     "@opentelemetry/instrumentation-net": "npm:^0.47.0"
     "@opentelemetry/instrumentation-oracledb": "npm:^0.29.0"
-    "@opentelemetry/instrumentation-pg": "npm:^0.55.0"
+    "@opentelemetry/instrumentation-pg": "npm:^0.56.0"
     "@opentelemetry/instrumentation-pino": "npm:^0.50.0"
     "@opentelemetry/instrumentation-redis": "npm:^0.51.0"
     "@opentelemetry/instrumentation-restify": "npm:^0.49.0"
     "@opentelemetry/instrumentation-router": "npm:^0.48.0"
-    "@opentelemetry/instrumentation-runtime-node": "npm:^0.17.0"
+    "@opentelemetry/instrumentation-runtime-node": "npm:^0.17.1"
     "@opentelemetry/instrumentation-socket.io": "npm:^0.50.0"
     "@opentelemetry/instrumentation-tedious": "npm:^0.22.0"
     "@opentelemetry/instrumentation-undici": "npm:^0.14.0"
-    "@opentelemetry/instrumentation-winston": "npm:^0.48.0"
+    "@opentelemetry/instrumentation-winston": "npm:^0.48.1"
     "@opentelemetry/resource-detector-alibaba-cloud": "npm:^0.31.3"
     "@opentelemetry/resource-detector-aws": "npm:^2.3.0"
     "@opentelemetry/resource-detector-azure": "npm:^0.10.0"
@@ -7003,7 +7003,7 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.4.1
     "@opentelemetry/core": ^2.0.0
-  checksum: 10c0/8598863a2c1227f33b142af3eb854b328b5194c9d270f7636b09b18843ef9b7475d49cb2952b469a667fe3f26492d1fe02802094954f95c40ccdb0c9d8e98bfa
+  checksum: 10c0/95782f56264b2733403b31cfc8c4203c38727a5da5544d1da0379633f276b3aa76d1169bb4c1b0fbe9831fdfd3b34e5aa3cf0c303b84fee08c3eea9d1b3a4902
   languageName: node
   linkType: hard
 
@@ -7258,9 +7258,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-aws-sdk@npm:^0.56.0":
-  version: 0.56.0
-  resolution: "@opentelemetry/instrumentation-aws-sdk@npm:0.56.0"
+"@opentelemetry/instrumentation-aws-sdk@npm:^0.57.0":
+  version: 0.57.0
+  resolution: "@opentelemetry/instrumentation-aws-sdk@npm:0.57.0"
   dependencies:
     "@opentelemetry/core": "npm:^2.0.0"
     "@opentelemetry/instrumentation": "npm:^0.203.0"
@@ -7268,7 +7268,7 @@ __metadata:
     "@opentelemetry/semantic-conventions": "npm:^1.34.0"
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: 10c0/b499de11511e72fbfb661f03c28a44c3136c08399a127b885daba955b9fbd322d12863062441d4db30e2cebe629e1b6782ebff96993f2e309015e29ce8ddc3c5
+  checksum: 10c0/74dbcc236f634e1018169ecdfef316b9ab164c573a5577b1c5b04843d5b3cab25dfa4feb4d85f256abd174a1226b6f664648f51c0e37c49f6b0ab0ca45818386
   languageName: node
   linkType: hard
 
@@ -7311,26 +7311,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-cucumber@npm:^0.18.0":
-  version: 0.18.0
-  resolution: "@opentelemetry/instrumentation-cucumber@npm:0.18.0"
+"@opentelemetry/instrumentation-cucumber@npm:^0.18.1":
+  version: 0.18.1
+  resolution: "@opentelemetry/instrumentation-cucumber@npm:0.18.1"
   dependencies:
     "@opentelemetry/instrumentation": "npm:^0.203.0"
     "@opentelemetry/semantic-conventions": "npm:^1.27.0"
   peerDependencies:
     "@opentelemetry/api": ^1.0.0
-  checksum: 10c0/48e86fdd71736a1ea7dc1e6dd602d460b49a08b25daa4512f3491c5acb47a44c9f278453fcb24b32977000ee6d3964a74ebd10251d1428a27d2272ef328bd24b
+  checksum: 10c0/85d72b038055ee03f1b40a72dea25e7bd6f54b72eaf37a6279a88ce98f9fae111c81623808fb6a78b325bff0303362a2f82cc41257753810619c6e0600ee2e63
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-dataloader@npm:^0.21.0":
-  version: 0.21.0
-  resolution: "@opentelemetry/instrumentation-dataloader@npm:0.21.0"
+"@opentelemetry/instrumentation-dataloader@npm:^0.21.1":
+  version: 0.21.1
+  resolution: "@opentelemetry/instrumentation-dataloader@npm:0.21.1"
   dependencies:
     "@opentelemetry/instrumentation": "npm:^0.203.0"
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: 10c0/70ed8f9f8f22c98fee685209c43494e4d40f8bf60934cd32865ba8adcf20a3e45c1a53677a3e744d5eba2f94a3733fa374ef5fa21a0e47b9e646d64e2067e156
+  checksum: 10c0/a9377dee842e48da4490fa1d35c064229e8b33f988be48aeb9d50a4dc000910e43b93f8f371ae8bddc2fc40a0f3c408f675af202c64c2ce0bd61791e216897e1
   languageName: node
   linkType: hard
 
@@ -7457,15 +7457,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-kafkajs@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "@opentelemetry/instrumentation-kafkajs@npm:0.12.0"
+"@opentelemetry/instrumentation-kafkajs@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "@opentelemetry/instrumentation-kafkajs@npm:0.13.0"
   dependencies:
     "@opentelemetry/instrumentation": "npm:^0.203.0"
     "@opentelemetry/semantic-conventions": "npm:^1.30.0"
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: 10c0/40c0979a99f39b6fe5b8c76e80206785f262ecf459e6c9859804188bf6d5f0755f4e5dccd75c8900997a477847a2a39813ed2ec439828c188b8fa7e9531165f0
+  checksum: 10c0/34b7d6ab7cde07657639dc9c5dc4f781f06ca199ffdab0ba93ab8008f63bb604a35c4ba49fdf5aa46c27ad06d7eafde2bf0bd071a60d1052ece63ac272e4135b
   languageName: node
   linkType: hard
 
@@ -7543,16 +7543,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-mysql2@npm:^0.49.0":
-  version: 0.49.0
-  resolution: "@opentelemetry/instrumentation-mysql2@npm:0.49.0"
+"@opentelemetry/instrumentation-mysql2@npm:^0.50.0":
+  version: 0.50.0
+  resolution: "@opentelemetry/instrumentation-mysql2@npm:0.50.0"
   dependencies:
     "@opentelemetry/instrumentation": "npm:^0.203.0"
     "@opentelemetry/semantic-conventions": "npm:^1.27.0"
     "@opentelemetry/sql-common": "npm:^0.41.0"
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: 10c0/c83614679dabb6e6783125574194bd50209a9526114d0ce01a786540724b45d845413b59acd38fdcb5f8af2719659d8e179bbd03f46f80ac9ff5b1bef6a38f3e
+  checksum: 10c0/09b44e155178918567493cc00b7c9afb2eb680666205cd020cf01e670bbd4e25547b911b77c97df51ffbef277af09c66646baaff1c08020f82edf37705afcf56
   languageName: node
   linkType: hard
 
@@ -7606,19 +7606,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-pg@npm:^0.55.0":
-  version: 0.55.0
-  resolution: "@opentelemetry/instrumentation-pg@npm:0.55.0"
+"@opentelemetry/instrumentation-pg@npm:^0.56.0":
+  version: 0.56.0
+  resolution: "@opentelemetry/instrumentation-pg@npm:0.56.0"
   dependencies:
     "@opentelemetry/core": "npm:^2.0.0"
     "@opentelemetry/instrumentation": "npm:^0.203.0"
-    "@opentelemetry/semantic-conventions": "npm:^1.27.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.34.0"
     "@opentelemetry/sql-common": "npm:^0.41.0"
     "@types/pg": "npm:8.15.4"
     "@types/pg-pool": "npm:2.0.6"
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: 10c0/f4054161e0ac0587463302ead4fe0c00bbeb181fb7693b5ee0dc72efa4d6817e7d93df2ab391c6db00cc7157589cf3d5e9b51bb0df0edaf0c88023a0ebce5a0d
+  checksum: 10c0/52c9af5da33e6755ea6b938ce64fdad57a1d55ccc931f09a7b512f1a51e09ad363cdecafe9d822c6ff955d152132ad3c4e18241aa599f291d41e10b93c1723aa
   languageName: node
   linkType: hard
 
@@ -7673,14 +7673,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-runtime-node@npm:^0.17.0":
-  version: 0.17.0
-  resolution: "@opentelemetry/instrumentation-runtime-node@npm:0.17.0"
+"@opentelemetry/instrumentation-runtime-node@npm:^0.17.1":
+  version: 0.17.1
+  resolution: "@opentelemetry/instrumentation-runtime-node@npm:0.17.1"
   dependencies:
     "@opentelemetry/instrumentation": "npm:^0.203.0"
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: 10c0/0f711a97e282d0a73b2b8dfa2a6887a6c954c976992ec44427e31759fc4affcef740e68bb3f5fa4b6d8dde7a23690d709fd602e1e8fbcffe15af4dc1e3838c54
+  checksum: 10c0/96e7b1191a15d986f89f98323cf20016b9d07e298ca5173750bab2ca144734827c5a4b7e7791c08a82f2b6cb690b9d68766f0023cb92ca2a9b8834b0b1797a6d
   languageName: node
   linkType: hard
 
@@ -7721,15 +7721,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-winston@npm:^0.48.0":
-  version: 0.48.0
-  resolution: "@opentelemetry/instrumentation-winston@npm:0.48.0"
+"@opentelemetry/instrumentation-winston@npm:^0.48.1":
+  version: 0.48.1
+  resolution: "@opentelemetry/instrumentation-winston@npm:0.48.1"
   dependencies:
     "@opentelemetry/api-logs": "npm:^0.203.0"
     "@opentelemetry/instrumentation": "npm:^0.203.0"
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: 10c0/a95aabb2a64dd3b3691f1745f01d7a9105ded465d46d8536ef5a22a2e22a12de250650331974d45f03fbbab5b07925e608ff8fe78032896ec0199af6c4c38a4b
+  checksum: 10c0/25392239f8155232d0dabfd8d182181ddc8b6d6bfeb0105e0ed2cc389aac4080f4dba1efdabb4b48a95ac64313fae13141e0f5dc3a3552907707a4ddb75c81a4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4133,6 +4133,7 @@ __metadata:
     "@graphql-yoga/plugin-defer-stream": "npm:^3.15.1"
     "@graphql-yoga/plugin-persisted-operations": "npm:^3.15.1"
     "@omnigraph/openapi": "npm:^0.109.11"
+    "@opentelemetry/api": "npm:^1.9.0"
     "@types/html-minifier-terser": "npm:^7.0.2"
     "@types/node": "npm:^22.15.30"
     "@types/react": "npm:^19"


### PR DESCRIPTION
Adds getters to the graphql context and the plugin instance to ease the access to the root spans (http, graphql operation and subgraph executions).

The goal is to allow users to easily modify (like adding custom attributes) to those spans.

There is 3 ways to access those utility functions: 
 - via the graphql context (so that it is accessible from the resolvers too).
 - via the Gateway Configuration Context, so that Hive plugins can easily have access to it
 - via the plugin instance itself, so that other Yoga plugins can easily have access to it

## Usage Examples

### From Graphql Context

```ts filename="gateway.config.ts"
import './telemetry.ts'
import { defineConfig } from '@graphql-hive/gateway'
import { trace } from '@opentelemetry/api'

export const gatewayConfig = defineConfig({
  openTelemetry: { traces: true },

  genericAuth: {
    mode: 'protect-granular',
    async resolveUserFn(ctx) {
      const token = ctx.request.headers.get('authorization')
      const user = await fetch(`https://auth/validate?token=${token}`).then(r => r.json)

      // When using from the graphql context, the function can automatically return 
      // the current request context without explicitly providing the request
      const httpSpan = trace.getSpan(ctx.opentelemetry.getHttpContext())
      httpSpan.setAttribute('auth.user.id', user?.id ?? '<unauthenticated>')

      return user
    }
  }
})
```

### From Hive Gateway Configuration Context

```ts filename="gateway.config.ts"
import './telemetry.ts'
import { defineConfig } from '@graphql-hive/gateway'
import { trace } from '@opentelemetry/api'

export const gatewayConfig = defineConfig({
  openTelemetry: { traces: true },
  plugins: (ctx) => {
    return [{
      onRequestParse({ request }) {
        const httpSpan = trace.getSpan(ctx.openTelemetry.getHttpContext({ request }))
        httpSpan?.setAttribute('session_id', request.headers.get('session-id'))
      },
    }]
  })
})
```

### From Yoga plugin

```ts filename="server.ts"
import './telemetry.ts'
import { createYoga } from 'graphql-yoga'
import { createServer } from 'node:http'
import { useOpenTelemetry } from '@graphql-mesh/plugin-opentelemetry'

const openTelemetry = useOpenTelemetry({ traces: true });

const yoga = createYoga({
  plugins: [
    openTelemetry,
    {
      onRequestParse({ request }) {
        // All utils functions are also available directly on the plugin instance
        const httpSpan = trace.getSpan(openTelemetry.getHttpContext({ request }))
        httpSpan?.setAttribute('session_id', request.headers.get('session-id'))
      },
    }
  ],
})

const server = createServer(yoga)
server.start(4000)
```