### PR TITLE
fix(stitch): merge root types with different names correctly

### DIFF
--- a/.changeset/shiny-jars-double.md
+++ b/.changeset/shiny-jars-double.md
@@ -1,0 +1,62 @@
+---
+'@graphql-tools/stitch': patch
+---
+
+Normalize the subschemas with root types in a custom names like `query_root` instead of `Query`, then stitch them
+
+```graphql
+schema {
+    query: query_root
+    subscription: subscription_root
+}
+
+type Post {
+    id: ID!
+    text: String
+    userId: ID!
+}
+
+type query_root {
+    postById(id: ID!): Post
+}
+
+type subscription_root {
+    postsByUserId(userId: ID!): [Post]!
+}
+```
+
+and
+```graphql
+type User {
+    id: ID!
+    email: String
+}
+
+type Query {
+    userById(id: ID!): User
+}
+```
+
+should be stitched as;
+
+```graphql
+type Query {
+  postById(id: ID!): Post
+  userById(id: ID!): User
+}
+
+type Subscription {
+  postsByUserId(userId: ID!): [Post]!
+}
+
+type Post {
+  id: ID!
+  text: String
+  userId: ID!
+}
+
+type User {
+  id: ID!
+  email: String
+}
+```

--- a/packages/stitch/src/mergeCandidates.ts
+++ b/packages/stitch/src/mergeCandidates.ts
@@ -64,7 +64,7 @@ export function mergeCandidates<TContext = Record<string, any>>(
   typeMergingOptions?: TypeMergingOptions<TContext>,
 ): GraphQLNamedType {
   const initialCandidateType = candidates[0]?.type;
-  if (candidates.length === 1) {
+  if (candidates.length === 1 && initialCandidateType?.name === typeName) {
     return initialCandidateType!;
   }
   if (


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/gateway/issues/1537

Normalize the subschemas with root types in a custom names like `query_root` instead of `Query`, then stitch them

```graphql
schema {
    query: query_root
    subscription: subscription_root
}

type Post {
    id: ID!
    text: String
    userId: ID!
}

type query_root {
    postById(id: ID!): Post
}

type subscription_root {
    postsByUserId(userId: ID!): [Post]!
}
```

and
```graphql
type User {
    id: ID!
    email: String
}

type Query {
    userById(id: ID!): User
}
```

should be stitched as;

```graphql
type Query {
  postById(id: ID!): Post
  userById(id: ID!): User
}

type Subscription {
  postsByUserId(userId: ID!): [Post]!
}

type Post {
  id: ID!
  text: String
  userId: ID!
}

type User {
  id: ID!
  email: String
}
```