### PR TITLE
Importable `@grpc/grpc-js` in Docker bundle

### DIFF
--- a/.changeset/late-swans-kneel.md
+++ b/.changeset/late-swans-kneel.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+Importable @grpc/grpc-js in Docker bundle

--- a/packages/gateway/rollup.config.js
+++ b/packages/gateway/rollup.config.js
@@ -86,6 +86,18 @@ const deps = {
     '../plugins/opentelemetry/src/async-context-manager.ts',
   'node_modules/@opentelemetry/exporter-trace-otlp-grpc/index':
     '../plugins/opentelemetry/src/exporter-trace-otlp-grpc.ts',
+  // sometimes the grpc exporter needs the credentials explicitly disabled so that users
+  // can use the grpc exporter from inside a private vpn network with self signed certificates.
+  //
+  // for example:
+  // import { credentials } from '@grpc/grpc-js';
+  // import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
+  // const exporter = new OTLPTraceExporter({
+  //   url: '<url of grpc>',
+  //   credentials: credentials.createInsecure(),
+  // });
+  'node_modules/@grpc/grpc-js/index':
+    '../../node_modules/@grpc/grpc-js/build/src/index.js',
   'node_modules/@opentelemetry/sdk-node/index':
     '../plugins/opentelemetry/src/sdk-node.ts',
   'node_modules/@opentelemetry/auto-instrumentations-node/index':

--- a/packages/gateway/rollup.config.js
+++ b/packages/gateway/rollup.config.js
@@ -86,8 +86,8 @@ const deps = {
     '../plugins/opentelemetry/src/async-context-manager.ts',
   'node_modules/@opentelemetry/exporter-trace-otlp-grpc/index':
     '../plugins/opentelemetry/src/exporter-trace-otlp-grpc.ts',
-  // sometimes the grpc exporter needs the credentials explicitly disabled so that users
-  // can use the grpc exporter from inside a private vpn network with self signed certificates.
+  // sometimes the grpc exporter needs to use insecure credentials (e.g. to bypass TLS
+  // certificate validation in private networks by using plain gRPC instead).
   //
   // for example:
   // import { credentials } from '@grpc/grpc-js';


### PR DESCRIPTION
Allows users to use insecure gRPC credentials for TLS domains in internal VPC networks with self signed certificates.

```ts
import { openTelemetrySetup } from '@graphql-hive/plugin-opentelemetry/setup';
import { credentials } from '@grpc/grpc-js';
import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';

const exporter = new OTLPTraceExporter({
  url: '<url of grpc>',
  credentials: credentials.createInsecure(),
});

openTelemetrySetup({
  contextManager: new AsyncLocalStorageContextManager(),
  traces: {
    exporter,
  },
  // ...rest of config
});
```