### PR TITLE
fix(runtime): fix the reference of the context passed to `onFetch` hook

### DIFF
--- a/.changeset/swift-terms-beam.md
+++ b/.changeset/swift-terms-beam.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Make `onFetch`'s `context` referentially stable, and do not recreate the context object, so it becomes the same object referentially in the execution pipeline

--- a/packages/pubsub/tests/pubsub.test.ts
+++ b/packages/pubsub/tests/pubsub.test.ts
@@ -48,7 +48,7 @@ for (const PubSub of PubSubCtors) {
           });
           break;
       }
-    });
+    }, 60_000);
 
     /** Imitates a flush of data/operations by simply waiting, if the pubsub is async, like Redis. */
     function flush(ms: number = 100) {

--- a/packages/runtime/src/wrapFetchWithHooks.ts
+++ b/packages/runtime/src/wrapFetchWithHooks.ts
@@ -21,6 +21,7 @@ export function wrapFetchWithHooks<TContext>(
     let fetchFn: MeshFetch;
     let response$: MaybePromise<Response>;
     const onFetchDoneHooks: OnFetchHookDone[] = [];
+    context.log ||= log;
     return handleMaybePromise(
       () =>
         iterateAsync(
@@ -40,7 +41,7 @@ export function wrapFetchWithHooks<TContext>(
               setOptions(newOptions) {
                 options = newOptions;
               },
-              context: { log, ...context },
+              context,
               logger: LegacyLogger.from(log),
               // @ts-expect-error TODO: why?
               info,

--- a/packages/runtime/src/wrapFetchWithHooks.ts
+++ b/packages/runtime/src/wrapFetchWithHooks.ts
@@ -17,7 +17,12 @@ export function wrapFetchWithHooks<TContext>(
   log: Logger,
   instrumentation?: () => FetchInstrumentation | undefined,
 ): MeshFetch {
-  let wrappedFetchFn = function wrappedFetchFn(url, options, context, info) {
+  let wrappedFetchFn = function wrappedFetchFn(
+    url,
+    options,
+    context = {},
+    info,
+  ) {
     let fetchFn: MeshFetch;
     let response$: MaybePromise<Response>;
     const onFetchDoneHooks: OnFetchHookDone[] = [];


### PR DESCRIPTION
The object spread in the code was breaking the reference of the `context` so we can't use WeakMaps or modify the original context object from `onFetch`. It basically copies it which breaks plugins like response-caching;
https://github.com/ardatan/graphql-mesh/actions/runs/17830207715/job/50692979596