### PR TITLE
Default `mergeDirectives` to true and fix `false` by stripping directive usages

### DIFF
--- a/.changeset/purple-monkeys-drum.md
+++ b/.changeset/purple-monkeys-drum.md
@@ -1,0 +1,29 @@
+---
+'@graphql-tools/stitch': patch
+---
+
+Always retain directive definitions from subschemas in stitched schema
+
+Custom directive definitions from subschemas were silently dropped from the stitched schema unless `mergeDirectives: true` was explicitly passed to `stitchSchemas`. This meant a schema like:
+
+```graphql
+directive @public on SCHEMA | OBJECT | FIELD_DEFINITION
+
+type Query @public {
+  isAnExample: Boolean @public
+}
+```
+
+would stitch into:
+
+```graphql
+type Query @public {
+  isAnExample: Boolean @public
+}
+```
+
+The directive usages on types and fields were preserved (carried over via AST nodes through `mergeCandidates`), but the directive definitions themselves were dropped, producing a broken schema where directives are used but never defined.
+
+`mergeDirectives` was flawed to begin with... `mergeDirectives: false` produced an internally inconsistent schema where directive usages existed on fields and types but the corresponding definitions were removed. The correct way to suppress directives from appearing in the stitched schema would have been to also strip their usages from field and type AST nodes - but that was never done. So `mergeDirectives: false` never achieved a clean "no directives" result, it just produced a broken one. In essence, fixing the `mergeDirectives: false` behavior would actually be a breaking change!
+
+Having said all that, we've instead removed the `mergeDirectives` argument and guard so directives from subschemas are always collected. This is correct default behavior - a stitched schema should retain all directive definitions from its subschemas unconditionally. This is not breaking because it actually fixes the partial merge.

--- a/.changeset/purple-monkeys-drum.md
+++ b/.changeset/purple-monkeys-drum.md
@@ -2,7 +2,7 @@
 '@graphql-tools/stitch': patch
 ---
 
-Always retain directive definitions from subschemas in stitched schema
+Fix `mergeDirectives` option and default it to `true`
 
 Custom directive definitions from subschemas were silently dropped from the stitched schema unless `mergeDirectives: true` was explicitly passed to `stitchSchemas`. This meant a schema like:
 
