### PR TITLE
Inject config context into the server context before all plugins avoiding potential short-circuits

### DIFF
--- a/.changeset/weak-zoos-switch.md
+++ b/.changeset/weak-zoos-switch.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Inject config context into the server context before all plugins avoiding potential short-circuits

--- a/e2e/context-log-outside-graphql-execution/context-log-outside-graphql-execution.e2e.ts
+++ b/e2e/context-log-outside-graphql-execution/context-log-outside-graphql-execution.e2e.ts
@@ -1,0 +1,41 @@
+import { createExampleSetup, createTenv } from '@internal/e2e';
+import { fetch } from '@whatwg-node/fetch';
+import { expect, it } from 'vitest';
+
+const { gateway } = createTenv(__dirname);
+const { supergraph, query, result } = createExampleSetup(__dirname);
+
+it('should have the log available in context outside of graphql execution', async () => {
+  const { execute, port, getStd } = await gateway({
+    supergraph: await supergraph(),
+  });
+
+  // graphiql
+  let res = await fetch(`http://localhost:${port}/graphql`, {
+    headers: {
+      accept: 'text/html',
+    },
+  });
+  await expect(res.text()).resolves.toContain('<title>Hive Gateway</title>');
+
+  // readiness
+  res = await fetch(`http://localhost:${port}/readiness`);
+  expect(res.ok).toBeTruthy();
+
+  // healthcheck
+  res = await fetch(`http://localhost:${port}/healthcheck`);
+  expect(res.ok).toBeTruthy();
+
+  // graphql execution just in case
+  await expect(
+    execute({
+      query,
+    }),
+  ).resolves.toEqual(result);
+
+  const gwOut = getStd('both');
+  expect(gwOut.match(/__CONTEXT_LOG_IS_AVAILABLE__/g)?.length).toBe(
+    // (availability check by tenv) + graphiql + readiness + healthcheck + graphql execution
+    5,
+  );
+});

--- a/e2e/context-log-outside-graphql-execution/gateway.config.ts
+++ b/e2e/context-log-outside-graphql-execution/gateway.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig, GatewayPlugin } from '@graphql-hive/gateway';
+
+export const gatewayConfig = defineConfig({
+  plugins: () => [
+    {
+      onResponse({ serverContext }) {
+        if (serverContext.log) {
+          console.log('__CONTEXT_LOG_IS_AVAILABLE__');
+        }
+      },
+    } as GatewayPlugin,
+  ],
+});

--- a/e2e/context-log-outside-graphql-execution/package.json
+++ b/e2e/context-log-outside-graphql-execution/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@e2e/context-log-outside-graphql-execution",
+  "private": true
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2912,6 +2912,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/context-log-outside-graphql-execution@workspace:e2e/context-log-outside-graphql-execution":
+  version: 0.0.0-use.local
+  resolution: "@e2e/context-log-outside-graphql-execution@workspace:e2e/context-log-outside-graphql-execution"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/demand-control@workspace:e2e/demand-control":
   version: 0.0.0-use.local
   resolution: "@e2e/demand-control@workspace:e2e/demand-control"


### PR DESCRIPTION
### TODO

- [x] Write tests making sure the logger is available even when not dealing with graphql requests