### PR TITLE
Copilot Fix: Unneeded defensive code

### DIFF
--- a/packages/wrap/src/transforms/HoistField.ts
+++ b/packages/wrap/src/transforms/HoistField.ts
@@ -297,13 +297,9 @@ export function unwrapValue(originalValue: any, alias: string): any {
 }
 
 function unwrapErrors(
-  errors: ReadonlyArray<GraphQLError> | undefined,
+  errors: ReadonlyArray<GraphQLError>,
   alias: string,
-): Array<GraphQLError> | undefined {
-  if (errors === undefined) {
-    return undefined;
-  }
-
+): Array<GraphQLError> {
   return errors.map((error) => {
     const originalPath = error.path;
     if (originalPath == null) {


### PR DESCRIPTION
To fix the problem, we should remove the unnecessary defensive check and make the function signature reflect that `errors` is always a defined array. That means changing the parameter type from `ReadonlyArray<GraphQLError> | undefined` to `ReadonlyArray<GraphQLError>`, removing the `if (errors === undefined)` block, and updating the return type to `Array<GraphQLError>` instead of `Array<GraphQLError> | undefined`. This eliminates the dead branch Triggering the CodeQL warning while preserving behavior at all current call sites (which, according to the analysis, never pass `undefined`).

Concretely, in `packages/wrap/src/transforms/HoistField.ts`, at the `unwrapErrors` function definition around lines 299–317, adjust the parameter and return types and delete the `if (errors === undefined) { return undefined; }` block. No additional imports or helper methods are needed; only the function signature and body need to be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._