### PR TITLE
Copilot fix - Useless assignment to local variable

### DIFF
--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -65,7 +65,7 @@ export function delegateToSchema<
     args,
   } = options;
 
-  let targetSchema = options.targetSchema;
+  let targetSchema;
   if (isSubschema(schema)) {
     targetSchema = schema.transformedSchema;
   } else if (isSchema(schema)) {


### PR DESCRIPTION
In general, to fix an "unused initial value" local variable issue, you either (a) remove the unused initialization, leaving a plain declaration, or (b) if the initial value was intended to be used, adjust the control flow so it is actually read on some path. Here, `targetSchema` is always reassigned before use, so the simplest and safest fix that does not change existing behavior is to remove the initializer and keep `let targetSchema;`. This preserves the subsequent logic that decides `targetSchema` based solely on `schema` and (in one branch) `stitchingInfo`.

Concretely, in `packages/delegate/src/delegateToSchema.ts`, change line 68 from `let targetSchema = options.targetSchema;` to `let targetSchema;`. No other code in this snippet needs to be modified, and no new imports or helper methods are required. The variable remains `let` because it is written multiple times.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._