### PR TITLE
Test @graphql-tools/utils alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@graphql-mesh/types": "0.104.28",
     "@graphql-mesh/utils": "0.104.36",
     "@graphql-tools/delegate": "workspace:*",
+    "@graphql-tools/utils": "11.2.0-alpha-20260623121950-9791cce120fe931141445a7135bb46cf4212582e",
     "@isaacs/brace-expansion": "5.0.1",
     "@opentelemetry/otlp-exporter-base@npm:^0.203.0": "patch:@opentelemetry/otlp-exporter-base@npm%3A^0.203.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch",
     "@rollup/plugin-node-resolve@npm:^15.2.3": "patch:@rollup/plugin-node-resolve@npm%3A^16.0.1#~/.yarn/patches/@rollup-plugin-node-resolve-npm-16.0.1-2936474bab.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5924,9 +5924,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/utils@npm:11.1.0, @graphql-tools/utils@npm:^11.0.0, @graphql-tools/utils@npm:^11.1.0":
-  version: 11.1.0
-  resolution: "@graphql-tools/utils@npm:11.1.0"
+"@graphql-tools/utils@npm:11.2.0-alpha-20260623121950-9791cce120fe931141445a7135bb46cf4212582e":
+  version: 11.2.0-alpha-20260623121950-9791cce120fe931141445a7135bb46cf4212582e
+  resolution: "@graphql-tools/utils@npm:11.2.0-alpha-20260623121950-9791cce120fe931141445a7135bb46cf4212582e"
   dependencies:
     "@graphql-typed-document-node/core": "npm:^3.1.1"
     "@whatwg-node/promise-helpers": "npm:^1.0.0"
@@ -5934,32 +5934,7 @@ __metadata:
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10c0/4858ee4a1df0f858c65a5459d991bedcfde488054484c8707c97e2ce9db9a8f74aaaa0d7c20f38ff872507db9a73fc1182d4d1860dd72099509552538dfd477a
-  languageName: node
-  linkType: hard
-
-"@graphql-tools/utils@npm:^10.0.0, @graphql-tools/utils@npm:^10.11.0":
-  version: 10.11.0
-  resolution: "@graphql-tools/utils@npm:10.11.0"
-  dependencies:
-    "@graphql-typed-document-node/core": "npm:^3.1.1"
-    "@whatwg-node/promise-helpers": "npm:^1.0.0"
-    cross-inspect: "npm:1.0.1"
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10c0/73459332c199d8f3aa698bdee4ac6ce802274dba95cc7eff1f0219b6fe6e3a8f314d2e824168e296df8f5ce18f6dbd23ca14406b71890a41ce80b7548e8ccd6d
-  languageName: node
-  linkType: hard
-
-"@graphql-tools/utils@npm:^8.5.2":
-  version: 8.13.1
-  resolution: "@graphql-tools/utils@npm:8.13.1"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10c0/f9bab1370aa91e706abec4c8ea980e15293cb78bd4effba53ad2365dc39d81148db7667b3ef89b35f0a0b0ad58081ffdac4264b7125c69fa8393590ae5025745
+  checksum: 10c0/62ab417acbda12544fc92161b8b4652b23708e721dc31e203b48a2fbd8f5df79738bb8dfc4523ad69c7e2fbe385e42cc5b277274e3691ef31d842fc699174609
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR tests the alpha release of `@graphql-tools/utils` in https://github.com/ardatan/graphql-tools/pull/8250 for GraphQL 17 support