### PR TITLE
Export RedisPubSub and NATSPubSub from `@graphql-hive/gateway` package

### DIFF
--- a/.changeset/four-books-wash.md
+++ b/.changeset/four-books-wash.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+Export RedisPubSub and NATSPubSub from `@graphql-hive/gateway` package

--- a/e2e/distributed-subscriptions-webhooks/gateway.config.ts
+++ b/e2e/distributed-subscriptions-webhooks/gateway.config.ts
@@ -1,5 +1,4 @@
-import { defineConfig } from '@graphql-hive/gateway';
-import { RedisPubSub } from '@graphql-hive/pubsub/redis';
+import { defineConfig, RedisPubSub } from '@graphql-hive/gateway';
 import Redis from 'ioredis';
 
 /**

--- a/e2e/event-driven-federated-subscriptions/gateway.config.ts
+++ b/e2e/event-driven-federated-subscriptions/gateway.config.ts
@@ -1,5 +1,4 @@
-import { defineConfig } from '@graphql-hive/gateway';
-import { NATSPubSub } from '@graphql-hive/pubsub/nats';
+import { defineConfig, NATSPubSub } from '@graphql-hive/gateway';
 import { connect } from '@nats-io/transport-node';
 
 export const gatewayConfig = defineConfig({

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -2,6 +2,8 @@ export * from './cli';
 export * from '@graphql-hive/logger';
 export * from '@graphql-hive/gateway-runtime';
 export * from '@graphql-hive/pubsub';
+export * from '@graphql-hive/pubsub/nats';
+export * from '@graphql-hive/pubsub/redis';
 export * from '@graphql-mesh/plugin-jwt-auth';
 export * from '@graphql-mesh/plugin-prometheus';
 export { default as useRateLimit } from '@graphql-mesh/plugin-rate-limit';


### PR DESCRIPTION
Now it is possible to import `RedisPubSub` and `NATSPubSub` from `@graphql-hive/gateway` package