### PR TITLE
Update OpenSSL packages in the Docker images

### DIFF
--- a/.changeset/pink-cows-travel.md
+++ b/.changeset/pink-cows-travel.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+Update OpenSSL packages (libssl3t64, openssl, openssl-provider-legacy) in the Docker image to fix the security vulnerability alert (CVE-2026-31790)

--- a/packages/gateway/bun.Dockerfile
+++ b/packages/gateway/bun.Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; \
     echo "Error: Could not determine architecture." >&2; \
     exit 1; \
   fi; \
-  openssl_version="3.5.4-1~deb13u2"; \
+  openssl_version="3.5.5-1~deb13u2"; \
   for pkg in openssl libssl3t64 openssl-provider-legacy; do \
     wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/${pkg}_${openssl_version}_${arch}.deb"; \
     dpkg -i "${pkg}_${openssl_version}_${arch}.deb"; \

--- a/packages/gateway/node.Dockerfile
+++ b/packages/gateway/node.Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; \
     echo "Error: Could not determine architecture." >&2; \
     exit 1; \
   fi; \
-  openssl_version="3.5.4-1~deb13u2"; \
+  openssl_version="3.5.5-1~deb13u2"; \
   for pkg in openssl libssl3t64 openssl-provider-legacy; do \
     wget "http://security.debian.org/debian-security/pool/updates/main/o/openssl/${pkg}_${openssl_version}_${arch}.deb"; \
     dpkg -i "${pkg}_${openssl_version}_${arch}.deb"; \


### PR DESCRIPTION
Update OpenSSL packages (libssl3t64, openssl, openssl-provider-legacy) in the Docker image to fix the security vulnerability alert (CVE-2026-31790)