### PR TITLE
fix(runtime): always provide an initial fetch implementation

### DIFF
--- a/.changeset/hip-radios-sneeze.md
+++ b/.changeset/hip-radios-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Fix the bug where `fetch` function is not available in `GatewayConfigContext` while initializing the plugins

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -34,6 +34,7 @@ import { useCSRFPrevention } from '@graphql-yoga/plugin-csrf-prevention';
 import { useDeferStream } from '@graphql-yoga/plugin-defer-stream';
 import { usePersistedOperations } from '@graphql-yoga/plugin-persisted-operations';
 import { AsyncDisposableStack } from '@whatwg-node/disposablestack';
+import * as defaultFetchAPI from '@whatwg-node/fetch';
 import { handleMaybePromise, MaybePromise } from '@whatwg-node/promise-helpers';
 import { ServerAdapterPlugin } from '@whatwg-node/server';
 import { useCookies } from '@whatwg-node/server-plugin-cookies';
@@ -47,6 +48,7 @@ import {
 import {
   chain,
   createYoga,
+  FetchAPI,
   isAsyncIterable,
   useExecutionCancellation,
   useReadinessCheck,
@@ -118,7 +120,18 @@ export type GatewayRuntime<
 export function createGatewayRuntime<
   TContext extends Record<string, any> = Record<string, any>,
 >(config: GatewayConfig<TContext>): GatewayRuntime<TContext> {
-  let fetchAPI = config.fetchAPI;
+  const fetchAPI: FetchAPI = {
+    ...defaultFetchAPI,
+  };
+  if (config?.fetchAPI) {
+    for (const key in config.fetchAPI) {
+      const fetchAPIKey = key as keyof FetchAPI;
+      if (config.fetchAPI[fetchAPIKey]) {
+        // @ts-expect-error - types don't match somehow
+        fetchAPI[fetchAPIKey] = config.fetchAPI[fetchAPIKey];
+      }
+    }
+  }
   const log = createLoggerFromLogging(config.logging);
 
   let instrumentation: GatewayPlugin['instrumentation'];
@@ -127,11 +140,14 @@ export function createGatewayRuntime<
   const onCacheGetHooks: OnCacheGetHook[] = [];
   const onCacheSetHooks: OnCacheSetHook[] = [];
   const onCacheDeleteHooks: OnCacheDeleteHook[] = [];
+
   const wrappedFetchFn = wrapFetchWithHooks(
     onFetchHooks,
     log,
     () => instrumentation,
+    fetchAPI.fetch,
   );
+
   const wrappedCache: KeyValueCache | undefined = config.cache
     ? wrapCacheWithHooks({
         cache: config.cache,
@@ -631,11 +647,6 @@ export function createGatewayRuntime<
   });
 
   const defaultGatewayPlugin: GatewayPlugin = {
-    onFetch({ setFetchFn }) {
-      if (fetchAPI?.fetch) {
-        setFetchFn(fetchAPI.fetch);
-      }
-    },
     onRequestParse() {
       return handleMaybePromise(getSchema, () => {});
     },
@@ -1000,8 +1011,6 @@ export function createGatewayRuntime<
     disposeOnProcessTerminate: true,
     multipart: config.multipart ?? false,
   });
-
-  fetchAPI ||= yoga.fetchAPI;
 
   Object.defineProperties(yoga, {
     version: {

--- a/packages/runtime/src/wrapFetchWithHooks.ts
+++ b/packages/runtime/src/wrapFetchWithHooks.ts
@@ -31,12 +31,12 @@ export function wrapFetchWithHooks<TContext>(
     info,
   ) {
     let fetchFn = initialFetchFn;
+    context.log ||= log;
     if (onFetchHooks.length === 0) {
       return fetchFn(url, options, context, info);
     }
     let response$: MaybePromise<Response>;
     const onFetchDoneHooks: OnFetchHookDone[] = [];
-    context.log ||= log;
     return handleMaybePromise(
       () =>
         iterateAsync(

--- a/packages/runtime/src/wrapFetchWithHooks.ts
+++ b/packages/runtime/src/wrapFetchWithHooks.ts
@@ -12,11 +12,17 @@ export type FetchInstrumentation = {
   ) => MaybePromise<void>;
 };
 
+const missingFetchFn: MeshFetch = function missingFetchFn() {
+  throw new Error(
+    'wrapFetchWithHooks requires an initial fetch function or an onFetch hook that sets fetchFn.',
+  );
+};
+
 export function wrapFetchWithHooks<TContext>(
   onFetchHooks: OnFetchHook<TContext>[],
   log: Logger,
   instrumentation?: () => FetchInstrumentation | undefined,
-  initialFetchFn?: MeshFetch,
+  initialFetchFn: MeshFetch = missingFetchFn,
 ): MeshFetch {
   let wrappedFetchFn = function wrappedFetchFn(
     url,
@@ -24,12 +30,9 @@ export function wrapFetchWithHooks<TContext>(
     context = {},
     info,
   ) {
-    let fetchFn: MeshFetch;
-    if (initialFetchFn) {
-      fetchFn = initialFetchFn;
-    }
+    let fetchFn = initialFetchFn;
     if (onFetchHooks.length === 0) {
-      return fetchFn!(url, options, context, info);
+      return fetchFn(url, options, context, info);
     }
     let response$: MaybePromise<Response>;
     const onFetchDoneHooks: OnFetchHookDone[] = [];

--- a/packages/runtime/src/wrapFetchWithHooks.ts
+++ b/packages/runtime/src/wrapFetchWithHooks.ts
@@ -16,6 +16,7 @@ export function wrapFetchWithHooks<TContext>(
   onFetchHooks: OnFetchHook<TContext>[],
   log: Logger,
   instrumentation?: () => FetchInstrumentation | undefined,
+  initialFetchFn?: MeshFetch,
 ): MeshFetch {
   let wrappedFetchFn = function wrappedFetchFn(
     url,
@@ -24,6 +25,12 @@ export function wrapFetchWithHooks<TContext>(
     info,
   ) {
     let fetchFn: MeshFetch;
+    if (initialFetchFn) {
+      fetchFn = initialFetchFn;
+    }
+    if (onFetchHooks.length === 0) {
+      return fetchFn!(url, options, context, info);
+    }
     let response$: MaybePromise<Response>;
     const onFetchDoneHooks: OnFetchHookDone[] = [];
     context.log ||= log;

--- a/packages/runtime/tests/wrapFetchWithHooks.test.ts
+++ b/packages/runtime/tests/wrapFetchWithHooks.test.ts
@@ -1,7 +1,10 @@
 import { Logger } from '@graphql-hive/logger';
+import { createDisposableServer, type MaybePromise } from '@internal/testing';
 import { createServerAdapter, Response } from '@whatwg-node/server';
-import type { GraphQLResolveInfo } from 'graphql';
+import { buildSchema, type GraphQLResolveInfo } from 'graphql';
 import { expect, it } from 'vitest';
+import { createGatewayRuntime } from '../src/createGatewayRuntime';
+import type { GatewayConfigContext, GatewayPlugin } from '../src/types';
 import {
   wrapFetchWithHooks,
   type FetchInstrumentation,
@@ -36,4 +39,73 @@ it('should wrap fetch instrumentation', async () => {
   } as GraphQLResolveInfo);
   expect(await res.json()).toEqual({ hello: 'world' });
   expect(receivedExecutionRequest).toBe(executionRequest);
+});
+
+const serverAdapter = createServerAdapter(() =>
+  Response.json({ hello: 'world' }),
+);
+const dummySchema = buildSchema(/* GraphQL */ `
+  type Query {
+    hello: String!
+  }
+`);
+
+it('ctx.fetch available on onPluginInit', async () => {
+  await using testServer = await createDisposableServer(serverAdapter);
+  let res$: MaybePromise<Response> | undefined;
+  function useMyPlugin<TContext extends Record<string, any>>(
+    ctx: GatewayConfigContext,
+  ): GatewayPlugin<TContext> {
+    return {
+      onPluginInit() {
+        res$ = ctx.fetch(testServer.url);
+      },
+    };
+  }
+  await using _gw = createGatewayRuntime({
+    supergraph: () => dummySchema,
+    plugins: (ctx) => [useMyPlugin(ctx)],
+  });
+  const res = await res$;
+  const json = await res?.json();
+  expect(json).toEqual({ hello: 'world' });
+});
+
+it('ctx.fetch available on plugin factory', async () => {
+  await using testServer = await createDisposableServer(serverAdapter);
+  let res$: MaybePromise<Response> | undefined;
+  function useMyPlugin<TContext extends Record<string, any>>(
+    ctx: GatewayConfigContext,
+  ): GatewayPlugin<TContext> {
+    res$ = ctx.fetch(testServer.url);
+    return {};
+  }
+  await using _gw = createGatewayRuntime({
+    supergraph: () => dummySchema,
+    plugins: (ctx) => [useMyPlugin(ctx)],
+  });
+  const res = await res$;
+  const json = await res?.json();
+  expect(json).toEqual({ hello: 'world' });
+});
+
+it('ctx.fetch available on onYogaInit', async () => {
+  await using testServer = await createDisposableServer(serverAdapter);
+  let res$: MaybePromise<Response> | undefined;
+  function useMyPlugin<TContext extends Record<string, any>>(
+    ctx: GatewayConfigContext,
+  ): GatewayPlugin<TContext> {
+    return {
+      onYogaInit() {
+        res$ = ctx.fetch(testServer.url);
+      },
+    };
+  }
+  await using _gw = createGatewayRuntime({
+    supergraph: () => dummySchema,
+    plugins: (ctx) => [useMyPlugin(ctx)],
+  });
+  const res = await res$;
+  const json = await res?.json();
+  expect(json).toEqual({ hello: 'world' });
 });


### PR DESCRIPTION
Fix the bug where `fetch` function is not available in `GatewayConfigContext` while initializing the plugins