### PR TITLE
test(delegate): reproduce variable defaultValue stripping bug from PR #1708

### DIFF
--- a/.changeset/pretty-frogs-joke.md
+++ b/.changeset/pretty-frogs-joke.md
@@ -1,0 +1,34 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+Respect existing variable definitions from the gateway request;
+1. If the argument uses a variable definition on the gateway request, keep and re-use it as-is.
+
+```graphql
+query ($var1: String = "default") {
+  rootField(arg1: $var1)
+}
+```
+
+2. If the argument does not use a variable definition on the gateway request, create a new variable definition for it and make sure it does not conflict with any existing variable definitions on the gateway request, because the gateway request can have variables that have nothing to do with the delegated argument.
+
+```graphql
+query ($arg1: String = "default") {
+  rootField(arg1: 2) {
+    someField(arg2: $arg1)
+  }
+}
+```
+
+In that case it should be delegated as:
+
+```graphql
+query ($arg1: String = "default", $rootField_arg1: String = "default") {
+  rootField(arg1: $rootField_arg1) {
+    someField(arg2: $arg1)
+  }
+}
+```
+
+

--- a/packages/delegate/tests/delegateToSchema.test.ts
+++ b/packages/delegate/tests/delegateToSchema.test.ts
@@ -305,89 +305,80 @@ describe('delegateToSchema', () => {
       return outerSchema;
     }
 
-    test.fails(
-      'should preserve variable default values in @include when delegating with validation',
-      async () => {
-        const outerSchema = makeValidatingDelegationSchema();
+    test('should preserve variable default values in @include when delegating with validation', async () => {
+      const outerSchema = makeValidatingDelegationSchema();
 
-        // $flag: Boolean = false is valid in @include(if: Boolean!) because
-        // the default value guarantees non-null per the GraphQL spec.
-        // The delegate must preserve the default value when building the
-        // subgraph query, otherwise the subgraph sees $flag: Boolean in a
-        // Boolean! position and rejects the VariablesInAllowedPosition rule.
-        const result = await graphql({
-          schema: outerSchema,
-          source: /* GraphQL */ `
-            query ($flag: Boolean = false) {
-              getData(flag: $flag) {
-                main
-                extra @include(if: $flag)
-              }
+      // $flag: Boolean = false is valid in @include(if: Boolean!) because
+      // the default value guarantees non-null per the GraphQL spec.
+      // The delegate must preserve the default value when building the
+      // subgraph query, otherwise the subgraph sees $flag: Boolean in a
+      // Boolean! position and rejects the VariablesInAllowedPosition rule.
+      const result = await graphql({
+        schema: outerSchema,
+        source: /* GraphQL */ `
+          query ($flag: Boolean = false) {
+            getData(flag: $flag) {
+              main
+              extra @include(if: $flag)
             }
-          `,
-        });
+          }
+        `,
+      });
 
-        expect(result.errors).toBeUndefined();
-        assertSome(result.data);
-        expect(result.data['getData']).toEqual({
-          main: 'mainValue',
-        });
-      },
-    );
+      expect(result.errors).toBeUndefined();
+      assertSome(result.data);
+      expect(result.data['getData']).toEqual({
+        main: 'mainValue',
+      });
+    });
 
-    test.fails(
-      'should preserve variable default values in @skip when delegating with validation',
-      async () => {
-        const outerSchema = makeValidatingDelegationSchema();
+    test('should preserve variable default values in @skip when delegating with validation', async () => {
+      const outerSchema = makeValidatingDelegationSchema();
 
-        const result = await graphql({
-          schema: outerSchema,
-          source: /* GraphQL */ `
-            query ($flag: Boolean = true) {
-              getData(flag: $flag) {
-                main
-                extra @skip(if: $flag)
-              }
+      const result = await graphql({
+        schema: outerSchema,
+        source: /* GraphQL */ `
+          query ($flag: Boolean = true) {
+            getData(flag: $flag) {
+              main
+              extra @skip(if: $flag)
             }
-          `,
-        });
+          }
+        `,
+      });
 
-        expect(result.errors).toBeUndefined();
-        assertSome(result.data);
-        expect(result.data['getData']).toEqual({
-          main: 'mainValue',
-        });
-      },
-    );
+      expect(result.errors).toBeUndefined();
+      assertSome(result.data);
+      expect(result.data['getData']).toEqual({
+        main: 'mainValue',
+      });
+    });
 
-    test.fails(
-      'should preserve variable default when caller provides explicit value',
-      async () => {
-        const outerSchema = makeValidatingDelegationSchema();
+    test('should preserve variable default when caller provides explicit value', async () => {
+      const outerSchema = makeValidatingDelegationSchema();
 
-        // When the caller explicitly provides a value, the query should still
-        // pass validation because the default in the definition guarantees non-null.
-        const result = await graphql({
-          schema: outerSchema,
-          source: /* GraphQL */ `
-            query ($flag: Boolean = false) {
-              getData(flag: $flag) {
-                main
-                extra @include(if: $flag)
-              }
+      // When the caller explicitly provides a value, the query should still
+      // pass validation because the default in the definition guarantees non-null.
+      const result = await graphql({
+        schema: outerSchema,
+        source: /* GraphQL */ `
+          query ($flag: Boolean = false) {
+            getData(flag: $flag) {
+              main
+              extra @include(if: $flag)
             }
-          `,
-          variableValues: { flag: true },
-        });
+          }
+        `,
+        variableValues: { flag: true },
+      });
 
-        expect(result.errors).toBeUndefined();
-        assertSome(result.data);
-        expect(result.data['getData']).toEqual({
-          main: 'mainValue',
-          extra: 'extraValue',
-        });
-      },
-    );
+      expect(result.errors).toBeUndefined();
+      assertSome(result.data);
+      expect(result.data['getData']).toEqual({
+        main: 'mainValue',
+        extra: 'extraValue',
+      });
+    });
 
     test('should reject nullable Boolean without default in @include position', async () => {
       const sourceSchema = makeExecutableSchema({


### PR DESCRIPTION
## Description

createRequest no longer preserves defaultValue on variable definitions used in @include/@skip directives, causing subgraph validation to reject queries like `$flag: Boolean = false` in `Boolean!` positions.

Related PR #1708