### PR TITLE
fix(runtime): fix SSE subscription buffering with contentEncoding enabled

### DIFF
--- a/.changeset/stupid-poems-attack.md
+++ b/.changeset/stupid-poems-attack.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+Disable compression for SSE responses due to the limitations of buffering in WHATWG Compression Stream

--- a/packages/runtime/src/plugins/useContentEncoding.ts
+++ b/packages/runtime/src/plugins/useContentEncoding.ts
@@ -7,11 +7,29 @@ export interface UseContentEncodingOpts {
   subgraphs?: string[];
 }
 
+function createContentEncodingPlugin<TContext extends Record<string, any>>() {
+  const origPlugin = useOrigContentEncoding();
+  return {
+    ...origPlugin,
+    onResponse(
+      payload: Parameters<NonNullable<typeof origPlugin.onResponse>>[0],
+    ) {
+      // Skip compression for SSE responses — CompressionStream buffers small
+      // events and never flushes them, breaking real-time delivery.
+      const contentType = payload.response.headers.get('content-type');
+      if (contentType?.includes('text/event-stream')) {
+        return;
+      }
+      return origPlugin.onResponse?.(payload);
+    },
+  } as GatewayPlugin<TContext>;
+}
+
 export function useContentEncoding<TContext extends Record<string, any>>({
   subgraphs,
 }: UseContentEncodingOpts = {}): GatewayPlugin<TContext> {
   if (!subgraphs?.length) {
-    return useOrigContentEncoding();
+    return createContentEncodingPlugin();
   }
   const compressionAlgorithm: CompressionFormat = 'gzip';
   let fetchAPI: FetchAPI;
@@ -22,7 +40,7 @@ export function useContentEncoding<TContext extends Record<string, any>>({
     },
     onPluginInit({ addPlugin }) {
       // @ts-ignore - this is flakey
-      addPlugin(useOrigContentEncoding());
+      addPlugin(createContentEncodingPlugin());
     },
     onSubgraphExecute({ subgraphName, executionRequest }) {
       if (subgraphs.includes(subgraphName) || subgraphs.includes('*')) {

--- a/packages/runtime/tests/contentEncoding.test.ts
+++ b/packages/runtime/tests/contentEncoding.test.ts
@@ -269,31 +269,25 @@ describe('contentEncoding with SSE subscriptions', () => {
       });
 
       const msgs: unknown[] = [];
-      const result = await Promise.race([
-        (async () => {
-          for await (const msg of sub) {
-            msgs.push(msg);
-            if (msgs.length >= 4) {
-              break;
-            }
-          }
-          return 'ok' as const;
-        })(),
-        new Promise<'timeout'>((resolve) =>
-          setTimeout(() => resolve('timeout'), 5_000),
-        ),
-      ]);
+      for await (const msg of sub) {
+        msgs.push(msg);
+        if (msgs.length >= 4) {
+          break;
+        }
+      }
 
       // If this fails, gzip compression is buffering small SSE events
       // and never flushing them to the client.
-      expect(result).toBe('ok');
       expect(msgs).toEqual([
         { data: { countdown: 3 } },
         { data: { countdown: 2 } },
         { data: { countdown: 1 } },
         { data: { countdown: 0 } },
       ]);
+
+      client.dispose();
+
+      return gateway.dispose();
     },
-    10_000,
   );
 });

--- a/packages/runtime/tests/contentEncoding.test.ts
+++ b/packages/runtime/tests/contentEncoding.test.ts
@@ -1,8 +1,10 @@
 import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
 import { getSupportedEncodings, useContentEncoding } from '@whatwg-node/server';
+import { createClient as createSSEClient } from 'graphql-sse';
 import {
   createSchema,
   createYoga,
+  Repeater,
   type FetchAPI,
   type YogaInitialContext,
 } from 'graphql-yoga';
@@ -192,4 +194,106 @@ describe('contentEncoding', () => {
       },
     });
   });
+});
+
+describe('contentEncoding with SSE subscriptions', () => {
+  const subgraphSchema = createSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        hello: String
+      }
+
+      type Subscription {
+        countdown(from: Int!): Int
+      }
+    `,
+    resolvers: {
+      Query: {
+        hello: () => 'world',
+      },
+      Subscription: {
+        countdown: {
+          subscribe: (_, { from }: { from: number }) =>
+            new Repeater(async (push, stop) => {
+              for (let i = from; i >= 0; i--) {
+                push(i);
+                await new Promise((resolve) => setTimeout(resolve, 50));
+              }
+              stop();
+            }),
+          resolve: (value: number) => value,
+        },
+      },
+    },
+  });
+  const subgraphServer = createYoga({
+    schema: subgraphSchema,
+  });
+  const gateway = createGatewayRuntime({
+    supergraph() {
+      return getUnifiedGraphGracefully([
+        {
+          name: 'subgraph',
+          schema: subgraphSchema,
+          url: 'http://localhost:4001/graphql',
+        },
+      ]);
+    },
+    contentEncoding: true,
+    plugins: () => [
+      useCustomFetch(
+        // @ts-expect-error TODO: MeshFetch is not compatible with @whatwg-node/server fetch
+        subgraphServer.fetch,
+      ),
+    ],
+  });
+  const firstSupportedEncoding = getSupportedEncodings(gateway.fetchAPI)[0];
+  const skipIfNoEncodingSupport = firstSupportedEncoding ? it : it.skip;
+  skipIfNoEncodingSupport(
+    'should deliver SSE subscription events to the client',
+    async () => {
+      const client = createSSEClient({
+        url: 'http://localhost:4000/graphql',
+        fetchFn: gateway.fetch,
+        headers: {
+          'Accept-Encoding': 'gzip',
+        },
+      });
+
+      const sub = client.iterate({
+        query: /* GraphQL */ `
+          subscription {
+            countdown(from: 3)
+          }
+        `,
+      });
+
+      const msgs: unknown[] = [];
+      const result = await Promise.race([
+        (async () => {
+          for await (const msg of sub) {
+            msgs.push(msg);
+            if (msgs.length >= 4) {
+              break;
+            }
+          }
+          return 'ok' as const;
+        })(),
+        new Promise<'timeout'>((resolve) =>
+          setTimeout(() => resolve('timeout'), 5_000),
+        ),
+      ]);
+
+      // If this fails, gzip compression is buffering small SSE events
+      // and never flushing them to the client.
+      expect(result).toBe('ok');
+      expect(msgs).toEqual([
+        { data: { countdown: 3 } },
+        { data: { countdown: 2 } },
+        { data: { countdown: 1 } },
+        { data: { countdown: 0 } },
+      ]);
+    },
+    10_000,
+  );
 });


### PR DESCRIPTION
## Description
When `contentEncoding: true` is enabled, SSE subscription responses are gzip-compressed. Small SSE events never reach the gzip minimum block size to trigger a flush, so compressed data accumulates in the buffer and the client receives 0 bytes.

Fixes: [#2259](https://github.com/graphql-hive/gateway/issues/2259)

**Expected**: Client receives SSE events normally
**Actual**: Client receives headers (200, `Content-Encoding: gzip`) but 0 bytes of body data - times out