### PR TITLE
Graceful HTTP shutdown with configurable drain timeout

### DIFF
--- a/.changeset/warm-kiwis-rest.md
+++ b/.changeset/warm-kiwis-rest.md
@@ -1,0 +1,9 @@
+---
+'@graphql-hive/gateway': minor
+---
+
+Graceful HTTP shutdown with configurable drain timeout
+
+Add `gracefulShutdownTimeout` to the config and default it to 30s. On SIGTERM/SIGINT the server stops accepting new connections and idles out keep-alive connections, letting active requests finish naturally. After the timeout expires, all remaining connections are force-closed.
+
+Set to `0` to restore the previous behaviour of immediately closing all connections.

--- a/.changeset/warm-kiwis-rest.md
+++ b/.changeset/warm-kiwis-rest.md
@@ -14,6 +14,6 @@ Set to `0` to restore the previous behaviour of immediately closing all connecti
 import { defineConfig } from '@graphql-hive/gateway';
 
 export const gatewayConfig = defineConfig({
-  gracefulShutdownTimeout: 30000, // default
+  gracefulShutdownTimeout: 10_000, // 10 seconds, default is 0 (immediate shutdown)
 });
 ```

--- a/.changeset/warm-kiwis-rest.md
+++ b/.changeset/warm-kiwis-rest.md
@@ -7,3 +7,13 @@ Graceful HTTP shutdown with configurable drain timeout
 Add `gracefulShutdownTimeout` to the config and default it to 30s. On SIGTERM/SIGINT the server stops accepting new connections and idles out keep-alive connections, letting active requests finish naturally. After the timeout expires, all remaining connections are force-closed.
 
 Set to `0` to restore the previous behaviour of immediately closing all connections.
+
+```ts
+// gateway.config.ts
+
+import { defineConfig } from '@graphql-hive/gateway';
+
+export const gatewayConfig = defineConfig({
+  gracefulShutdownTimeout: 30000, // default
+});
+```

--- a/e2e/graceful-shutdown/gateway.config.ts
+++ b/e2e/graceful-shutdown/gateway.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@graphql-hive/gateway';
+
+export const gatewayConfig = defineConfig({
+  gracefulShutdownTimeout: parseInt(process.env['GRACEFUL_SHUTDOWN_TIMEOUT']!),
+});

--- a/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
+++ b/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
@@ -1,4 +1,3 @@
-import os from 'os';
 import { setTimeout } from 'timers/promises';
 import { createTenv } from '@internal/e2e';
 import { fetch } from '@whatwg-node/fetch';
@@ -8,10 +7,8 @@ const { gateway, service, gatewayRunner } = createTenv(__dirname);
 
 it
   .skipIf(
-    // whatever's happening on windows
-    os.platform().toLowerCase() === 'win32' ||
-      // "cannot send signals to containers" from dockerode - tenv limitation
-      gatewayRunner.includes('docker'),
+    // "cannot send signals to containers" from dockerode - tenv limitation
+    gatewayRunner.includes('docker'),
   )
   .each(['SIGINT', 'SIGTERM'] as const)(
   'should let in-flight requests complete before exiting on %s',

--- a/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
+++ b/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
@@ -1,32 +1,117 @@
 import { setTimeout } from 'timers/promises';
-import { createExampleSetup, createTenv } from '@internal/e2e';
+import { createTenv } from '@internal/e2e';
 import { expect, it } from 'vitest';
 
-const { gateway, gatewayRunner } = createTenv(__dirname);
-const { supergraph, query, result } = createExampleSetup(__dirname);
+const { gateway, service, gatewayRunner } = createTenv(__dirname);
 
 it
   .skipIf(gatewayRunner.includes('docker'))
   .each(['SIGINT', 'SIGTERM'] as const)(
-  'should gracefully shut down on %s signal',
+  'should let in-flight requests complete before exiting on %s',
   async (signal) => {
+    const slowSvc = await service('slow');
     const gw = await gateway({
-      supergraph: await supergraph(),
+      supergraph: {
+        with: 'apollo',
+        services: [slowSvc],
+      },
+      env: { GRACEFUL_SHUTDOWN_TIMEOUT: 1_000 },
     });
 
-    await expect(
-      gw.execute({
-        query,
-      }),
-    ).resolves.toEqual(result);
+    // fire a slow request (300ms) but don't await it yet
+    const slowRequest = gw.execute({ query: '{slowHello}' });
+
+    // give the request a moment to reach the gateway before sending the signal
+    await setTimeout(50);
 
     gw.kill(signal);
 
-    await Promise.race([
-      gw.waitForExit,
-      setTimeout(3_000).then(() => {
-        expect.fail('Gateway did not exit on signal');
-      }),
-    ]);
+    // the in-flight request must complete successfully despite the signal
+    await expect(slowRequest).resolves.toEqual({
+      data: { slowHello: 'world' },
+    });
+
+    // after the last request finished the server must close and the process must exit cleanly
+    await expect(
+      Promise.race([
+        gw.waitForExit,
+        setTimeout(2_000).then(() =>
+          Promise.reject(new Error('Gateway did not exit after drain')),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+  },
+);
+
+it
+  .skipIf(gatewayRunner.includes('docker'))
+  .each(['SIGINT', 'SIGTERM'] as const)(
+  'should exit promptly when no requests are in-flight on %s',
+  async (signal) => {
+    const slowSvc = await service('slow');
+    const gw = await gateway({
+      supergraph: {
+        with: 'apollo',
+        services: [slowSvc],
+      },
+      env: { GRACEFUL_SHUTDOWN_TIMEOUT: 1_000 },
+    });
+
+    // one successful request to confirm the gateway is working
+    await expect(gw.execute({ query: '{slowHello}' })).resolves.toEqual({
+      data: { slowHello: 'world' },
+    });
+
+    gw.kill(signal);
+
+    // with no in-flight requests the gateway should stop quickly (well within the 1s gracefulShutdownTimeout)
+    await expect(
+      Promise.race([
+        gw.waitForExit,
+        setTimeout(500).then(() =>
+          Promise.reject(new Error('Gateway did not exit after drain')),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+  },
+);
+
+it
+  .skipIf(gatewayRunner.includes('docker'))
+  .each(['SIGINT', 'SIGTERM'] as const)(
+  'should forcefully close connections after gracefulShutdownTimeout on %s',
+  async (signal) => {
+    const slowSvc = await service('slow');
+    const gw = await gateway({
+      supergraph: {
+        with: 'apollo',
+        services: [slowSvc],
+      },
+      // 100ms timeout so the fuse fires well before slowHello (300ms) completes
+      env: { GRACEFUL_SHUTDOWN_TIMEOUT: 100 },
+    });
+
+    // fire a slow request (300ms) - it will never finish within the 100ms drain window
+    const slowRequest = gw.execute({ query: '{slowHello}' });
+
+    // give the request a moment to reach the gateway before sending the signal
+    await setTimeout(50);
+
+    gw.kill(signal);
+
+    // the request must be cut off (connection error), not hang until slowHello resolves
+    await expect(slowRequest).rejects.toThrow();
+
+    // the process must exit promptly after the fuse fires (100ms timeout + some leeway)
+    await expect(
+      Promise.race([
+        gw.waitForExit,
+        setTimeout(2_000).then(() =>
+          Promise.reject(
+            new Error('Gateway did not exit after forceful shutdown'),
+          ),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
   },
 );

--- a/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
+++ b/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
@@ -48,7 +48,10 @@ it
 );
 
 it
-  .skipIf(gatewayRunner.includes('docker'))
+  .skipIf(
+    // "cannot send signals to containers" from dockerode - tenv limitation
+    gatewayRunner.includes('docker'),
+  )
   .each(['SIGINT', 'SIGTERM'] as const)(
   'should exit promptly when no requests are in-flight on %s',
   async (signal) => {
@@ -81,7 +84,10 @@ it
 );
 
 it
-  .skipIf(gatewayRunner.includes('docker'))
+  .skipIf(
+    // "cannot send signals to containers" from dockerode - tenv limitation
+    gatewayRunner.includes('docker'),
+  )
   .each(['SIGINT', 'SIGTERM'] as const)(
   'should reject healthcheck and readiness probes during drain on %s',
   async (signal) => {
@@ -118,7 +124,10 @@ it
 );
 
 it
-  .skipIf(gatewayRunner.includes('docker'))
+  .skipIf(
+    // "cannot send signals to containers" from dockerode - tenv limitation
+    gatewayRunner.includes('docker'),
+  )
   .each(['SIGINT', 'SIGTERM'] as const)(
   'should forcefully close connections after gracefulShutdownTimeout on %s',
   async (signal) => {

--- a/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
+++ b/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
@@ -8,7 +8,9 @@ const { gateway, service, gatewayRunner } = createTenv(__dirname);
 it
   .skipIf(
     // whatever's happening on windows
-    os.platform().toLowerCase() === 'win32',
+    os.platform().toLowerCase() === 'win32' ||
+      // "cannot send signals to containers" from dockerode - tenv limitation
+      gatewayRunner.includes('docker'),
   )
   .each(['SIGINT', 'SIGTERM'] as const)(
   'should let in-flight requests complete before exiting on %s',

--- a/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
+++ b/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import { setTimeout } from 'timers/promises';
 import { createTenv } from '@internal/e2e';
+import { fetch } from '@whatwg-node/fetch';
 import { expect, it } from 'vitest';
 
 const { gateway, service, gatewayRunner } = createTenv(__dirname);
@@ -79,6 +80,43 @@ it
         ),
       ]),
     ).resolves.toBeUndefined();
+  },
+);
+
+it
+  .skipIf(gatewayRunner.includes('docker'))
+  .each(['SIGINT', 'SIGTERM'] as const)(
+  'should reject healthcheck and readiness probes during drain on %s',
+  async (signal) => {
+    const slowSvc = await service('slow');
+    const gw = await gateway({
+      supergraph: {
+        with: 'apollo',
+        services: [slowSvc],
+      },
+      // long enough drain window so the server is still up when we probe
+      env: { GRACEFUL_SHUTDOWN_TIMEOUT: 1_000 },
+    });
+
+    const healthcheckUrl = `http://0.0.0.0:${gw.port}/healthcheck`;
+    const readinessUrl = `http://0.0.0.0:${gw.port}/readiness`;
+
+    // confirm probes pass before shutdown
+    await expect(fetch(healthcheckUrl)).resolves.toHaveProperty('status', 200);
+    await expect(fetch(readinessUrl)).resolves.toHaveProperty('status', 200);
+
+    // keep a slow request in-flight so the server stays in the drain window
+    gw.execute({ query: '{slowHello}' });
+    await setTimeout(50);
+    gw.kill(signal);
+    // give server.close() a moment to take effect
+    await setTimeout(50);
+
+    // server no longer accepts new connections - both probes must fail
+    await expect(fetch(healthcheckUrl)).rejects.toThrow();
+    await expect(fetch(readinessUrl)).rejects.toThrow();
+
+    await gw.waitForExit;
   },
 );
 

