### PR TITLE
Adding breaking test case for missing __typename on federated non abstract types

### DIFF
--- a/packages/delegate/tests/finalizeGatewayRequest.test.ts
+++ b/packages/delegate/tests/finalizeGatewayRequest.test.ts
@@ -145,6 +145,48 @@ describe('finalizeGatewayRequest', () => {
     expect(print(filteredQuery.document)).toBe(print(expected));
   });
 
+  test('should expect __typename on non abstract types', () => {
+    const query = parse(/* GraphQL */ `
+      query bookingQuery($id: ID!) {
+        bookingById(id: $id) {
+          id
+          customer {
+            ... on Customer {
+              name
+            }
+          }
+        }
+      }
+    `);
+    const filteredQuery = finalizeGatewayRequest(
+      {
+        document: query,
+        variables: {
+          id: 'b1',
+        },
+      },
+      {
+        targetSchema: bookingSchema,
+      } as DelegationContext,
+      () => {},
+    );
+
+    const expected = parse(/* GraphQL */ `
+      query bookingQuery($id: ID!) {
+        bookingById(id: $id) {
+          id
+          customer {
+            __typename
+            ... on Customer {
+              name
+            }
+          }
+        }
+      }
+    `);
+    expect(print(filteredQuery.document)).toBe(print(expected));
+  });
+
   describe('Spreading on unions', () => {
     const targetSchema = buildSchema(/* GraphQL */ `
       type Query {


### PR DESCRIPTION
The test case covers the missing addition of the `__typename` for non abstract types.
When a federated non abstract type is requested with `... on SomeType`, it's not expanded with `__typename`.
This has been the case in previous releases (e.g. @graphql-tools/delegate@10.0.16).

What behaviour is expected here, @ardatan?