### PR TITLE
Copilot Fix: Missing space in string concatenation

### DIFF
--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -916,9 +916,11 @@ export function createGatewayRuntime<
   if (config.demandControl) {
     if ('proxy' in config && config.schema == null) {
       log.warn(
-        '`demandControl` is enabled in proxy mode without a defined schema ' +
-          'If you use directives like "@cost" or "@listSize", these won\'t be available for cost calculation. ' +
+        [
+          '`demandControl` is enabled in proxy mode without a defined schema',
+          'If you use directives like "@cost" or "@listSize", these won\'t be available for cost calculation.',
           'You have to define "schema" in the gateway config to make them available.',
+        ].join(' '),
       );
     }
     extraPlugins.push(useDemandControl(config.demandControl));


### PR DESCRIPTION
In general, to fix this kind of problem you should ensure that when you split a long user-facing string across multiple literals concatenated with `+`, each join either has a trailing space in the previous literal or a leading space in the next literal so that words remain properly separated.

The best fix here is to update the three string literals inside the `log.warn` call around lines 918–921 so that there is a space between sentences when they’re concatenated. Specifically:
- Add a trailing space at the end of the first literal, after `schema`.
- Add a leading space at the start of the second literal, or a trailing space at its end, to separate `calculation.` from `You`. For consistency, use trailing spaces on each segment except the last.
- Optionally also ensure a leading space on the second segment after the first join, but only one space at each join is needed.

Concretely, modify the literals so the final rendered message reads:

`'`demandControl` is enabled in proxy mode without a defined schema If you use directives like "@cost" or "@listSize", these won't be available for cost calculation. You have to define "schema" in the gateway config to make them available.'`

(or with a period and a space after `schema.` if desired, but that would change the wording slightly). The minimal, non-functional change is just to insert spaces at the concatenation boundaries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._