### PR TITLE
fix(delegate): preserve inline fragment type condition during cross-subgraph delegation

### DIFF
--- a/.changeset/delegate-inline-fragment-context.md
+++ b/.changeset/delegate-inline-fragment-context.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+Fix cross-subgraph delegation for unavailable fields selected through inline fragments or fragment spreads on interface fields.
+
+The fix in `extractUnavailableFieldsFromSelectionSet` within `extractUnavailableFields.ts` now preserves the fragment wrapper and type condition, so concrete-type fields do not lose their type context and get treated as missing.

--- a/packages/delegate/src/extractUnavailableFields.ts
+++ b/packages/delegate/src/extractUnavailableFields.ts
@@ -119,6 +119,7 @@ export function extractUnavailableFieldsFromSelectionSet(
           });
         }
       } else if (isObjectType(subFieldType) || isInterfaceType(subFieldType)) {
+        const unavailableSubSelections: SelectionNode[] = [];
         const subFieldTypeFields = subFieldType.getFields();
         for (const subSelection of selection.selectionSet.selections) {
           if (subSelection.kind === Kind.FIELD) {
@@ -130,10 +131,20 @@ export function extractUnavailableFieldsFromSelectionSet(
               subFieldTypeFields[subSelection.name.value];
             if (!subSelectionField) {
               if (shouldAdd(subFieldType, subSelection)) {
-                unavailableSelections.push(subSelection);
+                unavailableSubSelections.push(subSelection);
               }
             }
           }
+        }
+        if (unavailableSubSelections.length) {
+          // Preserve the inline fragment wrapper so the type condition is not lost
+          unavailableSelections.push({
+            ...selection,
+            selectionSet: {
+              kind: Kind.SELECTION_SET,
+              selections: unavailableSubSelections,
+            },
+          });
         }
       }
     } else if (selection.kind === Kind.FRAGMENT_SPREAD) {

--- a/packages/delegate/tests/extractUnavailableFields.test.ts
+++ b/packages/delegate/tests/extractUnavailableFields.test.ts
@@ -1,6 +1,7 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { parseSelectionSet } from '@graphql-tools/utils';
 import {
+  FragmentDefinitionNode,
   getOperationAST,
   isObjectType,
   Kind,
@@ -200,6 +201,147 @@ describe('extractUnavailableFields', () => {
     };
     expect(stripWhitespaces(print(extractedSelectionSet))).toBe(
       '{ category { id details } }',
+    );
+  });
+  it('preserves inline fragment wrappers when the concrete type is missing from the subschema', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        interface P {
+          id: ID!
+        }
+
+        interface Account {
+          id: ID!
+        }
+
+        type Relationship implements P {
+          id: ID!
+          acct: Account
+        }
+
+        type Query {
+          relByAcct: Relationship
+        }
+      `,
+    });
+    const relationshipQuery = /* GraphQL */ `
+      query {
+        relByAcct {
+          acct {
+            ... on Card {
+              billing
+            }
+          }
+          id
+        }
+      }
+    `;
+    const relationshipQueryDoc = parse(relationshipQuery, { noLocation: true });
+    const operationAst = getOperationAST(relationshipQueryDoc, null);
+    if (!operationAst) {
+      throw new Error('Operation AST not found');
+    }
+    const selectionSet = operationAst.selectionSet;
+    const relationshipSelection = selectionSet.selections[0];
+    if (relationshipSelection?.kind !== 'Field') {
+      throw new Error('Relationship selection not found');
+    }
+    const queryType = schema.getType('Query');
+    if (!isObjectType(queryType)) {
+      throw new Error('Query type not found');
+    }
+    const relationshipField = queryType.getFields()['relByAcct'];
+    if (!relationshipField) {
+      throw new Error('Relationship field not found');
+    }
+    const unavailableFields = extractUnavailableFields(
+      schema,
+      relationshipField,
+      relationshipSelection,
+      () => true,
+    );
+    const extractedSelectionSet: SelectionSetNode = {
+      kind: Kind.SELECTION_SET,
+      selections: unavailableFields,
+    };
+    expect(stripWhitespaces(print(extractedSelectionSet))).toBe(
+      '{ acct { ... on Card { billing } } }',
+    );
+  });
+  it('preserves inline fragment wrappers from fragment spreads when the concrete type is missing from the subschema', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        interface P {
+          id: ID!
+        }
+
+        interface Account {
+          id: ID!
+        }
+
+        type Relationship implements P {
+          id: ID!
+          acct: Account
+        }
+
+        type Query {
+          relByAcct: Relationship
+        }
+      `,
+    });
+    const relationshipQuery = /* GraphQL */ `
+      query {
+        relByAcct {
+          acct {
+            ...CardFields
+          }
+          id
+        }
+      }
+
+      fragment CardFields on Card {
+        billing
+      }
+    `;
+    const relationshipQueryDoc = parse(relationshipQuery, { noLocation: true });
+    const operationAst = getOperationAST(relationshipQueryDoc, null);
+    if (!operationAst) {
+      throw new Error('Operation AST not found');
+    }
+    const selectionSet = operationAst.selectionSet;
+    const relationshipSelection = selectionSet.selections[0];
+    if (relationshipSelection?.kind !== 'Field') {
+      throw new Error('Relationship selection not found');
+    }
+    const queryType = schema.getType('Query');
+    if (!isObjectType(queryType)) {
+      throw new Error('Query type not found');
+    }
+    const relationshipField = queryType.getFields()['relByAcct'];
+    if (!relationshipField) {
+      throw new Error('Relationship field not found');
+    }
+    const fragments = relationshipQueryDoc.definitions.reduce<
+      Record<string, FragmentDefinitionNode>
+    >((acc, definition) => {
+      if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+        acc[definition.name.value] = definition;
+      }
+      return acc;
+    }, {});
+    const unavailableFields = extractUnavailableFields(
+      schema,
+      relationshipField,
+      relationshipSelection,
+      () => true,
+      fragments,
+    );
+    const extractedSelectionSet: SelectionSetNode = {
+      kind: Kind.SELECTION_SET,
+      selections: unavailableFields,
+    };
+    expect(stripWhitespaces(print(extractedSelectionSet))).toBe(
+      '{ acct { ... on Card { billing } } }',
     );
   });
   it('issue #6614', () => {

--- a/packages/delegate/tests/extractUnavailableFields.test.ts
+++ b/packages/delegate/tests/extractUnavailableFields.test.ts
@@ -243,7 +243,7 @@ describe('extractUnavailableFields', () => {
     }
     const selectionSet = operationAst.selectionSet;
     const relationshipSelection = selectionSet.selections[0];
-    if (relationshipSelection?.kind !== 'Field') {
+    if (relationshipSelection?.kind !== Kind.FIELD) {
       throw new Error('Relationship selection not found');
     }
     const queryType = schema.getType('Query');


### PR DESCRIPTION
Closes: https://github.com/graphql-hive/gateway/issues/2381

## The Fix

Preserve the inline fragment wrapper:

```js
} else if (graphql.isObjectType(subFieldType) || graphql.isInterfaceType(subFieldType)) {
  const unavailableSubSelections = [];
  for (const subSelection of selection.selectionSet.selections) {
    if (subSelection.kind === graphql.Kind.FIELD && subSelection.name.value === "__typename") {
      continue;
    }
    if (shouldAdd(subFieldType, subSelection)) {
      unavailableSubSelections.push(subSelection);
    }
  }
  if (unavailableSubSelections.length) {
    // Preserve the inline fragment wrapper so the type condition is not lost
    unavailableSelections.push({
      ...selection,
      selectionSet: {
        kind: graphql.Kind.SELECTION_SET,
        selections: unavailableSubSelections
      }
    });
  }
}
```

### What changed

| Before (bug)                                                         | After (fix)                                                                                                          |
| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| `unavailableSelections.push(subSelection)` — pushes bare field nodes | `unavailableSelections.push({ ...selection, selectionSet: { selections } })` — wraps in the original inline fragment |
| Delegated query: `acct { billing }`                                   | Delegated query: `acct { ... on Card { billing } }`                                                                   |
| `filterSelectionSet` strips `billing` (not on interface)              | `filterSelectionSet` finds `billing` on `Card` ✅                                                                     |

---