@@ -14,16 +14,8 @@ type Query @public {
 }
 ```
 
-would stitch into:
+would stitch into a broken schema where `@public` was used on types and fields but never defined.
 
-```graphql
-type Query @public {
-  isAnExample: Boolean @public
-}
-```
+The default is now `true`, so directive definitions are always collected and retained in the stitched schema, this is the expected behaviour since the merging was partial before this fix (usages got merged, but definitions not).
 
-The directive usages on types and fields were preserved (carried over via AST nodes through `mergeCandidates`), but the directive definitions themselves were dropped, producing a broken schema where directives are used but never defined.
-
-`mergeDirectives` was flawed to begin with... `mergeDirectives: false` produced an internally inconsistent schema where directive usages existed on fields and types but the corresponding definitions were removed. The correct way to suppress directives from appearing in the stitched schema would have been to also strip their usages from field and type AST nodes - but that was never done. So `mergeDirectives: false` never achieved a clean "no directives" result, it just produced a broken one. In essence, fixing the `mergeDirectives: false` behavior would actually be a breaking change!
-
-Having said all that, we've instead removed the `mergeDirectives` argument and guard so directives from subschemas are always collected. This is correct default behavior - a stitched schema should retain all directive definitions from its subschemas unconditionally. This is not breaking because it actually fixes the partial merge.
+Passing `mergeDirectives: false` now produces a fully clean result - both directive definitions and all their usages on types, fields, input fields, and enum values are stripped.

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -176,37 +176,44 @@ export function stitchSchemas<
 }
 
 function stripCustomDirectiveUsages(types: GraphQLNamedType[]): void {
+  const isBuiltin = (d: { name: { value: string } }) =>
+    isSpecifiedDirective(
+      // @ts-expect-error it's ok to use just the name, isSpecifiedDirective does the same internally
+      { name: d.name.value },
+    );
+
   for (const type of types) {
     if (type.astNode?.directives?.length) {
-      (type.astNode as any).directives = type.astNode.directives.filter((d) =>
-        isSpecifiedDirective({ name: d.name.value } as GraphQLDirective),
-      );
+      type.astNode = {
+        ...type.astNode,
+        directives: type.astNode.directives.filter(isBuiltin),
+      };
     }
     if (isObjectType(type) || isInterfaceType(type)) {
       for (const field of Object.values(type.getFields())) {
         if (field.astNode?.directives?.length) {
-          (field.astNode as any).directives = field.astNode.directives.filter(
-            (d) =>
-              isSpecifiedDirective({ name: d.name.value } as GraphQLDirective),
-          );
+          field.astNode = {
+            ...field.astNode,
+            directives: field.astNode.directives.filter(isBuiltin),
+          };
         }
       }
     } else if (isInputObjectType(type)) {
       for (const field of Object.values(type.getFields())) {
         if (field.astNode?.directives?.length) {
-          (field.astNode as any).directives = field.astNode.directives.filter(
-            (d) =>
-              isSpecifiedDirective({ name: d.name.value } as GraphQLDirective),
-          );
+          field.astNode = {
+            ...field.astNode,
+            directives: field.astNode.directives.filter(isBuiltin),
+          };
         }
       }
     } else if (isEnumType(type)) {
       for (const value of type.getValues()) {
         if (value.astNode?.directives?.length) {
-          (value.astNode as any).directives = value.astNode.directives.filter(
-            (d) =>
-              isSpecifiedDirective({ name: d.name.value } as GraphQLDirective),
-          );
+          value.astNode = {
+            ...value.astNode,
+            directives: value.astNode.directives.filter(isBuiltin),
+          };
         }
       }
     }

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -47,7 +47,6 @@ export function stitchSchemas<
   types = [],
   typeDefs = [],
   onTypeConflict,
-  mergeDirectives,
   mergeTypes = true,
   typeMergingOptions,
   subschemaConfigTransforms = [],
@@ -58,6 +57,7 @@ export function stitchSchemas<
   schemaExtensions,
   ...rest
 }: IStitchSchemasOptions<TContext>): GraphQLSchema {
+  const mergeDirectives = rest.mergeDirectives ?? true;
   const transformedSubschemas: Array<Subschema<any, any, any, TContext>> = [];
   const subschemaMap: Map<
     GraphQLSchema | SubschemaConfig<any, any, any, TContext>,
@@ -93,7 +93,7 @@ export function stitchSchemas<
     parseOptions: rest,
     directiveMap,
     schemaDefs,
-    mergeDirectives: mergeDirectives ?? true,
+    mergeDirectives,
   });
 
   let stitchingInfo = createStitchingInfo(
@@ -112,7 +112,7 @@ export function stitchSchemas<
     typeMergingOptions,
   });
 
-  if (!(mergeDirectives ?? true)) {
+  if (!mergeDirectives) {
     stripCustomDirectiveUsages(Object.values(newTypeMap));
   }
 

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -18,8 +18,14 @@ import { inspect, IResolvers } from '@graphql-tools/utils';
 import {
   extendSchema,
   GraphQLDirective,
+  GraphQLNamedType,
   GraphQLObjectType,
   GraphQLSchema,
+  isEnumType,
+  isInputObjectType,
+  isInterfaceType,
+  isObjectType,
+  isSpecifiedDirective,
   specifiedDirectives,
 } from 'graphql';
 import {
@@ -87,6 +93,7 @@ export function stitchSchemas<
     parseOptions: rest,
     directiveMap,
     schemaDefs,
+    mergeDirectives: mergeDirectives ?? true,
   });
 
   let stitchingInfo = createStitchingInfo(
@@ -104,6 +111,10 @@ export function stitchSchemas<
     mergeTypes,
     typeMergingOptions,
   });
+
+  if (!(mergeDirectives ?? true)) {
+    stripCustomDirectiveUsages(Object.values(newTypeMap));
+  }
 
   let schema = new GraphQLSchema({
     query: newTypeMap[rootTypeNameMap.query] as GraphQLObjectType,
@@ -162,6 +173,44 @@ export function stitchSchemas<
   }
 
   return schema;
+}
+
+function stripCustomDirectiveUsages(types: GraphQLNamedType[]): void {
+  for (const type of types) {
+    if (type.astNode?.directives?.length) {
+      (type.astNode as any).directives = type.astNode.directives.filter((d) =>
+        isSpecifiedDirective({ name: d.name.value } as GraphQLDirective),
+      );
+    }
+    if (isObjectType(type) || isInterfaceType(type)) {
+      for (const field of Object.values(type.getFields())) {
+        if (field.astNode?.directives?.length) {
+          (field.astNode as any).directives = field.astNode.directives.filter(
+            (d) =>
+              isSpecifiedDirective({ name: d.name.value } as GraphQLDirective),
+          );
+        }
+      }
+    } else if (isInputObjectType(type)) {
+      for (const field of Object.values(type.getFields())) {
+        if (field.astNode?.directives?.length) {
+          (field.astNode as any).directives = field.astNode.directives.filter(
+            (d) =>
+              isSpecifiedDirective({ name: d.name.value } as GraphQLDirective),
+          );
+        }
+      }
+    } else if (isEnumType(type)) {
+      for (const value of type.getValues()) {
+        if (value.astNode?.directives?.length) {
+          (value.astNode as any).directives = value.astNode.directives.filter(
+            (d) =>
+              isSpecifiedDirective({ name: d.name.value } as GraphQLDirective),
+          );
+        }
+      }
+    }
+  }
 }
 
 const subschemaConfigTransformerPresets: Array<SubschemaConfigTransform<any>> =

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -87,7 +87,6 @@ export function stitchSchemas<
     parseOptions: rest,
     directiveMap,
     schemaDefs,
-    mergeDirectives,
   });
 
   let stitchingInfo = createStitchingInfo(

--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -53,7 +53,6 @@ export function buildTypeCandidates<
   parseOptions,
   directiveMap,
   schemaDefs,
-  mergeDirectives: isMergeDirectives,
 }: {
   subschemas: Array<Subschema<any, any, any, TContext>>;
   originalSubschemaMap: Map<
@@ -68,7 +67,6 @@ export function buildTypeCandidates<
     schemaDef: SchemaDefinitionNode;
     schemaExtensions: Array<SchemaExtensionNode>;
   };
-  mergeDirectives?: boolean | undefined;
 }): [
   Record<string, Array<MergeTypeCandidate<TContext>>>,
   Record<OperationTypeNode, string>,
@@ -120,17 +118,13 @@ export function buildTypeCandidates<
       });
     }
 
-    if (isMergeDirectives === true) {
-      for (const directive of schema.getDirectives()) {
-        let directiveCandidatesForName = directiveCandidates.get(
-          directive.name,
-        );
-        if (directiveCandidatesForName == null) {
-          directiveCandidatesForName = new Set();
-          directiveCandidates.set(directive.name, directiveCandidatesForName);
-        }
-        directiveCandidatesForName.add(directive);
+    for (const directive of schema.getDirectives()) {
+      let directiveCandidatesForName = directiveCandidates.get(directive.name);
+      if (directiveCandidatesForName == null) {
+        directiveCandidatesForName = new Set();
+        directiveCandidates.set(directive.name, directiveCandidatesForName);
       }
+      directiveCandidatesForName.add(directive);
     }
 
     const originalTypeMap = schema.getTypeMap();

--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -53,6 +53,7 @@ export function buildTypeCandidates<
   parseOptions,
   directiveMap,
   schemaDefs,
+  mergeDirectives: isMergeDirectives = true,
 }: {
   subschemas: Array<Subschema<any, any, any, TContext>>;
   originalSubschemaMap: Map<
@@ -67,6 +68,7 @@ export function buildTypeCandidates<
     schemaDef: SchemaDefinitionNode;
     schemaExtensions: Array<SchemaExtensionNode>;
   };
+  mergeDirectives?: boolean | undefined;
 }): [
   Record<string, Array<MergeTypeCandidate<TContext>>>,
   Record<OperationTypeNode, string>,
@@ -118,13 +120,17 @@ export function buildTypeCandidates<
       });
     }
 
-    for (const directive of schema.getDirectives()) {
-      let directiveCandidatesForName = directiveCandidates.get(directive.name);
-      if (directiveCandidatesForName == null) {
-        directiveCandidatesForName = new Set();
-        directiveCandidates.set(directive.name, directiveCandidatesForName);
+    if (isMergeDirectives) {
+      for (const directive of schema.getDirectives()) {
+        let directiveCandidatesForName = directiveCandidates.get(
+          directive.name,
+        );
+        if (directiveCandidatesForName == null) {
+          directiveCandidatesForName = new Set();
+          directiveCandidates.set(directive.name, directiveCandidatesForName);
+        }
+        directiveCandidatesForName.add(directive);
       }
-      directiveCandidatesForName.add(directive);
     }
 
     const originalTypeMap = schema.getTypeMap();

--- a/packages/stitch/src/types.ts
+++ b/packages/stitch/src/types.ts
@@ -59,7 +59,14 @@ export interface IStitchSchemasOptions<
   typeDefs?: TypeSource;
   types?: Array<GraphQLNamedType>;
   onTypeConflict?: OnTypeConflict<TContext>;
-  /** @deprecated Directives are always merged, this option has no effect. */
+  /**
+   * Should directive definitions from all subschemas be collected and included in the stitched schema.
+   *
+   * When false, custom directive definitions are excluded and their usages are stripped from all type
+   * and field AST nodes.
+   *
+   * @default true
+   */
   mergeDirectives?: boolean | undefined;
   mergeTypes?: boolean | Array<string> | MergeTypeFilter<TContext>;
   typeMergingOptions?: TypeMergingOptions<TContext>;

--- a/packages/stitch/src/types.ts
+++ b/packages/stitch/src/types.ts
@@ -59,6 +59,7 @@ export interface IStitchSchemasOptions<
   typeDefs?: TypeSource;
   types?: Array<GraphQLNamedType>;
   onTypeConflict?: OnTypeConflict<TContext>;
+  /** @deprecated Directives are always merged, this option has no effect. */
   mergeDirectives?: boolean | undefined;
   mergeTypes?: boolean | Array<string> | MergeTypeFilter<TContext>;
   typeMergingOptions?: TypeMergingOptions<TContext>;

--- a/packages/stitch/tests/stitchSchemas.test.ts
+++ b/packages/stitch/tests/stitchSchemas.test.ts
@@ -3849,8 +3849,8 @@ it('should be able to extend a transformed schema', async () => {
   ]);
 });
 
-it('stitch schemas retains schema directive usage and definitions within stitched schema result', async () => {
-  const sdl = /* GraphQL */ `
+describe('directive merging', () => {
+  const directiveMergeTestSdl = /* GraphQL */ `
     directive @public on SCHEMA | OBJECT | FIELD_DEFINITION
 
     type Query @public {
@@ -3858,29 +3858,36 @@ it('stitch schemas retains schema directive usage and definitions within stitche
     }
   `;
 
-  const stitchedSchema = stitchSchemas({
-    subschemas: [buildASTSchema(parse(sdl))],
+  it('stitch schemas retains directive definitions and usages by default (mergeDirectives: true)', () => {
+    const stitchedSchema = stitchSchemas({
+      subschemas: [buildASTSchema(parse(directiveMergeTestSdl))],
+    });
+    expect(printSchemaWithDirectives(stitchedSchema)).toMatchInlineSnapshot(`
+      "schema {
+        query: Query
+      }
+
+      directive @public on SCHEMA | OBJECT | FIELD_DEFINITION
+
+      type Query @public {
+        isAnExample: Boolean @public
+      }"
+    `);
   });
-  const stitchedSdl = printSchemaWithDirectives(stitchedSchema);
-  expect(
-    stitchedSchema
-      .getQueryType()
-      ?.astNode?.directives?.find((d) => d.name.value === 'public'),
-  ).toBeDefined();
-  expect(stitchedSdl).toContain(`type Query @public`);
-  expect(
-    stitchedSchema
-      .getQueryType()
-      ?.getFields()
-      ['isAnExample']?.astNode?.directives?.find(
-        (d) => d.name.value === 'public',
-      ),
-  ).toBeDefined();
-  expect(stitchedSdl).toContain(`isAnExample: Boolean @public`);
-  expect(
-    stitchedSchema.getDirectives().find((d) => d.name === 'public'),
-  ).toBeDefined();
-  expect(stitchedSdl).toContain(
-    `directive @public on SCHEMA | OBJECT | FIELD_DEFINITION`,
-  );
+
+  it('stitch schemas strips directive definitions and usages when mergeDirectives: false', () => {
+    const stitchedSchema = stitchSchemas({
+      subschemas: [buildASTSchema(parse(directiveMergeTestSdl))],
+      mergeDirectives: false,
+    });
+    expect(printSchemaWithDirectives(stitchedSchema)).toMatchInlineSnapshot(`
+      "schema {
+        query: Query
+      }
+
+      type Query {
+        isAnExample: Boolean
+      }"
+    `);
+  });
 });

--- a/packages/stitch/tests/stitchSchemas.test.ts
+++ b/packages/stitch/tests/stitchSchemas.test.ts
@@ -16,6 +16,7 @@ import {
   ExecutionResult,
   getResolversFromSchema,
   IResolvers,
+  printSchemaWithDirectives,
 } from '@graphql-tools/utils';
 import { assertAsyncIterable } from '@internal/testing';
 import {
@@ -30,6 +31,7 @@ import {
   subscriptionPubSubTrigger,
 } from '@internal/testing/fixtures/schemas';
 import {
+  buildASTSchema,
   buildSchema,
   graphql,
   GraphQLObjectType,
@@ -3845,4 +3847,40 @@ it('should be able to extend a transformed schema', async () => {
       },
     },
   ]);
+});
+
+it('stitch schemas retains schema directive usage and definitions within stitched schema result', async () => {
+  const sdl = /* GraphQL */ `
+    directive @public on SCHEMA | OBJECT | FIELD_DEFINITION
+
+    type Query @public {
+      isAnExample: Boolean @public
+    }
+  `;
+
+  const stitchedSchema = stitchSchemas({
+    subschemas: [buildASTSchema(parse(sdl))],
+  });
+  const stitchedSdl = printSchemaWithDirectives(stitchedSchema);
+  expect(
+    stitchedSchema
+      .getQueryType()
+      ?.astNode?.directives?.find((d) => d.name.value === 'public'),
+  ).toBeDefined();
+  expect(stitchedSdl).toContain(`type Query @public`);
+  expect(
+    stitchedSchema
+      .getQueryType()
+      ?.getFields()
+      ['isAnExample']?.astNode?.directives?.find(
+        (d) => d.name.value === 'public',
+      ),
+  ).toBeDefined();
+  expect(stitchedSdl).toContain(`isAnExample: Boolean @public`);
+  expect(
+    stitchedSchema.getDirectives().find((d) => d.name === 'public'),
+  ).toBeDefined();
+  expect(stitchedSdl).toContain(
+    `directive @public on SCHEMA | OBJECT | FIELD_DEFINITION`,
+  );
 });


