### PR TITLE
Keep alive timeout setting for Node server

### DIFF
--- a/.changeset/clean-yaks-tell.md
+++ b/.changeset/clean-yaks-tell.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+Keep alive timeout setting for Node server

--- a/packages/gateway/src/servers/nodeHttp.ts
+++ b/packages/gateway/src/servers/nodeHttp.ts
@@ -21,6 +21,7 @@ export async function startNodeHttpServer<TContext extends Record<string, any>>(
     maxHeaderSize,
     disableWebsockets,
     requestTimeout,
+    keepAliveTimeout,
   } = opts;
   let server: Server;
   let protocol: string;
@@ -62,6 +63,7 @@ export async function startNodeHttpServer<TContext extends Record<string, any>>(
         ...sslOptionsForNodeHttp,
         maxHeaderSize,
         requestTimeout,
+        keepAliveTimeout,
       },
       gwRuntime,
     );
@@ -71,6 +73,7 @@ export async function startNodeHttpServer<TContext extends Record<string, any>>(
       {
         maxHeaderSize,
         requestTimeout,
+        keepAliveTimeout,
       },
       gwRuntime,
     );

--- a/packages/gateway/src/servers/types.ts
+++ b/packages/gateway/src/servers/types.ts
@@ -37,6 +37,15 @@ export interface ServerConfig {
    * @default 300000 (5 minutes)
    */
   requestTimeout?: number;
+  /**
+   * Sets the number of milliseconds to wait before timing out a
+   * connection due to inactivity in Node's HTTP server
+   *
+   * This settings has no effect in Run, use {@link requestTimeout} instead.
+   *
+   * @default "Node's default (5 seconds)"
+   */
+  keepAliveTimeout?: number;
 }
 
 export interface ServerConfigSSLCredentials {

--- a/packages/gateway/src/servers/types.ts
+++ b/packages/gateway/src/servers/types.ts
@@ -41,7 +41,7 @@ export interface ServerConfig {
    * Sets the number of milliseconds to wait before timing out a
    * connection due to inactivity in Node's HTTP server
    *
-   * This settings has no effect in Run, use {@link requestTimeout} instead.
+   * This setting has no effect in Bun, use {@link requestTimeout} instead.
    *
    * @default "Node's default (5 seconds)"
    */


### PR DESCRIPTION
Configure the amount of inactivity time a server waits for additional incoming data after finishing writing the last response, before destroying the socket.

```ts
import { defineConfig } from '@graphql-hive/gateway';

export const gatewayConfig = defineConfig({
  keepAliveTimeout: 60000 // 60 seconds
});
```

P.S. Bun doesn't have a separate "request timeout" concept distinct from idleTimeout, they're the same thing. A connection is considered idle when there is no data being sent or received, including in-flight requests where your handler is still running but hasn't written any bytes yet. This setting only applies to Node.