### PR TITLE
No need to retry Bun unit tests and less retries for E2Es

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,12 +47,8 @@ jobs:
         uses: the-guild-org/shared-config/setup@v1
         with:
           node-version-file: .node-version
-      - name: Run Tests
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: yarn test:bun
+      - name: Test
+        run: yarn test:bun
 
   leaks:
     strategy:
@@ -189,8 +185,8 @@ jobs:
       - name: Test
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
-          timeout_minutes: 30
-          max_attempts: 5
+          timeout_minutes: 10
+          max_attempts: 3
           command: yarn test:e2e
         env:
           E2E_GATEWAY_RUNNER: ${{matrix.setup.gateway-runner}}


### PR DESCRIPTION
Absolutely no need to retry failing E2Es 5 times. Either the external service is unavailable or the tests are really failing. Same goes for Bun unit tests - they should pass from the first go.