### PR TITLE
Propagate headers options payloads contain the execution context

### DIFF
--- a/.changeset/clever-cougars-notice.md
+++ b/.changeset/clever-cougars-notice.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Define user/plugin extended context generics as partial

--- a/.changeset/honest-sheep-remember.md
+++ b/.changeset/honest-sheep-remember.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Propagate headers options payloads contain the execution context

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,9 +102,11 @@ jobs:
           - workflow-name: Node Binary on Ubuntu
             os: ubuntu-latest
             gateway-runner: bin
-          - workflow-name: Node Binary on Windows
-            os: windows-latest
-            gateway-runner: bin
+          # TODO: windows started failing wirdly, enable when fixed
+          # https://github.com/graphql-hive/gateway/pull/1446
+          # - workflow-name: Node Binary on Windows
+          #   os: windows-latest
+          #   gateway-runner: bin
 
           # Should be the same with Linux
           # - workflow-name: Node Binary on MacOS Arm64

--- a/e2e/graphos-polling/services/gateway-fastify.ts
+++ b/e2e/graphos-polling/services/gateway-fastify.ts
@@ -58,7 +58,7 @@ const gw = createGatewayRuntime<FastifyContext>({
     // Use the same header name as Fastify
     headerName: requestIdHeader,
     // Use the request id from Fastify
-    generateRequestId: ({ context }) => context.req.id,
+    generateRequestId: ({ context }) => context.req!.id,
   },
   // GraphOS configuration
   supergraph: {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -692,7 +692,7 @@ interface GatewayConfigBase<TContext extends Record<string, any>> {
   /**
    * Header Propagation
    */
-  propagateHeaders?: PropagateHeadersOpts;
+  propagateHeaders?: PropagateHeadersOpts<TContext>;
 
   /**
    * Upstream Timeout

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -667,14 +667,14 @@ interface GatewayConfigBase<TContext extends Record<string, any>> {
    *
    * [Learn more](https://graphql-hive.com/docs/gateway/other-features/security/https)
    */
-  customAgent?: AgentFactory<GatewayContext & TContext>;
+  customAgent?: AgentFactory<GatewayContext & Partial<TContext>>;
 
   /**
    * Generic Auth Configuration
    */
   genericAuth?: GenericAuthPluginOptions<
     Record<string, any>, // convenient for strict tsconfig environment
-    GatewayContext & TContext
+    GatewayContext & Partial<TContext>
   >;
 
   /**
@@ -713,7 +713,7 @@ interface GatewayConfigBase<TContext extends Record<string, any>> {
    *
    * @default true
    */
-  requestId?: boolean | RequestIdOptions<TContext>;
+  requestId?: boolean | RequestIdOptions<Partial<TContext>>;
 
   /**
    * Demand Control
@@ -760,7 +760,7 @@ interface GatewayConfigBase<TContext extends Record<string, any>> {
 
 interface DisableIntrospectionOptions<TContext extends Record<string, any>> {
   disableIf?: (args: {
-    context: GatewayContext & TContext;
+    context: GatewayContext & Partial<TContext>;
     params: ValidateFunctionParameters;
   }) => boolean;
 }


### PR DESCRIPTION
And disable windows E2E CI until #1446 lands.