### PR TITLE
Avoid usePropagateHeaders potential header duplication

### DIFF
--- a/packages/runtime/src/plugins/usePropagateHeaders.ts
+++ b/packages/runtime/src/plugins/usePropagateHeaders.ts
@@ -118,7 +118,10 @@ export function usePropagateHeaders<TContext extends Record<string, any>>(
           const value = headers[key];
           if (value) {
             for (const v of value) {
-              response.headers.append(key, v);
+              const current = response.headers.get(key);
+              if (v !== current) {
+                response.headers.append(key, v);
+              }
             }
           }
         }

--- a/packages/runtime/src/plugins/usePropagateHeaders.ts
+++ b/packages/runtime/src/plugins/usePropagateHeaders.ts
@@ -118,8 +118,7 @@ export function usePropagateHeaders<TContext extends Record<string, any>>(
           const value = headers[key];
           if (value) {
             for (const v of value) {
-              const current = response.headers.get(key);
-              if (v !== current) {
+              if (v !== response.headers.get(key)) {
                 response.headers.append(key, v);
               }
             }


### PR DESCRIPTION
Hi folks!

Currently, when forwarding naively back and forth headers from the gateway to the subgraphs, if we allow the request ID in both ways, we will end with 2 concatened request IDs:

```ts
const ALLOWED_HEADERS = new Set([
  "x-request-id", // <- our request ID

  "accept-language",
  "authorization",
  "content-type",
  "link",
  "location",
  "traceparent",
  "user-agent",
]);

const forwardHeaders = (input: Request | Response) => {
  const headers: Record<string, string> = {};

  for (const [key, value] of input.headers) {
    if (ALLOWED_HEADERS.has(key)) {
      headers[key] = value;
    }
  }

  return headers;
};

// …

propagateHeaders: {
  fromClientToSubgraphs: ({ request }) => forwardHeaders(request),
  fromSubgraphsToClient: ({ response }) => forwardHeaders(response),
}
```

This happens because:

- `useRequestId` set the request ID back on `onResponse` ([link](https://github.com/graphql-hive/gateway/blob/%40graphql-hive/gateway-runtime%402.1.7/packages/runtime/src/plugins/useRequestId.ts#L72))
- `usePropagateHeaders`, that runs after, **append** it to because it's forwarded ([link](https://github.com/graphql-hive/gateway/blob/%40graphql-hive/gateway-runtime%402.1.7/packages/runtime/src/plugins/usePropagateHeaders.ts#L121))

It can be avoided by separating the logic between `forwardRequestHeaders` and `forwardResponseHeaders`:

```ts
const REQUEST_ID_HEADER = "x-request-id"; // <- our request ID

const ALLOWED_HEADERS = new Set([
  REQUEST_ID_HEADER,

  "accept-language",
  "authorization",
  "content-type",
  "link",
  "location",
  "traceparent",
  "user-agent",
]);

const forwardRequestHeaders = (request: Request) => {
  const headers: Record<string, string> = {};

  for (const [key, value] of request.headers) {
    if (ALLOWED_HEADERS.has(key)) {
      headers[key] = value;
    }
  }

  return headers;
};

const forwardResponseHeaders = (response: Response) => {
  const headers: Record<string, string> = {};

  for (const [key, value] of response.headers) {
    if (ALLOWED_HEADERS.has(key) && key !== REQUEST_ID_HEADER) { // <- don't forward the id back (set by useRequestId)
      headers[key] = value;
    }
  }

  return headers;
};

// …

propagateHeaders: {
  fromClientToSubgraphs: ({ request }) => forwardRequestHeaders(request),
  fromSubgraphsToClient: ({ response }) => forwardResponseHeaders(response),
}
``` 

But I think we should add a basic check and don't `append` an identical value if it already has been set.