### PR TITLE
Hive Gateway images ship with Rust QP

### DIFF
--- a/.changeset/smart-swans-design.md
+++ b/.changeset/smart-swans-design.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+Hive Gateway images ship with Rust QP
+
+An accidental regression happened starting release v2.7.1 where the Rust QP was missing from the image.

--- a/.changeset/smart-swans-design.md
+++ b/.changeset/smart-swans-design.md
@@ -4,4 +4,4 @@
 
 Hive Gateway images ship with Rust QP
 
-An accidental regression happened starting release v2.7.1 where the Rust QP was missing from the image.
+An accidental regression happened starting with release v2.7.1 where the Rust QP was missing from the image.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,8 @@ jobs:
       - name: Build
         run: yarn build
       - name: Bundle
+        env:
+          NODE_OPTIONS: '--max-old-space-size=6144'
         run: yarn workspace @graphql-hive/gateway bundle
       - name: Inject version
         run: yarn workspace @graphql-hive/gateway tsx scripts/inject-version ${{ fromJSON(steps.ver-gateway.outputs.result).version }}
@@ -232,6 +234,8 @@ jobs:
       - name: Build
         run: yarn build
       - name: Bundle
+        env:
+          NODE_OPTIONS: '--max-old-space-size=6144'
         run: yarn workspace @graphql-hive/gateway bundle
       - name: Inject version
         run: yarn workspace @graphql-hive/gateway tsx scripts/inject-version "${{ steps.ver-gateway.outputs.result }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,50 +105,6 @@ jobs:
     secrets:
       githubToken: ${{ secrets.BOT_GITHUB_TOKEN }}
       npmToken: ${{ secrets.NPM_TOKEN }}
-  bundle:
-    name: Bundle
-    needs: [stable, snapshot]
-    if: always() && (
-      contains(needs.stable.outputs.publishedPackages, '@graphql-hive/gateway') ||
-      contains(needs.snapshot.outputs.publishedPackages, '@graphql-hive/gateway')
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Set up env
-        uses: the-guild-org/shared-config/setup@v1
-        with:
-          node-version-file: .node-version
-      - name: Get version
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
-        id: ver-gateway
-        with:
-          result-encoding: string
-          script: |
-            const publishedPackages = ${{ needs.stable.outputs.publishedPackages || needs.snapshot.outputs.publishedPackages }};
-            const gateway = publishedPackages.find((p) => p.name === '@graphql-hive/gateway');
-            if (!gateway) {
-              return core.setFailed('@graphql-hive/gateway was not published!');
-            }
-            return gateway.version;
-      - name: Build
-        run: yarn build
-      - name: Bundle
-        run: yarn workspace @graphql-hive/gateway bundle
-        env:
-          NODE_OPTIONS: '--max-old-space-size=6144'
-      - name: Inject version
-        run: yarn workspace @graphql-hive/gateway tsx scripts/inject-version "${{ steps.ver-gateway.outputs.result }}"
-      - name: Upload bundle artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-        with:
-          name: gateway-bundle
-          path: packages/gateway/bundle
-          include-hidden-files: true
-
   ghcr:
     runs-on: ubuntu-latest
     strategy:
@@ -156,9 +112,8 @@ jobs:
       matrix:
         runtime: [Node, Bun]
     name: ${{ matrix.runtime }} Docker image
-    needs: [bundle, stable, snapshot]
-    if:
-      always() && needs.bundle.result == 'success' && github.actor != 'dependabot[bot]' && (
+    needs: [stable, snapshot]
+    if: always() && github.actor != 'dependabot[bot]' && (
       contains(needs.stable.outputs.publishedPackages, '@graphql-hive/gateway') ||
       contains(needs.snapshot.outputs.publishedPackages, '@graphql-hive/gateway')
       )
@@ -200,14 +155,12 @@ jobs:
         uses: the-guild-org/shared-config/setup@v1
         with:
           node-version-file: .node-version
-      - name: Download bundle artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gateway-bundle
-          path: packages/gateway/bundle
-      - name: Remove query planner from shared bundle overlay
-        run: |
-          node -e "require('node:fs').rmSync('packages/gateway/bundle/node_modules/@graphql-hive/router-query-planner', { recursive: true, force: true })"
+      - name: Build
+        run: yarn build
+      - name: Bundle
+        run: yarn workspace @graphql-hive/gateway bundle
+      - name: Inject version
+        run: yarn workspace @graphql-hive/gateway tsx scripts/inject-version ${{ fromJSON(steps.ver-gateway.outputs.result).version }}
       - name: Bake and Push
         uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7.2.0
         env:
@@ -236,8 +189,8 @@ jobs:
 
   bin:
     name: Binary built on ${{ matrix.os }}
-    needs: [bundle, stable, snapshot]
-    if: always() && needs.bundle.result == 'success' && (
+    needs: [stable, snapshot]
+    if: always() && (
       contains(needs.stable.outputs.publishedPackages, '@graphql-hive/gateway') ||
       contains(needs.snapshot.outputs.publishedPackages, '@graphql-hive/gateway')
       )
@@ -276,16 +229,12 @@ jobs:
           node-version: 25.2.0
           # we skip-build on ubuntu arm because the "canvas" package wont build and there are no prebuilts
           install-command: ${{ matrix.os == 'ubuntu-24.04-arm' && 'yarn install --immutable --mode=skip-build' || '' }}
-      - name: Download bundle artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: gateway-bundle
-          path: packages/gateway/bundle
-      - name: Repack binary bundle with local query planner
-        run: |
-          node -e "require('node:fs').rmSync('packages/gateway/bundle/node_modules/@graphql-hive/router-query-planner', { recursive: true, force: true })"
-          node -e "require('node:fs').cpSync('node_modules/@graphql-hive/router-query-planner', 'packages/gateway/bundle/node_modules/@graphql-hive/router-query-planner', { recursive: true })"
-          yarn workspace @graphql-hive/gateway exec rollup -c rollup.config.binary.js
+      - name: Build
+        run: yarn build
+      - name: Bundle
+        run: yarn workspace @graphql-hive/gateway bundle
+      - name: Inject version
+        run: yarn workspace @graphql-hive/gateway tsx scripts/inject-version "${{ steps.ver-gateway.outputs.result }}"
       - name: Package binary
         run: yarn workspace @graphql-hive/gateway tsx scripts/package-binary
       - name: Set binary info


### PR DESCRIPTION
Reverts #2335, it's done too much and didnt really fix the original issue (which was an OOM on macOS) - it just added a --max-old-space-size=6144 and masked it with a bunch of "smartness". It also contains some fineky behaviour around the fact that OS-native addons must be used.