### PR TITLE
feat(federation): support `join__directive` while extracting subgraphs

### DIFF
--- a/.changeset/sour-guests-shake.md
+++ b/.changeset/sour-guests-shake.md
@@ -1,0 +1,85 @@
+---
+'@graphql-tools/federation': minor
+---
+
+Support `@join__directive` while extracting subgraph definitions from the supergraph
+
+For example;
+
+```graphql
+type Query @join__type(graph: PRODUCTS) {
+  products: [Product]
+    @join__field(graph: PRODUCTS)
+    @join__directive(
+      graphs: [PRODUCTS]
+      name: "connect"
+      args: {
+        source: "ecomm"
+        http: { GET: "/products" }
+        selection: "$.products {\n  id\n  name\n  description\n}"
+      }
+    )
+}
+```
+should extract `products` subgraph as;
+```graphql
+type Query {
+    products: @connect(
+      source: "ecomm"
+      http: { GET: "/products" }
+      selection: """
+      $.products {
+        id
+        name
+        description
+      }
+      """
+    )
+}
+```
+
+Same goes to the schema definition level directives;
+
+```graphql
+schema
+  @join__directive(
+    graphs: [PRODUCTS]
+    name: "link"
+    args: {
+      url: "https://specs.apollo.dev/connect/v0.2"
+      import: ["@connect", "@source"]
+    }
+  )
+  @join__directive(
+    graphs: [PRODUCTS]
+    name: "source"
+    args: {
+      name: "ecomm"
+      http: { baseURL: "https://ecommerce.demo-api.apollo.dev/", headers: [] }
+    }
+  ) {
+  query: Query
+}
+```
+
+should be extracted as;
+
+```graphql
+extend schema
+  @link( # Enable this schema to use Apollo Connectors
+    url: "https://specs.apollo.dev/connect/v0.2"
+    import: ["@connect", "@source"]
+  )
+  @source(
+    name: "ecomm"
+    # A @source directive defines a shared data source for multiple Connectors.
+    http: {
+        baseURL: "https://ecommerce.demo-api.apollo.dev/"
+        headers: [
+        # If your API requires headers, add them here and in your router.yaml file.
+        # Example:
+        # { name: "name", value: "{$config.apiKey}" }
+        ]
+    }
+  )
+```

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -42,7 +42,6 @@ import {
   buildASTSchema,
   ConstArgumentNode,
   ConstDirectiveNode,
-  ConstObjectValueNode,
   DefinitionNode,
   DirectiveDefinitionNode,
   DirectiveNode,
@@ -63,7 +62,6 @@ import {
   isObjectType,
   Kind,
   NamedTypeNode,
-  NameNode,
   ObjectTypeDefinitionNode,
   ObjectTypeExtensionNode,
   OperationTypeNode,
@@ -86,6 +84,7 @@ import {
   getCacheKeyFnFromKey,
   getKeyFnForFederation,
   getNamedTypeNode,
+  parseJoinDirective,
   ProgressiveOverrideHandler,
   progressiveOverridePossibilityHandler,
 } from './utils.js';
@@ -1020,64 +1019,19 @@ export function getStitchingOptionsFromSupergraphSdl(
     if (definition.kind === Kind.SCHEMA_DEFINITION) {
       if (definition.directives) {
         for (const directiveNode of definition.directives) {
-          if (directiveNode.name.value === 'join__directive') {
-            if (directiveNode.arguments) {
-              let directiveName: string | undefined = undefined;
-              let directiveArgsAst: ConstObjectValueNode | undefined =
-                undefined;
-              let graphNames: string[] = [];
-              for (const argumentNode of directiveNode.arguments) {
-                if (argumentNode.name.value === 'name') {
-                  if (argumentNode.value.kind === Kind.STRING) {
-                    directiveName = argumentNode.value.value;
-                  }
-                } else if (argumentNode.name.value === 'args') {
-                  if (argumentNode.value.kind === Kind.OBJECT) {
-                    directiveArgsAst = argumentNode.value;
-                  }
-                } else if (
-                  argumentNode.name.value === 'graphs' &&
-                  argumentNode.value.kind === Kind.LIST
-                ) {
-                  for (const graphNameNode of argumentNode.value.values) {
-                    if (graphNameNode.kind === Kind.ENUM) {
-                      graphNames.push(graphNameNode.value);
-                    }
-                  }
-                }
+          const parsed = parseJoinDirective(directiveNode);
+          if (parsed) {
+            for (const graphName of parsed.graphNames) {
+              let subgraphSchemaLevelDefs =
+                subgraphSchemaDefinitionDirectives.get(graphName);
+              if (!subgraphSchemaLevelDefs) {
+                subgraphSchemaLevelDefs = [];
+                subgraphSchemaDefinitionDirectives.set(
+                  graphName,
+                  subgraphSchemaLevelDefs,
+                );
               }
-              if (directiveName && graphNames.length > 0) {
-                for (const graphName of graphNames) {
-                  let subgraphSchemaLevelDefs =
-                    subgraphSchemaDefinitionDirectives.get(graphName);
-                  if (!subgraphSchemaLevelDefs) {
-                    subgraphSchemaLevelDefs = [];
-                    subgraphSchemaDefinitionDirectives.set(
-                      graphName,
-                      subgraphSchemaLevelDefs,
-                    );
-                  }
-                  let args: ConstArgumentNode[] | undefined = undefined;
-                  if (directiveArgsAst) {
-                    args = directiveArgsAst.fields.map((field) => ({
-                      kind: Kind.ARGUMENT,
-                      name: {
-                        kind: Kind.NAME,
-                        value: field.name.value,
-                      },
-                      value: field.value,
-                    }));
-                  }
-                  subgraphSchemaLevelDefs.push({
-                    kind: Kind.DIRECTIVE,
-                    name: {
-                      kind: Kind.NAME,
-                      value: directiveName,
-                    },
-                    arguments: args,
-                  });
-                }
-              }
+              subgraphSchemaLevelDefs.push(parsed.directive);
             }
           }
         }

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -42,6 +42,7 @@ import {
   buildASTSchema,
   ConstArgumentNode,
   ConstDirectiveNode,
+  ConstObjectValueNode,
   DefinitionNode,
   DirectiveDefinitionNode,
   DirectiveNode,
@@ -62,6 +63,7 @@ import {
   isObjectType,
   Kind,
   NamedTypeNode,
+  NameNode,
   ObjectTypeDefinitionNode,
   ObjectTypeExtensionNode,
   OperationTypeNode,
@@ -78,6 +80,7 @@ import {
 } from 'graphql';
 import {
   extractPercentageFromLabel,
+  filterDirectivesByGraph,
   filterInternalFieldsAndTypes,
   getArgsFromKeysForFederation,
   getCacheKeyFnFromKey,
@@ -221,6 +224,10 @@ export function getStitchingOptionsFromSupergraphSdl(
     Map<string, ProgressiveOverrideInfoOpposite[]>
   >();
   const overrideLabels = new Set<string>();
+  const subgraphSchemaDefinitionDirectives = new Map<
+    string,
+    ConstDirectiveNode[]
+  >();
 
   for (const definition of supergraphAst.definitions) {
     if ('fields' in definition) {
@@ -440,9 +447,10 @@ export function getStitchingOptionsFromSupergraphSdl(
                   fieldDefinitionNodesOfSubgraph.push({
                     ...fieldNode,
                     type: typeNode,
-                    directives: fieldNode.directives?.filter(
-                      (directiveNode) =>
-                        directiveNode.name.value !== 'join__field',
+                    directives: filterDirectivesByGraph(
+                      graphName,
+                      fieldNode.directives,
+                      ['join__field'],
                     ),
                   });
                 }
@@ -661,8 +669,10 @@ export function getStitchingOptionsFromSupergraphSdl(
             if (!joinFieldDirectives?.length) {
               fieldDefinitionNodesOfSubgraph.push({
                 ...fieldNode,
-                directives: fieldNode.directives?.filter(
-                  (directiveNode) => directiveNode.name.value !== 'join__field',
+                directives: filterDirectivesByGraph(
+                  graphName,
+                  fieldNode.directives,
+                  ['join__field'],
                 ),
               });
             } else if (
@@ -673,8 +683,10 @@ export function getStitchingOptionsFromSupergraphSdl(
             ) {
               fieldDefinitionNodesOfSubgraph.push({
                 ...fieldNode,
-                directives: fieldNode.directives?.filter(
-                  (directiveNode) => directiveNode.name.value !== 'join__field',
+                directives: filterDirectivesByGraph(
+                  graphName,
+                  fieldNode.directives,
+                  ['join__field'],
                 ),
               });
             }
@@ -769,12 +781,11 @@ export function getStitchingOptionsFromSupergraphSdl(
           ...typeNode,
           interfaces,
           fields: fieldDefinitionNodesOfSubgraph,
-          directives: typeNode.directives?.filter(
-            (directiveNode) =>
-              directiveNode.name.value !== 'join__type' &&
-              directiveNode.name.value !== 'join__owner' &&
-              directiveNode.name.value !== 'join__implements',
-          ),
+          directives: filterDirectivesByGraph(graphName, typeNode.directives, [
+            'join__type',
+            'join__owner',
+            'join__implements',
+          ]),
         };
         let subgraphTypes = subgraphTypesMap.get(graphName);
         if (!subgraphTypes) {
@@ -809,8 +820,10 @@ export function getStitchingOptionsFromSupergraphSdl(
               }
               subgraphTypes.push({
                 ...node,
-                directives: node.directives?.filter(
-                  (directiveNode) => directiveNode.name.value !== 'join__type',
+                directives: filterDirectivesByGraph(
+                  graphName,
+                  node.directives,
+                  ['join__type'],
                 ),
               });
             }
@@ -839,8 +852,10 @@ export function getStitchingOptionsFromSupergraphSdl(
               }
               subgraphTypes.push({
                 ...node,
-                directives: node.directives?.filter(
-                  (directiveNode) => directiveNode.name.value !== 'join__type',
+                directives: filterDirectivesByGraph(
+                  graphName,
+                  node.directives,
+                  ['join__type'],
                 ),
               });
             }
@@ -896,10 +911,10 @@ export function getStitchingOptionsFromSupergraphSdl(
                 subgraphTypes.push({
                   ...node,
                   types: unionMembers,
-                  directives: node.directives?.filter(
-                    (directiveNode) =>
-                      directiveNode.name.value !== 'join__type' &&
-                      directiveNode.name.value !== 'join__unionMember',
+                  directives: filterDirectivesByGraph(
+                    graphName,
+                    node.directives,
+                    ['join__type', 'join__unionMember'],
                   ),
                 });
               }
@@ -977,8 +992,10 @@ export function getStitchingOptionsFromSupergraphSdl(
               });
               const enumTypedDefNodeForSubgraph: EnumTypeDefinitionNode = {
                 ...node,
-                directives: node.directives?.filter(
-                  (directiveNode) => directiveNode.name.value !== 'join__type',
+                directives: filterDirectivesByGraph(
+                  graphName,
+                  node.directives,
+                  ['join__type'],
                 ),
                 values: enumValueNodes,
               };
@@ -998,6 +1015,77 @@ export function getStitchingOptionsFromSupergraphSdl(
     },
     ObjectTypeDefinition: TypeWithFieldsVisitor,
   });
+  // Get schema-level subgraph specific directives
+  for (const definition of supergraphAst.definitions) {
+    if (definition.kind === Kind.SCHEMA_DEFINITION) {
+      if (definition.directives) {
+        for (const directiveNode of definition.directives) {
+          if (directiveNode.name.value === 'join__directive') {
+            if (directiveNode.arguments) {
+              let directiveName: string | undefined = undefined;
+              let directiveArgsAst: ConstObjectValueNode | undefined =
+                undefined;
+              let graphNames: string[] = [];
+              for (const argumentNode of directiveNode.arguments) {
+                if (argumentNode.name.value === 'name') {
+                  if (argumentNode.value.kind === Kind.STRING) {
+                    directiveName = argumentNode.value.value;
+                  }
+                } else if (argumentNode.name.value === 'args') {
+                  if (argumentNode.value.kind === Kind.OBJECT) {
+                    directiveArgsAst = argumentNode.value;
+                  }
+                } else if (
+                  argumentNode.name.value === 'graphs' &&
+                  argumentNode.value.kind === Kind.LIST
+                ) {
+                  for (const graphNameNode of argumentNode.value.values) {
+                    if (graphNameNode.kind === Kind.ENUM) {
+                      graphNames.push(graphNameNode.value);
+                    }
+                  }
+                }
+              }
+              if (directiveName && graphNames.length > 0) {
+                for (const graphName of graphNames) {
+                  let subgraphSchemaLevelDefs =
+                    subgraphSchemaDefinitionDirectives.get(graphName);
+                  if (!subgraphSchemaLevelDefs) {
+                    subgraphSchemaLevelDefs = [];
+                    subgraphSchemaDefinitionDirectives.set(
+                      graphName,
+                      subgraphSchemaLevelDefs,
+                    );
+                  }
+                  let args: ConstArgumentNode[] | undefined = undefined;
+                  if (directiveArgsAst) {
+                    args = directiveArgsAst.fields.map((field) => ({
+                      kind: Kind.ARGUMENT,
+                      name: {
+                        kind: Kind.NAME,
+                        value: field.name.value,
+                      },
+                      value: field.value,
+                    }));
+                  }
+                  subgraphSchemaLevelDefs.push({
+                    kind: Kind.DIRECTIVE,
+                    name: {
+                      kind: Kind.NAME,
+                      value: directiveName,
+                    },
+                    arguments: args,
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+    } else {
+      continue;
+    }
+  }
   const subschemas: SubschemaConfig[] = [];
   for (const [subgraphName, endpoint] of subgraphEndpointMap) {
     const mergeConfig: SubschemaConfig['merge'] = {};
@@ -1426,6 +1514,14 @@ export function getStitchingOptionsFromSupergraphSdl(
       extraDefinitions.add({
         kind: Kind.SCHEMA_EXTENSION,
         directives: [...linkDirectiveNodes] as ConstDirectiveNode[],
+      });
+    }
+    const schemaDefDirectives =
+      subgraphSchemaDefinitionDirectives.get(subgraphName);
+    if (schemaDefDirectives) {
+      extraDefinitions.add({
+        kind: Kind.SCHEMA_EXTENSION,
+        directives: schemaDefDirectives,
       });
     }
 

--- a/packages/federation/src/utils.ts
+++ b/packages/federation/src/utils.ts
@@ -7,7 +7,16 @@ import {
   mergeDeep,
   parseSelectionSet,
 } from '@graphql-tools/utils';
-import { GraphQLSchema, Kind, SelectionSetNode, TypeNode } from 'graphql';
+import {
+  ConstArgumentNode,
+  ConstDirectiveNode,
+  ConstObjectValueNode,
+  GraphQLSchema,
+  Kind,
+  NameNode,
+  SelectionSetNode,
+  TypeNode,
+} from 'graphql';
 import { GraphQLResolveInfo } from 'graphql/type';
 
 export const getArgsFromKeysForFederation = memoize1(
@@ -285,4 +294,88 @@ export function extractPercentageFromLabel(label: string): number | undefined {
     return parsedFloat;
   }
   return undefined;
+}
+
+export function filterDirectivesByGraph(
+  graphName: string,
+  directives: readonly ConstDirectiveNode[] | undefined,
+  filterDirectives: string[],
+) {
+  if (!directives) {
+    return directives;
+  }
+  const subgraphSpecificDirectives: ConstDirectiveNode[] = [];
+  const filteredDirectives = directives?.filter((directiveNode) => {
+    if (filterDirectives.includes(directiveNode.name.value)) {
+      return false;
+    }
+    if (directiveNode.name.value === 'join__directive') {
+      let directiveName: string | undefined;
+      let directiveArgsAst: ConstObjectValueNode | undefined;
+      if (directiveNode.arguments == null) {
+        return false;
+      }
+      for (const joinDirectiveArg of directiveNode.arguments) {
+        if (
+          joinDirectiveArg.name.value === 'name' &&
+          joinDirectiveArg.value.kind === Kind.STRING
+        ) {
+          directiveName = joinDirectiveArg.value.value;
+        } else if (
+          joinDirectiveArg.name.value === 'args' &&
+          joinDirectiveArg.value.kind === Kind.OBJECT
+        ) {
+          directiveArgsAst = joinDirectiveArg.value;
+        } else if (
+          joinDirectiveArg.name.value === 'graphs' &&
+          joinDirectiveArg.value.kind === Kind.LIST
+        ) {
+          let graphMatches = false;
+          for (const graphAst of joinDirectiveArg.value.values) {
+            if (graphAst.kind === Kind.ENUM && graphAst.value === graphName) {
+              graphMatches = true;
+            }
+          }
+          if (!graphMatches) {
+            return false;
+          }
+        }
+      }
+      if (directiveName) {
+        const nameNode: NameNode = {
+          kind: Kind.NAME,
+          value: directiveName,
+        };
+        let args: ConstArgumentNode[] | undefined;
+        if (directiveArgsAst) {
+          args = [];
+          for (const argField of directiveArgsAst.fields) {
+            args.push({
+              kind: Kind.ARGUMENT,
+              name: argField.name,
+              value: argField.value,
+            });
+          }
+        }
+        subgraphSpecificDirectives.push({
+          kind: Kind.DIRECTIVE,
+          name: nameNode,
+          arguments: args,
+        });
+      }
+      return false;
+    }
+    return true;
+  });
+  const allDirectives = [];
+  if (filteredDirectives) {
+    allDirectives.push(...filteredDirectives);
+  }
+  if (subgraphSpecificDirectives.length > 0) {
+    allDirectives.push(...subgraphSpecificDirectives);
+  }
+  if (allDirectives.length === 0) {
+    return undefined;
+  }
+  return allDirectives;
 }

--- a/packages/federation/src/utils.ts
+++ b/packages/federation/src/utils.ts
@@ -370,7 +370,7 @@ export function filterDirectivesByGraph(
     }
     if (directiveNode.name.value === 'join__directive') {
       const parsed = parseJoinDirective(directiveNode);
-      if (parsed && parsed.graphNames.includes(graphName)) {
+      if (parsed?.graphNames.includes(graphName)) {
         subgraphSpecificDirectives.push(parsed.directive);
       }
       return false;

--- a/packages/federation/src/utils.ts
+++ b/packages/federation/src/utils.ts
@@ -13,7 +13,6 @@ import {
   ConstObjectValueNode,
   GraphQLSchema,
   Kind,
-  NameNode,
   SelectionSetNode,
   TypeNode,
 } from 'graphql';
@@ -296,84 +295,92 @@ export function extractPercentageFromLabel(label: string): number | undefined {
   return undefined;
 }
 
+/**
+ * Parses a `@join__directive` AST node into a concrete directive node and the
+ * list of subgraph names it applies to.  Returns `null` when the input is not a
+ * `@join__directive`, when the required `name` or `graphs` arguments are absent,
+ * or when `graphs` contains no entries.
+ */
+export function parseJoinDirective(
+  directiveNode: ConstDirectiveNode,
+): { graphNames: string[]; directive: ConstDirectiveNode } | null {
+  if (directiveNode.name.value !== 'join__directive') {
+    return null;
+  }
+  if (directiveNode.arguments == null) {
+    return null;
+  }
+  let directiveName: string | undefined;
+  let directiveArgsAst: ConstObjectValueNode | undefined;
+  const graphNames: string[] = [];
+  for (const argumentNode of directiveNode.arguments) {
+    if (
+      argumentNode.name.value === 'name' &&
+      argumentNode.value.kind === Kind.STRING
+    ) {
+      directiveName = argumentNode.value.value;
+    } else if (
+      argumentNode.name.value === 'args' &&
+      argumentNode.value.kind === Kind.OBJECT
+    ) {
+      directiveArgsAst = argumentNode.value;
+    } else if (
+      argumentNode.name.value === 'graphs' &&
+      argumentNode.value.kind === Kind.LIST
+    ) {
+      for (const graphNameNode of argumentNode.value.values) {
+        if (graphNameNode.kind === Kind.ENUM) {
+          graphNames.push(graphNameNode.value);
+        }
+      }
+    }
+  }
+  if (!directiveName || graphNames.length === 0) {
+    return null;
+  }
+  const args: ConstArgumentNode[] | undefined = directiveArgsAst
+    ? directiveArgsAst.fields.map((field) => ({
+        kind: Kind.ARGUMENT as const,
+        name: field.name,
+        value: field.value,
+      }))
+    : undefined;
+  return {
+    graphNames,
+    directive: {
+      kind: Kind.DIRECTIVE,
+      name: { kind: Kind.NAME, value: directiveName },
+      arguments: args,
+    },
+  };
+}
+
 export function filterDirectivesByGraph(
   graphName: string,
   directives: readonly ConstDirectiveNode[] | undefined,
   filterDirectives: string[],
-) {
+): readonly ConstDirectiveNode[] | undefined {
   if (!directives) {
     return directives;
   }
   const subgraphSpecificDirectives: ConstDirectiveNode[] = [];
-  const filteredDirectives = directives?.filter((directiveNode) => {
+  const filteredDirectives = directives.filter((directiveNode) => {
     if (filterDirectives.includes(directiveNode.name.value)) {
       return false;
     }
     if (directiveNode.name.value === 'join__directive') {
-      let directiveName: string | undefined;
-      let directiveArgsAst: ConstObjectValueNode | undefined;
-      if (directiveNode.arguments == null) {
-        return false;
-      }
-      for (const joinDirectiveArg of directiveNode.arguments) {
-        if (
-          joinDirectiveArg.name.value === 'name' &&
-          joinDirectiveArg.value.kind === Kind.STRING
-        ) {
-          directiveName = joinDirectiveArg.value.value;
-        } else if (
-          joinDirectiveArg.name.value === 'args' &&
-          joinDirectiveArg.value.kind === Kind.OBJECT
-        ) {
-          directiveArgsAst = joinDirectiveArg.value;
-        } else if (
-          joinDirectiveArg.name.value === 'graphs' &&
-          joinDirectiveArg.value.kind === Kind.LIST
-        ) {
-          let graphMatches = false;
-          for (const graphAst of joinDirectiveArg.value.values) {
-            if (graphAst.kind === Kind.ENUM && graphAst.value === graphName) {
-              graphMatches = true;
-            }
-          }
-          if (!graphMatches) {
-            return false;
-          }
-        }
-      }
-      if (directiveName) {
-        const nameNode: NameNode = {
-          kind: Kind.NAME,
-          value: directiveName,
-        };
-        let args: ConstArgumentNode[] | undefined;
-        if (directiveArgsAst) {
-          args = [];
-          for (const argField of directiveArgsAst.fields) {
-            args.push({
-              kind: Kind.ARGUMENT,
-              name: argField.name,
-              value: argField.value,
-            });
-          }
-        }
-        subgraphSpecificDirectives.push({
-          kind: Kind.DIRECTIVE,
-          name: nameNode,
-          arguments: args,
-        });
+      const parsed = parseJoinDirective(directiveNode);
+      if (parsed && parsed.graphNames.includes(graphName)) {
+        subgraphSpecificDirectives.push(parsed.directive);
       }
       return false;
     }
     return true;
   });
-  const allDirectives = [];
-  if (filteredDirectives) {
-    allDirectives.push(...filteredDirectives);
-  }
-  if (subgraphSpecificDirectives.length > 0) {
-    allDirectives.push(...subgraphSpecificDirectives);
-  }
+  const allDirectives: ConstDirectiveNode[] = [
+    ...filteredDirectives,
+    ...subgraphSpecificDirectives,
+  ];
   if (allDirectives.length === 0) {
     return undefined;
   }

--- a/packages/federation/tests/__snapshots__/split-subgraphs.test.ts.snap
+++ b/packages/federation/tests/__snapshots__/split-subgraphs.test.ts.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`split subgraphs correctly: LISTINGS 1`] = `
+""""A particular intergalactic location available for booking"""
+type Listing {
+  id: ID!
+  """The listing's title"""
+  title: String!
+  """The number of beds available"""
+  numOfBeds: Int
+  """The cost per night"""
+  costPerNight: Float
+  """Indicates whether listing is closed for bookings (on hiatus)"""
+  closed: Boolean
+}
+
+type Query {
+  """A curated array of listings to feature on the homepage"""
+  featuredListings: [Listing!]!
+  _entities(representations: [_Any!]!): [_Entity]!
+}
+
+union _Entity
+
+scalar _Any"
+`;
+
+exports[`split subgraphs correctly: PRODUCTS 1`] = `
+"extend schema @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]) @source(name: "ecomm", http: {baseURL: "https://ecommerce.demo-api.apollo.dev/", headers: []})
+
+type Price @connect(source: "ecomm", http: {GET: "/products/{$this.id}/price"}, selection: "id\\nactive\\ncurrency\\nunitAmount") {
+  id: ID!
+  active: Boolean
+  currency: String
+  unitAmount: Float
+}
+
+type Product @connect(source: "ecomm", http: {GET: "/products/{$this.id}"}, selection: "id\\nname\\ndescription\\nvariants {\\n  id: variantID\\n  name\\n}\\nprice {\\n    id: default_price\\n}") {
+  id: ID!
+  name: String
+  description: String
+  price: Price
+  variants: [Variant]
+}
+
+type Query {
+  products: [Product] @connect(source: "ecomm", http: {GET: "/products"}, selection: "$.products {\\n  id\\n  name\\n  description\\n}")
+  _entities(representations: [_Any!]!): [_Entity]!
+}
+
+type Variant {
+  id: ID!
+  name: String
+}
+
+union _Entity = Price
+
+scalar _Any"
+`;

--- a/packages/federation/tests/fixtures/connectors/listings.graphql
+++ b/packages/federation/tests/fixtures/connectors/listings.graphql
@@ -1,0 +1,36 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.11", import: ["@key"])
+
+type Query {
+  "A curated array of listings to feature on the homepage"
+  featuredListings: [Listing!]!
+
+  # # EXERCISE: LISTING DETAILS
+  # "A specific listing"
+  # listing(id: ID!): Listing
+}
+
+"A particular intergalactic location available for booking"
+type Listing {
+  id: ID!
+  "The listing's title"
+  title: String!
+  "The number of beds available"
+  numOfBeds: Int
+  "The cost per night"
+  costPerNight: Float
+  "Indicates whether listing is closed for bookings (on hiatus)"
+  closed: Boolean
+  # # EXERCISE: LISTING ACTIVITIES
+  # "The activities available for this listing"
+  # activities: [Activity!]!
+}
+
+# # EXERCISE: LISTING ACTIVITIES
+# type Activity {
+#   id: ID!
+#   name: String!
+#   description: String
+#   terrain: String
+#   groupSize: Int
+# }

--- a/packages/federation/tests/fixtures/connectors/products.graphql
+++ b/packages/federation/tests/fixtures/connectors/products.graphql
@@ -1,0 +1,94 @@
+# This schema uses Apollo Connectors, a declarative programming model for
+# GraphQL that allows you to plug in your existing REST services directly into
+# a graph. To learn more, visit Apollo's documentation: 🔗https://www.apollographql.com/docs/graphos/schema-design/connectors
+
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.11", import: ["@key"]) # Enable this schema to use Apollo Federation features
+  @link( # Enable this schema to use Apollo Connectors
+    url: "https://specs.apollo.dev/connect/v0.2"
+    import: ["@connect", "@source"]
+  )
+  # A @source directive defines a shared data source for multiple Connectors.
+  # ✏️ Replace the `name` and `baseURL` of this @source with your own REST API.
+  @source(
+    name: "ecomm"
+    # A @source directive defines a shared data source for multiple Connectors.
+    http: {
+      baseURL: "https://ecommerce.demo-api.apollo.dev/"
+      # If your API requires headers, add them here and in your router.yaml file.
+      # Example:
+      # { name: "name", value: "{$config.apiKey}" }
+      headers: []
+    }
+  )
+
+# ✏️ Replace this example type with your own object type.
+type Product
+  @connect(
+    source: "ecomm"
+    http: { GET: "/products/{$this.id}" }
+    selection: """
+    id
+    name
+    description
+    variants {
+      id: variantID
+      name
+    }
+    price {
+        id: default_price
+    }
+    """
+  ) {
+  id: ID!
+  name: String
+  description: String
+  price: Price
+  variants: [Variant]
+}
+
+type Price
+  @key(fields: "id")
+  @connect(
+    source: "ecomm"
+    http: { GET: "/products/{$this.id}/price" }
+    selection: """
+    id
+    active
+    currency
+    unitAmount
+    """
+  ) {
+  id: ID!
+  active: Boolean
+  currency: String
+  unitAmount: Float
+}
+
+# ✏️ Set up your Query field with the endpoint that returns the data you want.
+
+type Query {
+  # The Query.products field uses @connect to connect to the /products endpoint in the "ecomm" source.
+  # To check out the JSON response for this endpoint, go to 🔗 https://ecommerce.demo-api.apollo.dev/products.
+  products: [Product]
+    # A @connect directive defines the API data source of a GraphQL schema field.
+    @connect(
+      source: "ecomm"
+      http: { GET: "/products" } # GET, POST, PUT, PATCH, DELETE.
+      # Use @connect for any field that should be resolved by your REST API endpoints.
+      # Use the selection argument to map fields from the JSON response to the type.
+      # You can do more with this selection mapping. Learn more at 🔗 https://www.apollographql.com/docs/graphos/schema-design/connectors/responses
+      selection: """
+      $.products {
+        id
+        name
+        description
+      }
+      """
+    )
+}
+
+type Variant {
+  id: ID!
+  name: String
+}

--- a/packages/federation/tests/fixtures/connectors/supergraph.graphql
+++ b/packages/federation/tests/fixtures/connectors/supergraph.graphql
@@ -1,0 +1,186 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.2", for: EXECUTION)
+  @join__directive(
+    graphs: [PRODUCTS]
+    name: "link"
+    args: {
+      url: "https://specs.apollo.dev/connect/v0.2"
+      import: ["@connect", "@source"]
+    }
+  )
+  @join__directive(
+    graphs: [PRODUCTS]
+    name: "source"
+    args: {
+      name: "ecomm"
+      http: { baseURL: "https://ecommerce.demo-api.apollo.dev/", headers: [] }
+    }
+  ) {
+  query: Query
+}
+
+directive @join__directive(
+  graphs: [join__Graph!]
+  name: String!
+  args: join__DirectiveArguments
+) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+  overrideLabel: String
+  contextArguments: [join__ContextArgument!]
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  LISTINGS @join__graph(name: "listings", url: "http://ignore")
+  PRODUCTS @join__graph(name: "products", url: "http://ignore")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+"""
+A particular intergalactic location available for booking
+"""
+type Listing @join__type(graph: LISTINGS) {
+  id: ID!
+
+  """
+  The listing's title
+  """
+  title: String!
+
+  """
+  The number of beds available
+  """
+  numOfBeds: Int
+
+  """
+  The cost per night
+  """
+  costPerNight: Float
+
+  """
+  Indicates whether listing is closed for bookings (on hiatus)
+  """
+  closed: Boolean
+}
+
+type Price
+  @join__type(graph: PRODUCTS, key: "id")
+  @join__directive(
+    graphs: [PRODUCTS]
+    name: "connect"
+    args: {
+      source: "ecomm"
+      http: { GET: "/products/{$this.id}/price" }
+      selection: "id\nactive\ncurrency\nunitAmount"
+    }
+  ) {
+  id: ID!
+  active: Boolean
+  currency: String
+  unitAmount: Float
+}
+
+type Product
+  @join__type(graph: PRODUCTS)
+  @join__directive(
+    graphs: [PRODUCTS]
+    name: "connect"
+    args: {
+      source: "ecomm"
+      http: { GET: "/products/{$this.id}" }
+      selection: "id\nname\ndescription\nvariants {\n  id: variantID\n  name\n}\nprice {\n    id: default_price\n}"
+    }
+  ) {
+  id: ID!
+  name: String
+  description: String
+  price: Price
+  variants: [Variant]
+}
+
+type Query @join__type(graph: LISTINGS) @join__type(graph: PRODUCTS) {
+  """
+  A curated array of listings to feature on the homepage
+  """
+  featuredListings: [Listing!]! @join__field(graph: LISTINGS)
+  products: [Product]
+    @join__field(graph: PRODUCTS)
+    @join__directive(
+      graphs: [PRODUCTS]
+      name: "connect"
+      args: {
+        source: "ecomm"
+        http: { GET: "/products" }
+        selection: "$.products {\n  id\n  name\n  description\n}"
+      }
+    )
+}
+
+type Variant @join__type(graph: PRODUCTS) {
+  id: ID!
+  name: String
+}

--- a/packages/federation/tests/fixtures/connectors/supergraph.yaml
+++ b/packages/federation/tests/fixtures/connectors/supergraph.yaml
@@ -1,0 +1,10 @@
+subgraphs:
+  products:
+    routing_url: http://ignore
+    schema:
+      file: products.graphql
+  listings:
+    routing_url: http://ignore
+    schema:
+      file: listings.graphql
+federation_version: =2.11.0

--- a/packages/federation/tests/split-subgraphs.test.ts
+++ b/packages/federation/tests/split-subgraphs.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getStitchedSchemaFromSupergraphSdl } from '@graphql-tools/federation';
+import { DocumentNode, print } from 'graphql';
+import { expect, it } from 'vitest';
+
+it('split subgraphs correctly', () => {
+  const supergraphSdl = readFileSync(
+    join(__dirname, 'fixtures/connectors/supergraph.graphql'),
+    'utf-8',
+  );
+  const subgraphAstMap: Record<string, DocumentNode> = {};
+  getStitchedSchemaFromSupergraphSdl({
+    supergraphSdl,
+    onSubgraphAST(name, subgraphAST) {
+      subgraphAstMap[name] = subgraphAST;
+      return subgraphAST;
+    },
+  });
+  for (const subgraphName in subgraphAstMap) {
+    const subgraphAst = subgraphAstMap[subgraphName]!;
+    expect(print(subgraphAst)).toMatchSnapshot(subgraphName);
+  }
+});

--- a/packages/federation/tests/split-subgraphs.test.ts
+++ b/packages/federation/tests/split-subgraphs.test.ts
@@ -17,7 +17,7 @@ it('split subgraphs correctly', () => {
       return subgraphAST;
     },
   });
-  for (const subgraphName in subgraphAstMap) {
+  for (const subgraphName of Object.keys(subgraphAstMap).sort()) {
     const subgraphAst = subgraphAstMap[subgraphName]!;
     expect(print(subgraphAst)).toMatchSnapshot(subgraphName);
   }


### PR DESCRIPTION
Support `@join__directive` while extracting subgraph definitions from the supergraph

For example;

```graphql
type Query @join__type(graph: PRODUCTS) {
  products: [Product]
    @join__field(graph: PRODUCTS)
    @join__directive(
      graphs: [PRODUCTS]
      name: "connect"
      args: {
        source: "ecomm"
        http: { GET: "/products" }
        selection: "$.products {\n  id\n  name\n  description\n}"
      }
    )
}
```
should extract `products` subgraph as;
```graphql
type Query {
    products: @connect(
      source: "ecomm"
      http: { GET: "/products" }
      selection: """
      $.products {
        id
        name
        description
      }
      """
    )
}
```

Same goes to the schema definition level directives;

```graphql
schema
  @join__directive(
    graphs: [PRODUCTS]
    name: "link"
    args: {
      url: "https://specs.apollo.dev/connect/v0.2"
      import: ["@connect", "@source"]
    }
  )
  @join__directive(
    graphs: [PRODUCTS]
    name: "source"
    args: {
      name: "ecomm"
      http: { baseURL: "https://ecommerce.demo-api.apollo.dev/", headers: [] }
    }
  ) {
  query: Query
}
```

should be extracted as;

```graphql
extend schema
  @link( # Enable this schema to use Apollo Connectors
    url: "https://specs.apollo.dev/connect/v0.2"
    import: ["@connect", "@source"]
  )
  @source(
    name: "ecomm"
    # A @source directive defines a shared data source for multiple Connectors.
    http: {
        baseURL: "https://ecommerce.demo-api.apollo.dev/"
        headers: [
        # If your API requires headers, add them here and in your router.yaml file.
        # Example:
        # { name: "name", value: "{$config.apiKey}" }
        ]
    }
  )
```