### PR TITLE
Skip parent-entity-call test suite for coordinated PR

### DIFF
--- a/packages/federation/tests/federation-compatibility.test.ts
+++ b/packages/federation/tests/federation-compatibility.test.ts
@@ -64,6 +64,10 @@ describe('Federation Compatibility', () => {
   });
 
   for (const supergraphName of supergraphList) {
+    if (supergraphName === 'parent-entity-call') {
+      // Skip parent-entity-call test suite - to be enabled with coordinated audit repo changes
+      continue;
+    }
     describe(supergraphName, () => {
       let stitchedSchema: GraphQLSchema;
       let supergraphSdl: string;

--- a/packages/stitch/src/getFieldsNotInSubschema.ts
+++ b/packages/stitch/src/getFieldsNotInSubschema.ts
@@ -143,35 +143,6 @@ export function getFieldsNotInSubschema(
           fieldsNotInSchema.add(subFieldNode);
         }
       }
-    } else {
-      for (const subFieldNode of subFieldNodes) {
-        const unavailableFields = extractUnavailableFields(
-          sourceSchema,
-          field,
-          subFieldNode,
-          (fieldType) => {
-            if (
-              stitchingInfo.mergedTypes[fieldType.name]?.resolvers.get(
-                subschema,
-              )
-            ) {
-              return false;
-            }
-            return true;
-          },
-          fragments,
-        );
-        if (unavailableFields.length) {
-          fieldNotInSchema = true;
-          fieldsNotInSchema.add({
-            ...subFieldNode,
-            selectionSet: {
-              kind: Kind.SELECTION_SET,
-              selections: unavailableFields,
-            },
-          });
-        }
-      }
     }
     const isComputedField =
       subschema.merge?.[gatewayType.name]?.fields?.[fieldName]?.computed;


### PR DESCRIPTION
# Disable parent-entity-call feature in schema stitching

## Summary
This PR disables the parent-entity-call feature introduced in recent versions [PR 6117](https://github.com/ardatan/graphql-tools/pull/6117) of the schema stitching library. This change is necessary to maintain backwards compatibility with our existing implementation while we work on a long-term solution to address underlying schema design issues.

## Changes
- Disabled the parent-entity-call feature in the gateway
- Skipped parent-entity-call test suite until audit repo changes are merged
  - Updated related tests to expect null values for unresolved fields

## Motivation
Recent updates to the schema stitching library (PRs [#6117](https://github.com/ardatan/graphql-tools/pull/6117) and [#6092](https://github.com/ardatan/graphql-tools/pull/6092)) introduced changes in how the query planner resolves fields across multiple subschemas. While these changes fix a bug, within our enterprise usecase, they create unexpected additional traffic to our subschemas and break existing functionality in our implementation.

### Enterprise Impact
As one of the large enterprise users of this library, we have built significant business-critical functionality based on the previous behavior. While we acknowledge we're depending on what was technically a bug in the previous version:

1. The current implementation is deeply integrated into our production systems
1. An immediate migration to the new behavior would require significant coordination across multiple teams and services
1. The additional cross-schema resolution attempts would create substantial unnecessary load on our production systems

## Short-term Solution
This PR provides a temporary solution and demonstrates a way to switch off this feature and revert to the previous behavior, so that we could introduce a new config to turn it off, allowing us to:
- Maintain system stability
- Prevent unexpected production issues
- Give us time to properly plan and execute the migration

## Long-term Plan
We are committed to:
1. Conducting a comprehensive schema quality audit
2. Developing a proper schema design that aligns with the intended behavior
3. Creating a controlled migration path that doesn't disrupt business operations
4. Working with the community to implement these changes in a sustainable way

## Testing
All test cases have passed successfully, except for the intentionally skipped parent-entity-call tests.

## Reviewers
@DenisBadurina

Please review to ensure there are no unintended side effects on other features.
