### PR TITLE
Update changesets and disable prettier formatting, exclude `examples` from dependabot

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,9 +1,10 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
     "@changesets/changelog-github",
     { "repo": "graphql-hive/gateway" }
   ],
+  "prettier": false,
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'daily'
+    exclude-paths:
+      - 'examples'
     groups:
       all-minor-patch:
         patterns:

--- a/.yarn/patches/@changesets-cli-npm-2.29.6-ac8361deb8.patch
+++ b/.yarn/patches/@changesets-cli-npm-2.29.6-ac8361deb8.patch
@@ -1,11 +1,11 @@
 diff --git a/dist/changesets-cli.cjs.js b/dist/changesets-cli.cjs.js
-index 986fdf27f1d85412f8a6b2f5cc026d811ea04372..1f9ce913c42e765c860ca97fff670c2f96c928fb 100644
+index 53fc925f8aa492e7333033483e9f3e45839963ad..81cc3183c9ce6097519c8a130ffc9f3087bca63c 100644
 --- a/dist/changesets-cli.cjs.js
 +++ b/dist/changesets-cli.cjs.js
-@@ -666,32 +666,6 @@ function getCorrectRegistry(packageJson) {
-   return !registry || registry === "https://registry.yarnpkg.com" ? "https://registry.npmjs.org" : registry;
+@@ -630,30 +630,6 @@ function getCorrectRegistry(packageJson) {
+     registry: !registry || registry === "https://registry.yarnpkg.com" ? "https://registry.npmjs.org" : registry
+   };
  }