### PR DESCRIPTION
Custom directive definitions from subschemas were silently dropped from the stitched schema unless `mergeDirectives: true` was explicitly passed to `stitchSchemas`. This meant a schema like:

```graphql
directive @public on SCHEMA | OBJECT | FIELD_DEFINITION

type Query @public {
  isAnExample: Boolean @public
}
```

would stitch into a broken schema where `@public` was used on types and fields but never defined - because directive usages were carried over via AST nodes through `mergeCandidates`, but the directive definitions themselves were not collected.

The old `mergeDirectives: false` behavior was also broken for the inverse reason: it only dropped directive definitions, but left all the usages on field and type AST nodes intact. So it never achieved a clean "no directives" schema - it just produced an inconsistent one. The correct suppression would have required also stripping usages from every field, type, input field, and enum value AST node, which was never done.

This PR fixes both sides:

- `mergeDirectives` now defaults to `true`, so directive definitions are always collected from subschemas and retained in the stitched schema. This is the expected (now fixed) default behavior - a stitched schema should reflect the full set of directives its subschemas declare.
- `mergeDirectives: false` now does the full job: directive definitions are not collected, and all custom directive usages are stripped from type, field, input field, and enum value AST nodes. Built-in directives (`@deprecated`, `@specifiedBy`, etc.) are preserved regardless.
