### PR TITLE
Copilot Fix - Unused loop iteration variable

### DIFF
--- a/internal/perf/src/heapsnapshot.ts
+++ b/internal/perf/src/heapsnapshot.ts
@@ -47,9 +47,11 @@ export async function leakingObjectsInHeapSnapshotFiles(
     baseSnap = snap;
 
     const growingDiff: HeapSnapshotDiff = {};
-    for (const { addedIndexes, deletedIndexes, ...diff } of Object.values(
-      snapshotDiff,
-    )) {
+    for (const {
+      addedIndexes: _ignoreAddedIndexes,
+      deletedIndexes: _ignoreDeletedIndexes,
+      ...diff
+    } of Object.values(snapshotDiff)) {
       if (
         // size just kept growing
         diff.sizeDelta > 0


### PR DESCRIPTION
General approach: Remove the unused loop variables while preserving the behavior of excluding `addedIndexes` and `deletedIndexes` from the `diff` object stored in `growingDiff`. We still want to destructure and drop those properties, but we do not need to bind them to names.

Best concrete fix: In `internal/perf/src/heapsnapshot.ts`, at the `for` loop starting on line 50, change the destructuring pattern from:

```ts
for (const { addedIndexes, deletedIndexes, ...diff } of Object.values(
  snapshotDiff,
)) {
```

to:

```ts
for (const { addedIndexes: _addedIndexes, deletedIndexes: _deletedIndexes, ...diff } of Object.values(
  snapshotDiff,
)) {
```

or, even better, to a pattern that omits binding entirely while still excluding properties. However, JavaScript/TypeScript destructuring requires property identifiers when excluding, so the minimal practical change while avoiding unused-variable warnings is to rename them to underscore-prefixed variables and ensure that any linters treat those as intentionally unused. Since the CodeQL rule is specifically about unused loop *variables*, a safer fix is to avoid creating variables at all by destructuring into a temporary and immediately re-destructuring, but that would be more invasive.

A slightly different but behaviorally identical and simpler fix that avoids introducing dummy variables is:

```ts
for (const value of Object.values(snapshotDiff)) {
  const { addedIndexes, deletedIndexes, ...diff } = value;
  if (diff.sizeDelta > 0) {
    growingDiff[diff.name] = diff;
  }
}
```

However, this still declares `addedIndexes` and `deletedIndexes` and leaves them unused. The optimal fix that preserves semantics and removes unused variables is:

```ts
for (const { addedIndexes: _ignoreAdded, deletedIndexes: _ignoreDeleted, ...diff } of Object.values(
  snapshotDiff,
)) {
  if (diff.sizeDelta > 0) {
    growingDiff[diff.name] = diff;
  }
}
```

Assuming the project treats underscore-prefixed variables as intentionally unused (a common convention), CodeQL should no longer flag them, and the runtime behavior is unchanged: `addedIndexes` and `deletedIndexes` are still excluded from `diff`.

Changes needed:

- In `internal/perf/src/heapsnapshot.ts`, adjust the destructuring pattern in the `for` loop around lines 49–52 as described.
- No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._