### PR TITLE
Nothing is leaking on Node v26 leaktests

### DIFF
--- a/packages/fusion-runtime/tests/polling.test.ts
+++ b/packages/fusion-runtime/tests/polling.test.ts
@@ -446,13 +446,7 @@ describe('Polling', () => {
     });
     expect(unifiedGraphFetcher).toHaveBeenCalledTimes(1);
     graphDeferred = createDeferred();
-    const timeout$ = new Promise<void>((resolve) => {
-      globalThis.setTimeout(() => {
-        resolve();
-      }, 10_000);
-    });
     await advanceTimersByTimeAsync(10_000);
-    await timeout$;
     const secondRes = await executor({
       document: parse(/* GraphQL */ `
         query {


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix Node v26 leaktest by removing unnecessary timeout await in polling test
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Ok bear with me...

When running leak tests on Node v26.2+, `vi.useRealTimers()` internally calls fake-timers `uninstall()`, which deletes `globalThis.setTimeout` from the jest vm sandbox rather than restoring it (because `setTimeout` is inherited rather than an own property of the sandbox global, causing fake-timers to delete instead of reassign on cleanup). This meant `new Promise(resolve => globalThis.setTimeout(...))` threw inside the Promise constructor, producing an immediately-rejected timeout$ with no handler attached yet - triggering a `PromiseRejectionHandledWarning` when `await timeout$` later added one, and keeping the rejected Promise alive long enough for jest's FinalizationRegistry-based leak detector to flag the test suite as leaking. Phew.

All this just to realise that awaiting the timeout was unnecessary because we advanced the timers with jest.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Remove redundant real-time <b><i>setTimeout</i></b> Promise from polling test.
• Rely solely on Jest timer advancement to drive the test forward.
• Prevent Node v26 fake-timers cleanup from triggering unhandled rejection/leak detection.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["polling.test.ts"] --> B["Jest timers"] --> C["advanceTimersByTimeAsync"] --> D["Polling execution"]
  B --> E["Fake timers"] --> F["Sandbox globals"]
  F --> G["Promise rejection/leaktests"]

  subgraph Legend
    direction LR
    _t["Test"] ~~~ _rt["Runtime/timers"] ~~~ _r["Risk"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Patch fake-timers restore behavior for inherited globals</b></summary>

- ➕ Addresses the root cause for all tests/environments
- ➕ Avoids similar issues when real timers are used intentionally
- ➖ Higher scope and risk; requires dependency changes or upstream coordination
- ➖ Harder to validate across Node/Jest/Vitest versions

</details>

<details>
<summary><b>2. Avoid `useRealTimers()`/real timers in leak-sensitive suites via configuration</b></summary>

- ➕ Keeps test behavior consistent across Node versions
- ➕ Reduces exposure to VM sandbox/global edge cases
- ➖ May constrain legitimate tests that need real timers
- ➖ Config-based mitigations can be brittle and framework/version-specific

</details>

<details>
<summary><b>3. Restore sandbox `setTimeout` explicitly in test teardown</b></summary>

- ➕ Localized mitigation without dependency changes
- ➕ Keeps existing test structure intact
- ➖ More boilerplate and easy to forget in other tests
- ➖ Still works around, rather than eliminates, the redundant await pattern

</details>

**Recommendation:** The chosen approach (remove the redundant real-time timeout Promise and rely on timer advancement) is best here: it reduces async surface area, aligns with how the test already drives time, and avoids Node v26 fake-timers cleanup edge cases without introducing new framework/dependency coupling.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>polling.test.ts</strong> <code>Remove redundant timeout Promise awaited after advancing fake timers</code> <code>+0/-6</code></summary>

<br/>

>Remove redundant timeout Promise awaited after advancing fake timers
>
><pre>
>• Deletes a manually-created &#x27;setTimeout&#x27;-backed Promise and the subsequent &#x27;await&#x27;, since the test already advances timers by 10 seconds. This prevents Node v26+ fake-timers cleanup from interacting badly with sandboxed globals and leak detection.
></pre>
>
><a href='https://github.com/graphql-hive/gateway/pull/2413/files#diff-8457bda0b3d12ab6ea29ba27bd2af79d8005ccd0014351b31d51d2cc2d7a7d5b'>packages/fusion-runtime/tests/polling.test.ts</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>