### PR TITLE
feat: add `hive.graphql` attribute on graphql root spans

### DIFF
--- a/packages/plugins/opentelemetry/src/attributes.ts
+++ b/packages/plugins/opentelemetry/src/attributes.ts
@@ -21,6 +21,9 @@ export {
 export const SEMATTRS_GRAPHQL_DOCUMENT = 'graphql.document';
 export const SEMATTRS_GRAPHQL_OPERATION_TYPE = 'graphql.operation.type';
 export const SEMATTRS_GRAPHQL_OPERATION_NAME = 'graphql.operation.name';
+
+// Identifies a graphql request
+export const SEMATTRS_HIVE_GRAPHQL = 'hive.graphql';
 export const SEMATTRS_HIVE_GRAPHQL_OPERATION_HASH =
   'hive.graphql.operation.hash';
 export const SEMATTRS_HIVE_GRAPHQL_ERROR_COUNT = 'hive.graphql.error.count';

--- a/packages/plugins/opentelemetry/src/hive-span-processor.ts
+++ b/packages/plugins/opentelemetry/src/hive-span-processor.ts
@@ -11,6 +11,7 @@ import type { SpanImpl } from '@opentelemetry/sdk-trace-base/build/src/Span';
 import { SEMATTRS_HTTP_METHOD } from '@opentelemetry/semantic-conventions';
 import {
   SEMATTRS_HIVE_GATEWAY_OPERATION_SUBGRAPH_NAMES,
+  SEMATTRS_HIVE_GRAPHQL,
   SEMATTRS_HIVE_GRAPHQL_ERROR_CODES,
   SEMATTRS_HIVE_GRAPHQL_ERROR_COUNT,
 } from './attributes';
@@ -130,6 +131,8 @@ export class HiveTracingSpanProcessor implements SpanProcessor {
         for (const attr in span.attributes) {
           operationSpan.attributes[attr] ??= span.attributes[attr];
         }
+
+        operationSpan.attributes[SEMATTRS_HIVE_GRAPHQL] = true;
 
         // Now that operation spans have been updated, we can report it
         this.processor.onEnd(operationSpan);

--- a/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
+++ b/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
@@ -9,6 +9,7 @@ import {
   SEMATTRS_GRAPHQL_OPERATION_TYPE,
   SEMATTRS_HIVE_GATEWAY_OPERATION_SUBGRAPH_NAMES,
   SEMATTRS_HIVE_GATEWAY_UPSTREAM_SUBGRAPH_NAME,
+  SEMATTRS_HIVE_GRAPHQL,
   SEMATTRS_HIVE_GRAPHQL_ERROR_CODES,
   SEMATTRS_HIVE_GRAPHQL_ERROR_COUNT,
   SEMATTRS_HIVE_GRAPHQL_OPERATION_HASH,
@@ -1189,6 +1190,7 @@ describe('useOpenTelemetry', () => {
         [SEMATTRS_HTTP_STATUS_CODE]: 500,
 
         // Hive specific
+        [SEMATTRS_HIVE_GRAPHQL]: true,
         ['hive.client.name']: 'test-client-name',
         ['hive.client.version']: 'test-client-version',
 


### PR DESCRIPTION
Closes https://github.com/graphql-hive/gateway/issues/1553

Add a simple property on the root span of a graphql request that indicates it is a graphql request trace (a boolean primitive type). This makes it straight-forward and future-proof to indicate graphql requests on our end (Hive Console).