### PR TITLE
fix(gateway): bump openssl in the docker image

### DIFF
--- a/.changeset/mean-shrimps-sing.md
+++ b/.changeset/mean-shrimps-sing.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+Bump OpenSSL version from 3.5.1-1+deb13u1 to 3.5.4-1~deb13u2 in the Docker image

--- a/packages/gateway/bun.Dockerfile
+++ b/packages/gateway/bun.Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; \
     echo "Error: Could not determine architecture." >&2; \
     exit 1; \
   fi; \
-  openssl_version="3.5.1-1+deb13u1"; \
+  openssl_version="3.5.4-1~deb13u2"; \
   for pkg in openssl libssl3t64 openssl-provider-legacy; do \
     wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/${pkg}_${openssl_version}_${arch}.deb"; \
     dpkg -i "${pkg}_${openssl_version}_${arch}.deb"; \

--- a/packages/gateway/node.Dockerfile
+++ b/packages/gateway/node.Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; \
     echo "Error: Could not determine architecture." >&2; \
     exit 1; \
   fi; \
-  openssl_version="3.5.1-1+deb13u1"; \
+  openssl_version="3.5.4-1~deb13u2"; \
   for pkg in openssl libssl3t64 openssl-provider-legacy; do \
     wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/${pkg}_${openssl_version}_${arch}.deb"; \
     dpkg -i "${pkg}_${openssl_version}_${arch}.deb"; \


### PR DESCRIPTION
Bump OpenSSL version from 3.5.1-1+deb13u1 to 3.5.4-1~deb13u2 in the Docker image in order to fix the recent CVE alerts