### PR TITLE
⛑️ Fix potential runtime error in `useSubgraphExecuteDebug` plugin when `context.log` is undefined.

### DIFF
--- a/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
+++ b/packages/runtime/src/plugins/useSubgraphExecuteDebug.ts
@@ -7,7 +7,7 @@ export function useSubgraphExecuteDebug<
 >(): GatewayPlugin<TContext> {
   return {
     onSubgraphExecute({ executionRequest }) {
-      let log = executionRequest.context?.log.child(
+      let log = executionRequest.context?.log?.child(
         '[useSubgraphExecuteDebug] ',
       );
       let shouldLog = false;


### PR DESCRIPTION
Fix potential runtime error in `useSubgraphExecuteDebug` plugin when `context.log` is undefined.

 **Problem**

  In `packages/runtime/src/plugins/useSubgraphExecuteDebug.ts:10`, the code uses optional chaining on `executionRequest.context` but not on the `log` property before calling `.child()`:

  ```typescript
  let log = executionRequest.context?.log.child('[useSubgraphExecuteDebug] ');
```

  This can cause a runtime error: Cannot read property 'child' of undefined if executionRequest.context exists but context.log is undefined or null.

  **Solution**

  Add optional chaining to the log property to safely handle cases where the logger is not available:

  ```typescript
  let log = executionRequest.context?.log?.child('[useSubgraphExecuteDebug] ');
```

  This change ensures the plugin gracefully handles missing loggers, which is consistent with the existing null checks on line 15 (if (!log || !shouldLog)).