- 
 -async function getPublishTool(cwd) {
 -  const pm = await packageManagerDetector.detect({
 -    cwd
@@ -13,7 +13,6 @@ index 986fdf27f1d85412f8a6b2f5cc026d811ea04372..1f9ce913c42e765c860ca97fff670c2f
 -  if (!pm || pm.name !== "pnpm") return {
 -    name: "npm"
 -  };
--
 -  try {
 -    let result = await spawn__default["default"]("pnpm", ["--version"], {
 -      cwd
@@ -31,30 +30,27 @@ index 986fdf27f1d85412f8a6b2f5cc026d811ea04372..1f9ce913c42e765c860ca97fff670c2f
 -    };
 -  }
 -}
--
  async function getTokenIsRequired() {
-   // Due to a super annoying issue in yarn, we have to manually override this env variable
-   // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
-@@ -783,7 +757,6 @@ let getOtpCode = async twoFactorState => {
+   const {
+     scope,
+@@ -744,16 +720,12 @@ let getOtpCode = async twoFactorState => {
+ // we have this so that we can do try a publish again after a publish without
  // the call being wrapped in the npm request limit and causing the publishes to potentially never run
- 
- async function internalPublish(pkgName, opts, twoFactorState) {
+ async function internalPublish(packageJson, opts, twoFactorState) {
 -  let publishTool = await getPublishTool(opts.cwd);
    let publishFlags = opts.access ? ["--access", opts.access] : [];
    publishFlags.push("--tag", opts.tag);
- 
-@@ -792,9 +765,7 @@ async function internalPublish(pkgName, opts, twoFactorState) {
+   if ((await twoFactorState.isRequired) && !ciInfo.isCI) {
+     let otpCode = await getOtpCode(twoFactorState);
      publishFlags.push("--otp", otpCode);
    }
- 
 -  if (publishTool.name === "pnpm" && publishTool.shouldAddNoGitChecks) {
 -    publishFlags.push("--no-git-checks");
--  } // Due to a super annoying issue in yarn, we have to manually override this env variable
-+  // Due to a super annoying issue in yarn, we have to manually override this env variable
-   // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
- 
- 
-@@ -805,11 +776,9 @@ async function internalPublish(pkgName, opts, twoFactorState) {
+-  }
+   const {
+     scope,
+     registry
+@@ -768,11 +740,9 @@ async function internalPublish(packageJson, opts, twoFactorState) {
      code,
      stdout,
      stderr
@@ -65,16 +61,16 @@ index 986fdf27f1d85412f8a6b2f5cc026d811ea04372..1f9ce913c42e765c860ca97fff670c2f
 -  }) : await spawn__default["default"](publishTool.name, ["publish", opts.publishDir, "--json", ...publishFlags], {
 -    env: Object.assign({}, process.env, envOverride)
    });
- 
    if (code !== 0) {
+     // NPM's --json output is included alongside the `prepublish` and `postpublish` output in terminal
 diff --git a/dist/changesets-cli.esm.js b/dist/changesets-cli.esm.js
-index f0c19f8f1130425be51c04743abd9f8f078ea840..976a84000179394fff29a180c4de63c67d565154 100644
+index 6c363c0551d7a5b69e2e48be0bcd757699609094..0981b98e21ef371ba3eb6a996a05046671736b57 100644
 --- a/dist/changesets-cli.esm.js
 +++ b/dist/changesets-cli.esm.js
-@@ -628,32 +628,6 @@ function getCorrectRegistry(packageJson) {
-   return !registry || registry === "https://registry.yarnpkg.com" ? "https://registry.npmjs.org" : registry;
+@@ -592,30 +592,6 @@ function getCorrectRegistry(packageJson) {
+     registry: !registry || registry === "https://registry.yarnpkg.com" ? "https://registry.npmjs.org" : registry
+   };
  }
- 
 -async function getPublishTool(cwd) {
 -  const pm = await detect({
 -    cwd
@@ -82,7 +78,6 @@ index f0c19f8f1130425be51c04743abd9f8f078ea840..976a84000179394fff29a180c4de63c6
 -  if (!pm || pm.name !== "pnpm") return {
 -    name: "npm"
 -  };
--
 -  try {
 -    let result = await spawn$1("pnpm", ["--version"], {
 -      cwd
@@ -100,30 +95,27 @@ index f0c19f8f1130425be51c04743abd9f8f078ea840..976a84000179394fff29a180c4de63c6
 -    };
 -  }
 -}
--
  async function getTokenIsRequired() {
-   // Due to a super annoying issue in yarn, we have to manually override this env variable
-   // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
-@@ -745,7 +719,6 @@ let getOtpCode = async twoFactorState => {
+   const {
+     scope,
+@@ -706,16 +682,12 @@ let getOtpCode = async twoFactorState => {
+ // we have this so that we can do try a publish again after a publish without
  // the call being wrapped in the npm request limit and causing the publishes to potentially never run
- 
- async function internalPublish(pkgName, opts, twoFactorState) {
+ async function internalPublish(packageJson, opts, twoFactorState) {
 -  let publishTool = await getPublishTool(opts.cwd);
    let publishFlags = opts.access ? ["--access", opts.access] : [];
    publishFlags.push("--tag", opts.tag);
- 
-@@ -754,9 +727,7 @@ async function internalPublish(pkgName, opts, twoFactorState) {
+   if ((await twoFactorState.isRequired) && !isCI) {
+     let otpCode = await getOtpCode(twoFactorState);
      publishFlags.push("--otp", otpCode);
    }
- 
 -  if (publishTool.name === "pnpm" && publishTool.shouldAddNoGitChecks) {
 -    publishFlags.push("--no-git-checks");
--  } // Due to a super annoying issue in yarn, we have to manually override this env variable
-+  // Due to a super annoying issue in yarn, we have to manually override this env variable
-   // See: https://github.com/yarnpkg/yarn/issues/2935#issuecomment-355292633
- 
- 
-@@ -767,11 +738,9 @@ async function internalPublish(pkgName, opts, twoFactorState) {
+-  }
+   const {
+     scope,
+     registry
+@@ -730,11 +702,9 @@ async function internalPublish(packageJson, opts, twoFactorState) {
      code,
      stdout,
      stderr
@@ -134,5 +126,5 @@ index f0c19f8f1130425be51c04743abd9f8f078ea840..976a84000179394fff29a180c4de63c6
 -  }) : await spawn$1(publishTool.name, ["publish", opts.publishDir, "--json", ...publishFlags], {
 -    env: Object.assign({}, process.env, envOverride)
    });
- 
    if (code !== 0) {
+     // NPM's --json output is included alongside the `prepublish` and `postpublish` output in terminal

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-env": "7.28.0",
     "@babel/preset-typescript": "7.27.1",
     "@changesets/changelog-github": "^0.5.0",
-    "@changesets/cli": "patch:@changesets/cli@npm:2.27.9#~/.yarn/patches/@changesets-cli-npm-2.27.9-5df61a909e.patch",
+    "@changesets/cli": "patch:@changesets/cli@npm%3A2.29.6#~/.yarn/patches/@changesets-cli-npm-2.29.6-ac8361deb8.patch",
     "@ianvs/prettier-plugin-sort-imports": "4.5.1",
     "@tsconfig/strictest": "2.0.5",
     "@types/node": "22.15.32",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2543,7 +2543,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/apply-release-plan@npm:^7.0.5":
+"@changesets/apply-release-plan@npm:^7.0.12":
   version: 7.0.12
   resolution: "@changesets/apply-release-plan@npm:7.0.12"
   dependencies:
@@ -2564,9 +2564,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/assemble-release-plan@npm:^6.0.4, @changesets/assemble-release-plan@npm:^6.0.8":
-  version: 6.0.8
-  resolution: "@changesets/assemble-release-plan@npm:6.0.8"
+"@changesets/assemble-release-plan@npm:^6.0.9":
+  version: 6.0.9
+  resolution: "@changesets/assemble-release-plan@npm:6.0.9"
   dependencies:
     "@changesets/errors": "npm:^0.2.0"
     "@changesets/get-dependents-graph": "npm:^2.1.3"
@@ -2574,11 +2574,11 @@ __metadata:
     "@changesets/types": "npm:^6.1.0"
     "@manypkg/get-packages": "npm:^1.1.3"
     semver: "npm:^7.5.3"
-  checksum: 10c0/b3e133a22896b1a5d5ffeaa8aed2ad044997ceda9fce6327bbcb6c56ba426d9d2df502fa003ae6d6ad6263e6a5d039761bfeaab62c884c825b99fb4cbdd1c42f
+  checksum: 10c0/128f87975f65d9ceb2c997df186a5deae8637fd3868098bb4fb9772f35fdd3b47883ccbdc2761d0468e60a83ef4e2c1561a8e58f8052bfe2daf1ea046803fe1a
   languageName: node
   linkType: hard
 
-"@changesets/changelog-git@npm:^0.2.0":
+"@changesets/changelog-git@npm:^0.2.1":
   version: 0.2.1
   resolution: "@changesets/changelog-git@npm:0.2.1"
   dependencies:
@@ -2598,29 +2598,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/cli@npm:2.27.9":
-  version: 2.27.9
-  resolution: "@changesets/cli@npm:2.27.9"
+"@changesets/cli@npm:2.29.6":
+  version: 2.29.6
+  resolution: "@changesets/cli@npm:2.29.6"
   dependencies:
-    "@changesets/apply-release-plan": "npm:^7.0.5"
-    "@changesets/assemble-release-plan": "npm:^6.0.4"
-    "@changesets/changelog-git": "npm:^0.2.0"
-    "@changesets/config": "npm:^3.0.3"
+    "@changesets/apply-release-plan": "npm:^7.0.12"
+    "@changesets/assemble-release-plan": "npm:^6.0.9"
+    "@changesets/changelog-git": "npm:^0.2.1"
+    "@changesets/config": "npm:^3.1.1"
     "@changesets/errors": "npm:^0.2.0"
-    "@changesets/get-dependents-graph": "npm:^2.1.2"
-    "@changesets/get-release-plan": "npm:^4.0.4"
-    "@changesets/git": "npm:^3.0.1"
+    "@changesets/get-dependents-graph": "npm:^2.1.3"
+    "@changesets/get-release-plan": "npm:^4.0.13"
+    "@changesets/git": "npm:^3.0.4"
     "@changesets/logger": "npm:^0.1.1"
-    "@changesets/pre": "npm:^2.0.1"
-    "@changesets/read": "npm:^0.6.1"
-    "@changesets/should-skip-package": "npm:^0.1.1"
-    "@changesets/types": "npm:^6.0.0"
-    "@changesets/write": "npm:^0.3.2"
+    "@changesets/pre": "npm:^2.0.2"
+    "@changesets/read": "npm:^0.6.5"
+    "@changesets/should-skip-package": "npm:^0.1.2"
+    "@changesets/types": "npm:^6.1.0"
+    "@changesets/write": "npm:^0.4.0"
+    "@inquirer/external-editor": "npm:^1.0.0"
     "@manypkg/get-packages": "npm:^1.1.3"
     ansi-colors: "npm:^4.1.3"
     ci-info: "npm:^3.7.0"
-    enquirer: "npm:^2.3.0"
-    external-editor: "npm:^3.1.0"
+    enquirer: "npm:^2.4.1"
     fs-extra: "npm:^7.0.1"
     mri: "npm:^1.2.0"
     p-limit: "npm:^2.2.0"
@@ -2628,53 +2628,15 @@ __metadata:
     picocolors: "npm:^1.1.0"
     resolve-from: "npm:^5.0.0"
     semver: "npm:^7.5.3"
-    spawndamnit: "npm:^2.0.0"
+    spawndamnit: "npm:^3.0.1"
     term-size: "npm:^2.1.0"
   bin:
     changeset: bin.js
-  checksum: 10c0/bcd651aa177eb58eaee4c3c86f961c5411dbe7c77a9b421d22cd4a422f4802795d1cd51be6769c16bb30d3f88dc8a06ab4977fc6457430373b680fd5ee59b59a
+  checksum: 10c0/6e09201df1bc83f45526f7ab3d77b1171c2c74e89639993367acf183b9d0809d02845b9d900f34a5febcd1a963cdad7246e2b9c444da2440760d297aad3aff32
   languageName: node
   linkType: hard
 
-"@changesets/cli@patch:@changesets/cli@npm:2.27.9#~/.yarn/patches/@changesets-cli-npm-2.27.9-5df61a909e.patch":
-  version: 2.27.9
-  resolution: "@changesets/cli@patch:@changesets/cli@npm%3A2.27.9#~/.yarn/patches/@changesets-cli-npm-2.27.9-5df61a909e.patch::version=2.27.9&hash=b5de50"
-  dependencies:
-    "@changesets/apply-release-plan": "npm:^7.0.5"
-    "@changesets/assemble-release-plan": "npm:^6.0.4"
-    "@changesets/changelog-git": "npm:^0.2.0"
-    "@changesets/config": "npm:^3.0.3"
-    "@changesets/errors": "npm:^0.2.0"
-    "@changesets/get-dependents-graph": "npm:^2.1.2"
-    "@changesets/get-release-plan": "npm:^4.0.4"
-    "@changesets/git": "npm:^3.0.1"
-    "@changesets/logger": "npm:^0.1.1"
-    "@changesets/pre": "npm:^2.0.1"
-    "@changesets/read": "npm:^0.6.1"
-    "@changesets/should-skip-package": "npm:^0.1.1"
-    "@changesets/types": "npm:^6.0.0"
-    "@changesets/write": "npm:^0.3.2"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    ansi-colors: "npm:^4.1.3"
-    ci-info: "npm:^3.7.0"
-    enquirer: "npm:^2.3.0"
-    external-editor: "npm:^3.1.0"
-    fs-extra: "npm:^7.0.1"
-    mri: "npm:^1.2.0"
-    p-limit: "npm:^2.2.0"
-    package-manager-detector: "npm:^0.2.0"
-    picocolors: "npm:^1.1.0"
-    resolve-from: "npm:^5.0.0"
-    semver: "npm:^7.5.3"
-    spawndamnit: "npm:^2.0.0"
-    term-size: "npm:^2.1.0"
-  bin:
-    changeset: bin.js
-  checksum: 10c0/84bae9b6a339122d409920bd0f5a7954b10431168d6f2b249b86b633eafb1d52c9cd7d22a921f1892c0ab932b68206fbc8877f5297ba086e692088ec6ec63732
-  languageName: node
-  linkType: hard
-
-"@changesets/config@npm:^3.0.3, @changesets/config@npm:^3.1.1":
+"@changesets/config@npm:^3.1.1":
   version: 3.1.1
   resolution: "@changesets/config@npm:3.1.1"
   dependencies:
@@ -2698,7 +2660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/get-dependents-graph@npm:^2.1.2, @changesets/get-dependents-graph@npm:^2.1.3":
+"@changesets/get-dependents-graph@npm:^2.1.3":
   version: 2.1.3
   resolution: "@changesets/get-dependents-graph@npm:2.1.3"
   dependencies:
@@ -2720,17 +2682,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/get-release-plan@npm:^4.0.4":
-  version: 4.0.12
-  resolution: "@changesets/get-release-plan@npm:4.0.12"
+"@changesets/get-release-plan@npm:^4.0.13":
+  version: 4.0.13
+  resolution: "@changesets/get-release-plan@npm:4.0.13"
   dependencies:
-    "@changesets/assemble-release-plan": "npm:^6.0.8"
+    "@changesets/assemble-release-plan": "npm:^6.0.9"
     "@changesets/config": "npm:^3.1.1"
     "@changesets/pre": "npm:^2.0.2"
     "@changesets/read": "npm:^0.6.5"
     "@changesets/types": "npm:^6.1.0"
     "@manypkg/get-packages": "npm:^1.1.3"
-  checksum: 10c0/bab1233d7e0c2259b706c4710aecafa4c97f4ad8bbcc1adfb51da86e5691a55257224b7ea49b01723e2a3d93378da63cf815b1fa92e30aa8247b92db1ead6148
+  checksum: 10c0/908fea784ced29764e02065da6d3d0f1e6590d1c8ac77504efe5879ef183de7a01b2da0be210caa28fc10159125da10540f4bcb6917d371988e50c5b984edd07
   languageName: node
   linkType: hard
 
@@ -2741,7 +2703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/git@npm:^3.0.1, @changesets/git@npm:^3.0.4":
+"@changesets/git@npm:^3.0.4":
   version: 3.0.4
   resolution: "@changesets/git@npm:3.0.4"
   dependencies:
@@ -2773,7 +2735,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/pre@npm:^2.0.1, @changesets/pre@npm:^2.0.2":
+"@changesets/pre@npm:^2.0.2":
   version: 2.0.2
   resolution: "@changesets/pre@npm:2.0.2"
   dependencies:
@@ -2785,7 +2747,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/read@npm:^0.6.1, @changesets/read@npm:^0.6.5":
+"@changesets/read@npm:^0.6.5":
   version: 0.6.5
   resolution: "@changesets/read@npm:0.6.5"
   dependencies:
@@ -2800,7 +2762,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/should-skip-package@npm:^0.1.1, @changesets/should-skip-package@npm:^0.1.2":
+"@changesets/should-skip-package@npm:^0.1.2":
   version: 0.1.2
   resolution: "@changesets/should-skip-package@npm:0.1.2"
   dependencies:
@@ -2817,22 +2779,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/types@npm:^6.0.0, @changesets/types@npm:^6.1.0":
+"@changesets/types@npm:^6.1.0":
   version: 6.1.0
   resolution: "@changesets/types@npm:6.1.0"
   checksum: 10c0/b4cea3a4465d1eaf0bbd7be1e404aca5a055a61d4cc72aadcb73bbbda1670b4022736b8d3052616cbf1f451afa0637545d077697f4b923236539af9cd5abce6c
   languageName: node
   linkType: hard
 
-"@changesets/write@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "@changesets/write@npm:0.3.2"
+"@changesets/write@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@changesets/write@npm:0.4.0"
   dependencies:
-    "@changesets/types": "npm:^6.0.0"
+    "@changesets/types": "npm:^6.1.0"
     fs-extra: "npm:^7.0.1"
-    human-id: "npm:^1.0.2"
+    human-id: "npm:^4.1.1"
     prettier: "npm:^2.7.1"
-  checksum: 10c0/1e00af0a82a780f74e03359d672690b35b6c788891e515a37488fca756109471f0d2da4904185b758a38d26e5cc2f426de4a2201ca3b6e26cf03ab747773690f
+  checksum: 10c0/311f4d0e536d1b5f2d3f9053537d62b2d4cdbd51e1d2767807ac9d1e0f380367f915d2ad370e5c73902d5a54bffd282d53fff5418c8ad31df51751d652bea826
   languageName: node
   linkType: hard
 
@@ -6053,6 +6015,21 @@ __metadata:
   version: 0.33.5
   resolution: "@img/sharp-win32-x64@npm:0.33.5"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@inquirer/external-editor@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@inquirer/external-editor@npm:1.0.1"
+  dependencies:
+    chardet: "npm:^2.1.0"
+    iconv-lite: "npm:^0.6.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/bdac4395e0bba7065d39b141d618bfc06369f246c402c511396a5238baf2657f3038ccba8438521a49e5cb602f4302b9d1f46b52b647b27af2c9911720022118
   languageName: node
   linkType: hard
 
@@ -11359,10 +11336,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chardet@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "chardet@npm:0.7.0"
-  checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
+"chardet@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "chardet@npm:2.1.0"
+  checksum: 10c0/d1b03e47371851ed72741a898281d58f8a9b577aeea6fdfa75a86832898b36c550b3ad057e66d50d774a9cebd9f56c66b6880e4fe75e387794538ba7565b0b6f
   languageName: node
   linkType: hard
 
@@ -12495,7 +12472,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enquirer@npm:^2.3.0, enquirer@npm:^2.3.6":
+"enquirer@npm:^2.3.6, enquirer@npm:^2.4.1":
   version: 2.4.1
   resolution: "enquirer@npm:2.4.1"
   dependencies:
@@ -13232,17 +13209,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"external-editor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "external-editor@npm:3.1.0"
-  dependencies:
-    chardet: "npm:^0.7.0"
-    iconv-lite: "npm:^0.4.24"
-    tmp: "npm:^0.0.33"
-  checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
-  languageName: node
-  linkType: hard
-
 "extract-files@npm:13.0.0":
   version: 13.0.0
   resolution: "extract-files@npm:13.0.0"
@@ -13869,7 +13835,7 @@ __metadata:
     "@babel/preset-env": "npm:7.28.0"
     "@babel/preset-typescript": "npm:7.27.1"
     "@changesets/changelog-github": "npm:^0.5.0"
-    "@changesets/cli": "patch:@changesets/cli@npm:2.27.9#~/.yarn/patches/@changesets-cli-npm-2.27.9-5df61a909e.patch"
+    "@changesets/cli": "npm:2.29.6"
     "@ianvs/prettier-plugin-sort-imports": "npm:4.5.1"
     "@tsconfig/strictest": "npm:2.0.5"
     "@types/node": "npm:22.15.32"
@@ -14590,10 +14556,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"human-id@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "human-id@npm:1.0.2"
-  checksum: 10c0/e4c3be49b3927ff8ac54ae4a95ed77ad94fd793b57be51aff39aa81931c6efe56303ce1ec76a70c74f85748644207c89ccfa63d828def1313eff7526a14c3b3b
+"human-id@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "human-id@npm:4.1.1"
+  bin:
+    human-id: dist/cli.js
+  checksum: 10c0/9a9a18130fb7d6bc707054bacc32cb328289be0de47ba5669fd04995435e7e59931b87c644a223d68473c450221d104175a5fefe93d77f3522822ead8945def8
   languageName: node
   linkType: hard
 
@@ -14613,7 +14581,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
+"iconv-lite@npm:0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
   dependencies:
@@ -19593,16 +19561,6 @@ __metadata:
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
-  languageName: node
-  linkType: hard
-
-"spawndamnit@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "spawndamnit@npm:2.0.0"
-  dependencies:
-    cross-spawn: "npm:^5.1.0"
-    signal-exit: "npm:^3.0.2"
-  checksum: 10c0/3d3aa1b750130a78cad591828c203e706cb132fbd7dccab8ae5354984117cd1464c7f9ef6c4756e6590fec16bab77fe2c85d1eb8e59006d303836007922d359c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #1415

Just look at any publish GitHub Action workflow's release step before this PR, [like this one](https://github.com/graphql-hive/gateway/actions/runs/17323618968/job/49182302804?pr=1409), it's polluted with prettier parsing errors that can confuse the viewer in thinking the publish didnt work - but it did. Simply disable prettier formatting (we anyway ignore the CHANGELOG.mds)