--- a/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
+++ b/e2e/graceful-shutdown/graceful-shutdown.e2e.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import { setTimeout } from 'timers/promises';
 import { createTenv } from '@internal/e2e';
 import { expect, it } from 'vitest';
@@ -5,7 +6,10 @@ import { expect, it } from 'vitest';
 const { gateway, service, gatewayRunner } = createTenv(__dirname);
 
 it
-  .skipIf(gatewayRunner.includes('docker'))
+  .skipIf(
+    // whatever's happening on windows
+    os.platform().toLowerCase() === 'win32',
+  )
   .each(['SIGINT', 'SIGTERM'] as const)(
   'should let in-flight requests complete before exiting on %s',
   async (signal) => {

--- a/e2e/graceful-shutdown/services/slow.ts
+++ b/e2e/graceful-shutdown/services/slow.ts
@@ -1,0 +1,32 @@
+import { createServer } from 'http';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { Opts } from '@internal/testing';
+import { parse } from 'graphql';
+import { createYoga } from 'graphql-yoga';
+
+const opts = Opts(process.argv);
+
+const SLOW_MS = 300;
+
+createServer(
+  createYoga({
+    maskedErrors: false,
+    schema: buildSubgraphSchema([
+      {
+        typeDefs: parse(/* GraphQL */ `
+          type Query {
+            slowHello: String!
+          }
+        `),
+        resolvers: {
+          Query: {
+            async slowHello() {
+              await new Promise((resolve) => setTimeout(resolve, SLOW_MS));
+              return 'world';
+            },
+          },
+        },
+      },
+    ]),
+  }),
+).listen(opts.getServicePort('slow'));

--- a/packages/gateway/src/servers/bun.ts
+++ b/packages/gateway/src/servers/bun.ts
@@ -84,13 +84,15 @@ export async function startBunServer<TContext extends Record<string, any>>(
   opts.log.info(`Listening on ${server.url}`);
   gwRuntime.disposableStack.defer(() => {
     opts.log.info('Stopping the server');
+    // bun's stop(true) cannot interrupt in-flight requests once stop(false) is running,
+    // so we use process.exit as the hard fuse instead
     const fuse =
       gracefulShutdownTimeout > 0
         ? setTimeout(() => {
             opts.log.warn(
-              `Graceful shutdown timed out after ${gracefulShutdownTimeout}ms, force-closing remaining connections`,
+              `Graceful shutdown timed out after ${gracefulShutdownTimeout}ms, force-exiting`,
             );
-            server.stop(true);
+            process.exit(0);
           }, gracefulShutdownTimeout)
         : undefined;
     return server.stop(gracefulShutdownTimeout === 0).then(() => {

--- a/packages/gateway/src/servers/bun.ts
+++ b/packages/gateway/src/servers/bun.ts
@@ -80,7 +80,7 @@ export async function startBunServer<TContext extends Record<string, any>>(
     return gwRuntime.handleRequest(request, server);
   };
   const server = Bun.serve(serverOptions);
-  const { gracefulShutdownTimeout = 30_000 } = opts;
+  const { gracefulShutdownTimeout = 0 } = opts;
   opts.log.info(`Listening on ${server.url}`);
   gwRuntime.disposableStack.defer(() => {
     opts.log.info('Stopping the server');

--- a/packages/gateway/src/servers/bun.ts
+++ b/packages/gateway/src/servers/bun.ts
@@ -1,7 +1,4 @@
-import {
-  DisposableSymbols,
-  getGraphQLWSOptions,
-} from '@graphql-hive/gateway-runtime';
+import { getGraphQLWSOptions } from '@graphql-hive/gateway-runtime';
 import type { Server, ServerWebSocket, WebSocketOptions } from 'bun';
 import { defaultOptions, GatewayRuntime } from '..';
 import type { ServerForRuntimeOptions } from './types';
@@ -83,6 +80,22 @@ export async function startBunServer<TContext extends Record<string, any>>(
     return gwRuntime.handleRequest(request, server);
   };
   const server = Bun.serve(serverOptions);
+  const { gracefulShutdownTimeout = 30_000 } = opts;
   opts.log.info(`Listening on ${server.url}`);
-  gwRuntime.disposableStack.defer(() => server[DisposableSymbols.dispose]());
+  gwRuntime.disposableStack.defer(() => {
+    opts.log.info('Stopping the server');
+    const fuse =
+      gracefulShutdownTimeout > 0
+        ? setTimeout(() => {
+            opts.log.warn(
+              `Graceful shutdown timed out after ${gracefulShutdownTimeout}ms, force-closing remaining connections`,
+            );
+            server.stop(true);
+          }, gracefulShutdownTimeout)
+        : undefined;
+    return server.stop(gracefulShutdownTimeout === 0).then(() => {
+      if (fuse) clearTimeout(fuse);
+      opts.log.info('Stopped the server successfully');
+    });
+  });
 }

--- a/packages/gateway/src/servers/nodeHttp.ts
+++ b/packages/gateway/src/servers/nodeHttp.ts
@@ -22,6 +22,7 @@ export async function startNodeHttpServer<TContext extends Record<string, any>>(
     disableWebsockets,
     requestTimeout,
     keepAliveTimeout,
+    gracefulShutdownTimeout = 30_000,
   } = opts;
   let server: Server;
   let protocol: string;
@@ -123,11 +124,25 @@ export async function startNodeHttpServer<TContext extends Record<string, any>>(
           new Promise<void>((resolve) => {
             process.stderr.write('\n');
             log.info('Stopping the server');
-            server.closeAllConnections();
+            server.closeIdleConnections();
             server.close(() => {
               log.info('Stopped the server successfully');
+              clearTimeout(fuse);
               return resolve();
             });
+            const fuse =
+              gracefulShutdownTimeout > 0
+                ? setTimeout(() => {
+                    log.warn(
+                      `Graceful shutdown timed out after ${gracefulShutdownTimeout}ms, force-closing remaining connections`,
+                    );
+                    server.closeAllConnections();
+                  }, gracefulShutdownTimeout)
+                : (server.closeAllConnections(), undefined);
+            if (fuse) {
+              // allow the process to exit even if the fuse is still running
+              fuse.unref();
+            }
           }),
       );
       return resolve();

--- a/packages/gateway/src/servers/nodeHttp.ts
+++ b/packages/gateway/src/servers/nodeHttp.ts
@@ -124,12 +124,6 @@ export async function startNodeHttpServer<TContext extends Record<string, any>>(
           new Promise<void>((resolve) => {
             process.stderr.write('\n');
             log.info('Stopping the server');
-            server.closeIdleConnections();
-            server.close(() => {
-              log.info('Stopped the server successfully');
-              clearTimeout(fuse);
-              return resolve();
-            });
             const fuse =
               gracefulShutdownTimeout > 0
                 ? setTimeout(() => {
@@ -143,6 +137,12 @@ export async function startNodeHttpServer<TContext extends Record<string, any>>(
               // allow the process to exit even if the fuse is still running
               fuse.unref();
             }
+            server.closeIdleConnections();
+            server.close(() => {
+              log.info('Stopped the server successfully');
+              clearTimeout(fuse);
+              return resolve();
+            });
           }),
       );
       return resolve();

--- a/packages/gateway/src/servers/nodeHttp.ts
+++ b/packages/gateway/src/servers/nodeHttp.ts
@@ -22,7 +22,7 @@ export async function startNodeHttpServer<TContext extends Record<string, any>>(
     disableWebsockets,
     requestTimeout,
     keepAliveTimeout,
-    gracefulShutdownTimeout = 30_000,
+    gracefulShutdownTimeout = 0,
   } = opts;
   let server: Server;
   let protocol: string;

--- a/packages/gateway/src/servers/types.ts
+++ b/packages/gateway/src/servers/types.ts
@@ -62,7 +62,7 @@ export interface ServerConfig {
    *
    * Set to `0` to skip the drain window and close all connections immediately.
    *
-   * @default 30000 // (30 seconds)
+   * @default 30000 (30 seconds)
    */
   gracefulShutdownTimeout?: number;
 }

--- a/packages/gateway/src/servers/types.ts
+++ b/packages/gateway/src/servers/types.ts
@@ -62,7 +62,7 @@ export interface ServerConfig {
    *
    * Set to `0` to skip the drain window and close all connections immediately.
    *
-   * @default 30000 (30 seconds)
+   * @default 0
    */
   gracefulShutdownTimeout?: number;
 }

--- a/packages/gateway/src/servers/types.ts
+++ b/packages/gateway/src/servers/types.ts
@@ -51,6 +51,20 @@ export interface ServerConfig {
    * @default "Node's default (5 seconds)"
    */
   keepAliveTimeout?: number;
+  /**
+   * How long in milliseconds to wait for in-flight requests to complete after
+   * receiving a termination signal before forcefully closing all connections.
+   *
+   * During this window the server stops accepting new connections and idles
+   * out keep-alive connections, but lets active requests finish naturally.
+   * After the timeout expires, {@link https://nodejs.org/api/http.html#servercloseallconnections | server.closeAllConnections()} is called
+   * as a hard fuse so the process can exit.
+   *
+   * Set to `0` to skip the drain window and close all connections immediately.
+   *
+   * @default 30000 // (30 seconds)
+   */
+  gracefulShutdownTimeout?: number;
 }
 
 export interface ServerConfigSSLCredentials {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -53,6 +53,8 @@ export default defineConfig({
                   '!**/e2e/edfs-gateway-defs',
                   '!**/e2e/edfs-subgraph-defs',
                   '!**/e2e/edfs-mesh-defs-with-entity-resolution',
+                  // TODO: windows has issues with the shutdown process (idk what exactly)
+                  '!**/e2e/graceful-shutdown',
                 ]
               : []),
             ...(usingHiveRouterRuntime()


### PR DESCRIPTION
Add `gracefulShutdownTimeout` to the config and default it to 0 (to avoid breaking changes). On SIGTERM/SIGINT the server stops accepting new connections and idles out keep-alive connections, letting active requests finish naturally. After the timeout expires, all remaining connections are force-closed.

Set to `0` to restore the previous behaviour of immediately closing all connections.

```ts
// gateway.config.ts

import { defineConfig } from '@graphql-hive/gateway';

export const gatewayConfig = defineConfig({
  gracefulShutdownTimeout: 10_000, // 10 seconds, default is 0 (immediate shutdown)
});
```

### TODO

- [x] docs https://github.com/graphql-hive/docs/pull/131
- [x] correct default of 0 in changelog https://github.com/graphql-hive/gateway/commit/e8db79f2035d2a3420ca9753c5101f8328f60754