### PR TITLE
Copilot Fix: Unneeded defensive code

### DIFF
--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -260,16 +260,14 @@ function projectArgumentValue(argValue: any, argType: GraphQLInputType): any {
     }
     return projectedValue;
   }
-  if (argValue != null) {
-    if (argType.name === 'Boolean') {
-      return Boolean(argValue);
-    }
-    if (argType.name === 'Int' || argType.name === 'Float') {
-      return Number(argValue);
-    }
-    if (argType.name === 'String') {
-      return String(argValue);
-    }
+  if (argType.name === 'Boolean') {
+    return Boolean(argValue);
+  }
+  if (argType.name === 'Int' || argType.name === 'Float') {
+    return Number(argValue);
+  }
+  if (argType.name === 'String') {
+    return String(argValue);
   }
   return argValue;
 }


### PR DESCRIPTION
In general, to fix "defensive code that guards against a situation that never happens," we remove or simplify the unnecessary condition while preserving the actual behavior of the code inside the guarded block. If needed, we can rely on the earlier checks or type constraints that already guarantee the condition.

Here, `projectArgumentValue` returns immediately when `argValue == null`. Thus, by the time execution reaches line 263, `argValue` is guaranteed to be neither `null` nor `undefined`. The conversions for scalar input types (`Boolean`, `Int`, `Float`, `String`) can therefore be executed unconditionally. The best minimal fix is to remove the `if (argValue != null)` wrapper and unindent its inner `if` statements so the logic for scalar coercion runs directly. This does not alter behavior, because previously the block always ran; it only eliminates the redundant guard that CodeQL flagged.

Concretely, in `packages/delegate/src/createRequest.ts`, in the `projectArgumentValue` function around lines 263–273, remove the `if (argValue != null) { ... }` and keep the nested `if` statements at the same place but one indentation level up. No imports, new methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._