### PR TITLE
feat(runtime): graceful supergraph reload via generation overlap

### DIFF
--- a/.changeset/graceful-schema-reload.md
+++ b/.changeset/graceful-schema-reload.md
@@ -16,8 +16,11 @@ mutations finish on the schema they were admitted under. Operations are
 reference-counted per generation for their whole lifetime (across all subgraph
 hops, and until `@defer`/`@stream` streams end). A superseded generation is
 disposed once idle, or force-disposed after `drainTimeout`; `maxConcurrentGenerations`
-caps how many generations may overlap. Subscriptions are not overlapped — they
-end on reload and reconnect. Disabled by default.
+caps how many generations may overlap. Subscriptions are not pinned: one on a
+superseded generation ends with `SCHEMA_RELOAD` when that generation is
+disposed — immediately on reload when nothing is draining, otherwise once the
+last in-flight operation finishes (at the latest after `drainTimeout`) — and
+the client then reconnects against the new schema. Disabled by default.
 
 ```ts
 export const gatewayConfig = defineConfig({

--- a/.changeset/graceful-schema-reload.md
+++ b/.changeset/graceful-schema-reload.md
@@ -1,0 +1,26 @@
+---
+'@graphql-hive/gateway-runtime': minor
+'@graphql-mesh/fusion-runtime': minor
+---
+
+Add opt-in graceful supergraph reload ("generation overlap").
+
+By default, when the supergraph reloads, the previous generation (executor +
+subgraph transports) is disposed immediately, aborting any in-flight operation
+on it with a `SCHEMA_RELOAD` / 503 error (queries are retried on the new schema;
+mutations are not).
+
+With the new `gracefulSchemaReload` config the previous generation is kept alive
+and only new requests are routed to the new one, so in-flight queries and
+mutations finish on the schema they were admitted under. Operations are
+reference-counted per generation for their whole lifetime (across all subgraph
+hops, and until `@defer`/`@stream` streams end). A superseded generation is
+disposed once idle, or force-disposed after `drainTimeout`; `maxConcurrentGenerations`
+caps how many generations may overlap. Subscriptions are not overlapped — they
+end on reload and reconnect. Disabled by default.
+
+```ts
+export const gatewayConfig = defineConfig({
+  gracefulSchemaReload: { drainTimeout: 10_000 }, // ms; default off
+});
+```

--- a/packages/fusion-runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion-runtime/src/unifiedGraphManager.ts
@@ -137,6 +137,25 @@ export interface UnifiedGraphManagerOptions<TContext> {
     label: string,
     context: any,
   ): MaybePromise<boolean>;
+
+  /**
+   * When greater than 0, enables "generation overlap" on schema reload: a
+   * superseded generation (executor + transports) is kept alive so in-flight
+   * single-result operations can finish, instead of being disposed (and
+   * aborted) immediately. This is the maximum time, in milliseconds, a
+   * superseded generation is kept alive before it is force-disposed.
+   *
+   * Defaults to disposing immediately (previous behavior).
+   */
+  schemaReloadDrainTimeout?: number;
+  /**
+   * Maximum number of schema generations kept alive simultaneously (current +
+   * draining) when {@link schemaReloadDrainTimeout} is enabled. When exceeded,
+   * the oldest draining generation is force-disposed.
+   *
+   * @default 10
+   */
+  maxConcurrentSchemaGenerations?: number;
 }
 
 export type Instrumentation = {
@@ -160,6 +179,64 @@ export type Instrumentation = {
 
 const UNIFIEDGRAPH_CACHE_KEY = 'hive-gateway:supergraph';
 
+/** Default cap on the number of schema generations kept alive simultaneously. */
+const DEFAULT_MAX_CONCURRENT_GENERATIONS = 10;
+
+function createSchemaReloadError(): GraphQLError {
+  return createGraphQLError(
+    'operation has been aborted due to a schema reload',
+    {
+      extensions: {
+        code: 'SCHEMA_RELOAD',
+        http: {
+          status: 503,
+        },
+        [CRITICAL_ERROR]: true,
+      },
+    },
+  );
+}
+
+/**
+ * A single "generation" of the unified graph: the executor and subgraph
+ * transports built for one supergraph schema. When the schema reloads, a new
+ * generation is created and becomes the one serving new requests; the previous
+ * generation may be kept alive ("draining") so that operations already in flight
+ * on it can finish before it is disposed. See {@link GracefulSchemaReloadConfig}.
+ */
+interface SchemaGeneration {
+  /**
+   * The executor for this generation, when the unified graph handler produces
+   * one (e.g. the router runtime). The default stitching/federation handler
+   * executes through the schema's resolvers and returns no executor, so this is
+   * undefined there; it is kept only so it can be disposed alongside the
+   * transports.
+   */
+  executor: Executor | undefined;
+  /** The subgraph transports built for this generation. */
+  transportExecutorStack: AsyncDisposableStack;
+  /**
+   * Number of in-flight operations pinned to this generation. Incremented once
+   * per operation (in the gateway's onExecute) and held until that operation
+   * fully completes — i.e. across all of its subgraph hops. A superseded
+   * generation is disposed once this reaches zero.
+   */
+  inFlight: number;
+  /** Whether a newer generation has replaced this one. */
+  superseded: boolean;
+  /** Whether this generation's resources have already been disposed. */
+  disposed: boolean;
+  /**
+   * Abort reason (SCHEMA_RELOAD) attached as soon as this generation is
+   * superseded. It is only *consulted* when the transports are actually
+   * disposed (drain timeout, cap eviction, or shutdown), so operations that
+   * finish while the generation drains are never affected by it.
+   */
+  disposeReason?: GraphQLError;
+  /** Timer that force-disposes this generation once the drain timeout elapses. */
+  forceDisposeTimer?: ReturnType<typeof setTimeout>;
+}
+
 export class UnifiedGraphManager<TContext> implements AsyncDisposable {
   private batch: boolean;
   private handleUnifiedGraph: UnifiedGraphHandler;
@@ -178,6 +255,16 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
   private instrumentation: () => Instrumentation | undefined;
   private overrideLabelsByContext: WeakMap<any, Set<string>> = new WeakMap();
   private overrideLabels: Iterable<string> | undefined;
+  /** The generation currently serving new requests. */
+  private currentGeneration?: SchemaGeneration;
+  /** Superseded generations being kept alive until their in-flight work drains. */
+  private drainingGenerations = new Set<SchemaGeneration>();
+  /** Maps each built unified schema to its generation, so an operation can pin
+   * the generation it executes against for its whole lifetime. */
+  private generationBySchema = new WeakMap<GraphQLSchema, SchemaGeneration>();
+  /** Latch so the "schema not tracked → graceful reload has no effect" warning
+   * is emitted at most once instead of per request. */
+  private warnedUntrackedSchema = false;
 
   constructor(private opts: UnifiedGraphManagerOptions<TContext>) {
     this.batch = opts.batch ?? true;
@@ -376,6 +463,13 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
         }) => {
           this.overrideLabels = overrideLabels;
           const transportExecutorStack = new AsyncDisposableStack();
+          const generation: SchemaGeneration = {
+            executor,
+            transportExecutorStack,
+            inFlight: 0,
+            superseded: false,
+            disposed: false,
+          };
           onSubgraphExecute = getOnSubgraphExecute({
             onSubgraphExecuteHooks: this.onSubgraphExecuteHooks,
             transports: this.opts.transports,
@@ -383,15 +477,20 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
             transportEntryMap,
             getSubgraphSchema,
             transportExecutorStack,
-            getDisposeReason: () => this.disposeReason,
+            // Each generation aborts its own in-flight requests with its own
+            // reason; `this.disposeReason` carries the shutdown reason, which
+            // applies to every generation.
+            getDisposeReason: () =>
+              generation.disposeReason ?? this.disposeReason,
             batch: this.batch,
             instrumentation: () => this.instrumentation(),
           });
 
-          const previousTransportExecutorStack = this._transportExecutorStack;
-          const previousExecutor = this.executor;
+          const previousGeneration = this.currentGeneration;
           const previousUnifiedGraph = this.lastLoadedUnifiedGraph;
 
+          this.currentGeneration = generation;
+          this.generationBySchema.set(newUnifiedGraph, generation);
           this.lastLoadedUnifiedGraph = loadedUnifiedGraph;
           this.unifiedGraph = newUnifiedGraph;
           this.executor = executor;
@@ -402,39 +501,23 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
           this.opts?.onUnifiedGraphChange?.(newUnifiedGraph);
 
           this.polling$ = undefined;
-          if (previousUnifiedGraph != null) {
-            this.disposeReason = createGraphQLError(
-              'operation has been aborted due to a schema reload',
-              {
-                extensions: {
-                  code: 'SCHEMA_RELOAD',
-                  http: {
-                    status: 503,
-                  },
-                  [CRITICAL_ERROR]: true,
-                },
-              },
-            );
+          if (previousGeneration && previousUnifiedGraph != null) {
             this.opts.transportContext?.log.debug(
               'Supergraph has been changed, updating...',
             );
+            return handleMaybePromise(
+              () => this.retirePreviousGeneration(previousGeneration),
+              () => this.unifiedGraph!,
+              (err) => {
+                this.opts.transportContext?.log.error(
+                  err,
+                  'Failed to dispose the existing transports and executors',
+                );
+                return this.unifiedGraph!;
+              },
+            );
           }
-          return handleMaybePromise(
-            () =>
-              disposeAll([previousTransportExecutorStack, previousExecutor]),
-            () => {
-              this.disposeReason = undefined;
-              return this.unifiedGraph!;
-            },
-            (err) => {
-              this.disposeReason = undefined;
-              this.opts.transportContext?.log.error(
-                err,
-                'Failed to dispose the existing transports and executors',
-              );
-              return this.unifiedGraph!;
-            },
-          );
+          return this.unifiedGraph!;
         },
       );
     } else if (!this.unifiedGraph) {
@@ -446,6 +529,156 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
     this.polling$ = undefined;
     this.lastLoadTime = Date.now();
     return this.unifiedGraph;
+  }
+
+  /**
+   * Pin the generation serving `schema` for the lifetime of one operation, so it
+   * is not disposed while the operation is still running across all of its
+   * subgraph hops. Returns an idempotent release callback. If `schema` is not a
+   * known live generation, retention is a no-op and disposal falls back to the
+   * drain timeout.
+   *
+   * Long-lived streaming operations (subscriptions) are intentionally NOT pinned
+   * by the caller — they end on reload (and reconnect) rather than overlapping.
+   */
+  public retainGenerationFor(schema: GraphQLSchema): () => void {
+    const generation = this.generationBySchema.get(schema);
+    if (!generation) {
+      // The schema isn't one we built (e.g. a plugin returned a wrapped/rebuilt
+      // schema object). Graceful reload then silently has no effect for this
+      // traffic, so warn once — not per request — to make it visible.
+      if (!this.warnedUntrackedSchema) {
+        this.warnedUntrackedSchema = true;
+        this.opts.transportContext?.log.warn(
+          'Graceful reload: operations are executing against a schema that is not a tracked generation ' +
+            '(a plugin likely returned a wrapped schema); operations will not be pinned across reloads',
+        );
+      }
+      return () => {};
+    }
+    if (generation.disposed) {
+      // The operation outlived its generation (already disposed). Benign — it
+      // proceeds unpinned; not warned, as this is expected around reloads.
+      return () => {};
+    }
+    generation.inFlight++;
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      this.releaseGeneration(generation);
+    };
+  }
+
+  private releaseGeneration(generation: SchemaGeneration): void {
+    generation.inFlight--;
+    if (
+      generation.superseded &&
+      generation.inFlight <= 0 &&
+      !generation.disposed
+    ) {
+      // The superseded generation's last pinned operation has finished; dispose
+      // it now. This also tears down any unpinned long-lived streams (e.g.
+      // subscriptions) still running on it, aborting them with the SCHEMA_RELOAD
+      // reason.
+      void this.disposeGeneration(generation);
+    }
+  }
+
+  /**
+   * Retire a generation that has just been superseded by a reload. With graceful
+   * reload disabled it is disposed immediately (aborting in-flight operations,
+   * the previous behavior). Otherwise it is kept alive so in-flight operations
+   * can finish, bounded by a hard-stop timer and a cap on live generations.
+   */
+  private retirePreviousGeneration(
+    generation: SchemaGeneration,
+  ): MaybePromise<void> {
+    generation.superseded = true;
+    // Whenever this generation is finally disposed, anything still running on it
+    // (in-flight work past the drain timeout, or long-lived subscriptions which
+    // are never overlapped) must be aborted with SCHEMA_RELOAD. The reason is
+    // only consulted when the transports are actually disposed, so it does not
+    // disturb operations that finish while the generation drains.
+    generation.disposeReason = createSchemaReloadError();
+    const drainTimeout = this.opts.schemaReloadDrainTimeout;
+    if (!drainTimeout || drainTimeout <= 0) {
+      return this.disposeGeneration(generation);
+    }
+    if (generation.inFlight <= 0) {
+      return this.disposeGeneration(generation);
+    }
+    this.drainingGenerations.add(generation);
+    const forceDisposeTimer = setTimeout(() => {
+      void this.forceDisposeGeneration(generation);
+    }, drainTimeout);
+    (forceDisposeTimer as { unref?: () => void }).unref?.();
+    generation.forceDisposeTimer = forceDisposeTimer;
+    // Enforce the cap after registering this generation; if it is exceeded the
+    // oldest draining generation is force-disposed immediately — the cap takes
+    // precedence over its drain timer.
+    this.enforceGenerationCap(
+      this.opts.maxConcurrentSchemaGenerations ??
+        DEFAULT_MAX_CONCURRENT_GENERATIONS,
+    );
+    return undefined;
+  }
+
+  /**
+   * Force-dispose the oldest draining generations until the number of live
+   * generations (the current one plus draining ones) is within the cap.
+   */
+  private enforceGenerationCap(maxConcurrentGenerations: number): void {
+    // Sets iterate in insertion order, so the first draining generation is the
+    // oldest. With a cap of 1 the only draining entry is the one just retired,
+    // so it is force-disposed here — i.e. overlap is effectively off. The guard
+    // also handles a non-positive cap (drain everything).
+    while (this.drainingGenerations.size + 1 > maxConcurrentGenerations) {
+      const oldest = this.drainingGenerations.values().next().value;
+      if (!oldest) {
+        break;
+      }
+      void this.forceDisposeGeneration(oldest);
+    }
+  }
+
+  private forceDisposeGeneration(
+    generation: SchemaGeneration,
+  ): MaybePromise<void> {
+    if (generation.disposed) {
+      return undefined;
+    }
+    // `disposeReason` (SCHEMA_RELOAD) was already set when the generation was
+    // retired; disposing it now aborts whatever is still in flight on it.
+    return this.disposeGeneration(generation);
+  }
+
+  private disposeGeneration(generation: SchemaGeneration): MaybePromise<void> {
+    if (generation.disposed) {
+      return undefined;
+    }
+    generation.disposed = true;
+    if (generation.forceDisposeTimer) {
+      clearTimeout(generation.forceDisposeTimer);
+      generation.forceDisposeTimer = undefined;
+    }
+    this.drainingGenerations.delete(generation);
+    // Most callers dispose fire-and-forget (`void this.disposeGeneration(...)`),
+    // so swallow-and-log here rather than letting a transport that fails to
+    // close escape as an unhandled rejection with no context.
+    return handleMaybePromise(
+      () =>
+        disposeAll([generation.transportExecutorStack, generation.executor]),
+      () => undefined,
+      (err) => {
+        this.opts.transportContext?.log.error(
+          err,
+          'Graceful reload: failed to dispose a superseded schema generation; its transports may be leaked',
+        );
+      },
+    );
   }
 
   private getAndSetUnifiedGraph(): MaybePromise<GraphQLSchema> {
@@ -558,8 +791,32 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
         },
       },
     );
+    // Dispose every live generation — the current one and any still draining —
+    // so no transports or in-flight executors are leaked on shutdown.
+    const generations: SchemaGeneration[] = [];
+    if (this.currentGeneration) {
+      generations.push(this.currentGeneration);
+    }
+    for (const generation of this.drainingGenerations) {
+      generations.push(generation);
+    }
+    const disposables: unknown[] = [];
+    for (const generation of generations) {
+      if (generation.forceDisposeTimer) {
+        clearTimeout(generation.forceDisposeTimer);
+        generation.forceDisposeTimer = undefined;
+      }
+      generation.disposed = true;
+      // Clear any per-generation SCHEMA_RELOAD reason so in-flight work on a
+      // draining generation aborts with SHUTTING_DOWN (via the `?? this.disposeReason`
+      // fallback) rather than SCHEMA_RELOAD — otherwise clients might retry into
+      // a shutting-down gateway instead of failing over.
+      generation.disposeReason = undefined;
+      disposables.push(generation.transportExecutorStack, generation.executor);
+    }
+    this.drainingGenerations.clear();
     return handleMaybePromise(
-      () => disposeAll([this._transportExecutorStack, this.executor]),
+      () => disposeAll(disposables),
       () => {
         this.unifiedGraph = undefined;
         this.initialUnifiedGraph$ = undefined;
@@ -570,7 +827,7 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
         this.executor = undefined;
         this._transportEntryMap = undefined;
         this._transportExecutorStack = undefined;
-        this.executor = undefined;
+        this.currentGeneration = undefined;
       },
     ) as Promise<void>;
   }

--- a/packages/fusion-runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion-runtime/src/unifiedGraphManager.ts
@@ -559,7 +559,9 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
    * the drain timeout.
    *
    * Long-lived streaming operations (subscriptions) are intentionally NOT pinned
-   * by the caller — they end on reload (and reconnect) rather than overlapping.
+   * by the caller — rather than overlapping indefinitely, they end (and the
+   * client reconnects) when their superseded generation is disposed: right away
+   * when it is idle, otherwise once it finishes draining.
    */
   public retainGenerationFor(
     schema: GraphQLSchema,

--- a/packages/fusion-runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion-runtime/src/unifiedGraphManager.ts
@@ -249,9 +249,7 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
   private initialUnifiedGraph$?: MaybePromise<GraphQLSchema>;
   private polling$?: MaybePromise<void>;
   private _transportEntryMap?: Record<string, TransportEntry>;
-  private _transportExecutorStack?: AsyncDisposableStack;
   private lastLoadTime?: number;
-  private executor?: Executor;
   private instrumentation: () => Instrumentation | undefined;
   private overrideLabelsByContext: WeakMap<any, Set<string>> = new WeakMap();
   private overrideLabels: Iterable<string> | undefined;
@@ -404,7 +402,11 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
               );
               if (isPromise(cacheSet$)) {
                 cacheSet$.then(() => {}, logCacheSetError);
-                this._transportExecutorStack?.defer(() => cacheSet$);
+                // Tie the cache write to the current generation's transport
+                // stack disposal (no generation yet on the very first load).
+                this.currentGeneration?.transportExecutorStack?.defer(
+                  () => cacheSet$,
+                );
               }
             } catch (e) {
               logCacheSetError(e);
@@ -493,8 +495,6 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
           this.generationBySchema.set(newUnifiedGraph, generation);
           this.lastLoadedUnifiedGraph = loadedUnifiedGraph;
           this.unifiedGraph = newUnifiedGraph;
-          this.executor = executor;
-          this._transportExecutorStack = transportExecutorStack;
           this.inContextSDK = inContextSDK;
           this.lastLoadTime = Date.now();
           this._transportEntryMap = transportEntryMap;
@@ -719,7 +719,7 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
   public getExecutor(): MaybePromise<Executor | undefined> {
     return handleMaybePromise(
       () => this.ensureUnifiedGraph(),
-      () => this.executor,
+      () => this.currentGeneration?.executor,
     );
   }
 
@@ -828,9 +828,7 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
         this.inContextSDK = undefined;
         this.lastLoadTime = undefined;
         this.polling$ = undefined;
-        this.executor = undefined;
         this._transportEntryMap = undefined;
-        this._transportExecutorStack = undefined;
         this.currentGeneration = undefined;
       },
     ) as Promise<void>;

--- a/packages/fusion-runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion-runtime/src/unifiedGraphManager.ts
@@ -237,6 +237,23 @@ interface SchemaGeneration {
   forceDisposeTimer?: ReturnType<typeof setTimeout>;
 }
 
+/**
+ * An operation's hold on the schema generation it was admitted under, returned
+ * by {@link UnifiedGraphManager.retainGenerationFor}. The operation must
+ * execute through {@link executor} so that it runs on the same generation it
+ * pins, and call {@link release} exactly when it fully completes.
+ */
+export interface SchemaGenerationLease {
+  /**
+   * The pinned generation's executor, when its unified graph handler produced
+   * one (e.g. the router runtime). Undefined for the default handler, which
+   * executes through the schema's own resolvers.
+   */
+  executor: Executor | undefined;
+  /** Release the pin. Idempotent. */
+  release(): void;
+}
+
 export class UnifiedGraphManager<TContext> implements AsyncDisposable {
   private batch: boolean;
   private handleUnifiedGraph: UnifiedGraphHandler;
@@ -534,14 +551,19 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
   /**
    * Pin the generation serving `schema` for the lifetime of one operation, so it
    * is not disposed while the operation is still running across all of its
-   * subgraph hops. Returns an idempotent release callback. If `schema` is not a
-   * known live generation, retention is a no-op and disposal falls back to the
-   * drain timeout.
+   * subgraph hops. Returns a lease exposing the pinned generation's executor —
+   * the operation must execute through it (not through the current generation's,
+   * which may already be a newer one) — and an idempotent release callback.
+   * Returns undefined if `schema` is not a known live generation; the operation
+   * then proceeds unpinned on the current generation, and disposal falls back to
+   * the drain timeout.
    *
    * Long-lived streaming operations (subscriptions) are intentionally NOT pinned
    * by the caller — they end on reload (and reconnect) rather than overlapping.
    */
-  public retainGenerationFor(schema: GraphQLSchema): () => void {
+  public retainGenerationFor(
+    schema: GraphQLSchema,
+  ): SchemaGenerationLease | undefined {
     const generation = this.generationBySchema.get(schema);
     if (!generation) {
       // The schema isn't one we built (e.g. a plugin returned a wrapped/rebuilt
@@ -554,21 +576,24 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
             '(a plugin likely returned a wrapped schema); operations will not be pinned across reloads',
         );
       }
-      return () => {};
+      return undefined;
     }
     if (generation.disposed) {
       // The operation outlived its generation (already disposed). Benign — it
       // proceeds unpinned; not warned, as this is expected around reloads.
-      return () => {};
+      return undefined;
     }
     generation.inFlight++;
     let released = false;
-    return () => {
-      if (released) {
-        return;
-      }
-      released = true;
-      this.releaseGeneration(generation);
+    return {
+      executor: generation.executor,
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        this.releaseGeneration(generation);
+      },
     };
   }
 

--- a/packages/fusion-runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion-runtime/src/unifiedGraphManager.ts
@@ -390,6 +390,7 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
         return this.unifiedGraph;
       }
       let serializedUnifiedGraph: string | undefined;
+      let cacheSet$: PromiseLike<void> | undefined;
       if (!doNotCache && this.opts.transportContext?.cache) {
         serializedUnifiedGraph =
           serializeLoadedUnifiedGraph(loadedUnifiedGraph);
@@ -412,18 +413,14 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
               );
             };
             try {
-              const cacheSet$ = this.opts.transportContext?.cache.set(
+              const result = this.opts.transportContext?.cache.set(
                 UNIFIEDGRAPH_CACHE_KEY,
                 serializedUnifiedGraph,
                 { ttl },
               );
-              if (isPromise(cacheSet$)) {
-                cacheSet$.then(() => {}, logCacheSetError);
-                // Tie the cache write to the current generation's transport
-                // stack disposal (no generation yet on the very first load).
-                this.currentGeneration?.transportExecutorStack?.defer(
-                  () => cacheSet$,
-                );
+              if (isPromise(result)) {
+                cacheSet$ = result;
+                result.then(() => {}, logCacheSetError);
               }
             } catch (e) {
               logCacheSetError(e);
@@ -489,6 +486,9 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
             superseded: false,
             disposed: false,
           };
+          if (cacheSet$) {
+            transportExecutorStack.defer(() => cacheSet$!);
+          }
           onSubgraphExecute = getOnSubgraphExecute({
             onSubgraphExecuteHooks: this.onSubgraphExecuteHooks,
             transports: this.opts.transports,

--- a/packages/fusion-runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion-runtime/src/unifiedGraphManager.ts
@@ -508,6 +508,11 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
           const previousGeneration = this.currentGeneration;
           const previousUnifiedGraph = this.lastLoadedUnifiedGraph;
 
+          const disposePrevious =
+            previousGeneration && previousUnifiedGraph != null
+              ? this.retirePreviousGeneration(previousGeneration)
+              : undefined;
+
           this.currentGeneration = generation;
           this.generationBySchema.set(newUnifiedGraph, generation);
           this.lastLoadedUnifiedGraph = loadedUnifiedGraph;
@@ -523,7 +528,7 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
               'Supergraph has been changed, updating...',
             );
             return handleMaybePromise(
-              () => this.retirePreviousGeneration(previousGeneration),
+              () => disposePrevious,
               () => this.unifiedGraph!,
               (err) => {
                 this.opts.transportContext?.log.error(

--- a/packages/fusion-runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion-runtime/src/unifiedGraphManager.ts
@@ -618,11 +618,15 @@ export class UnifiedGraphManager<TContext> implements AsyncDisposable {
     generation.forceDisposeTimer = forceDisposeTimer;
     // Enforce the cap after registering this generation; if it is exceeded the
     // oldest draining generation is force-disposed immediately — the cap takes
-    // precedence over its drain timer.
-    this.enforceGenerationCap(
-      this.opts.maxConcurrentSchemaGenerations ??
-        DEFAULT_MAX_CONCURRENT_GENERATIONS,
-    );
+    // precedence over its drain timer. Fall back to the default for any invalid
+    // value (including NaN, which would make `size + 1 > cap` always false and
+    // silently disable the cap).
+    const configuredCap = this.opts.maxConcurrentSchemaGenerations;
+    const maxGenerations =
+      Number.isFinite(configuredCap) && (configuredCap as number) >= 1
+        ? (configuredCap as number)
+        : DEFAULT_MAX_CONCURRENT_GENERATIONS;
+    this.enforceGenerationCap(maxGenerations);
     return undefined;
   }
 

--- a/packages/fusion-runtime/tests/polling.test.ts
+++ b/packages/fusion-runtime/tests/polling.test.ts
@@ -190,6 +190,44 @@ describe('Polling', () => {
     // Check if transport executor is disposed on global shutdown
     expect(disposeFn).toHaveBeenCalledTimes(3);
   });
+  it('retires the previous generation before publishing the new schema', async () => {
+    const schemas = [
+      createSchema({ typeDefs: 'type Query { value: String }' }),
+      createSchema({ typeDefs: 'type Query { value: String, next: String }' }),
+    ];
+    let schemaIndex = 0;
+    let releaseDuringPublish: (() => void) | undefined;
+    let disposedDuringPublish = false;
+    let publishing = false;
+
+    await using manager = new UnifiedGraphManager({
+      getUnifiedGraph: () => schemas[schemaIndex]!,
+      schemaReloadDrainTimeout: 30_000,
+      onUnifiedGraphChange() {
+        publishing = true;
+        releaseDuringPublish?.();
+        publishing = false;
+      },
+      handleUnifiedGraph: ({ unifiedGraph }) => ({
+        unifiedGraph,
+        getSubgraphSchema: () => unifiedGraph,
+        executor: makeDisposable(createDefaultExecutor(unifiedGraph), () => {
+          if (publishing) {
+            disposedDuringPublish = true;
+          }
+        }),
+      }),
+    });
+
+    const firstSchema = await manager.getUnifiedGraph();
+    releaseDuringPublish = manager.retainGenerationFor(firstSchema)!.release;
+    schemaIndex = 1;
+
+    await manager.invalidateUnifiedGraph();
+
+    expect(disposedDuringPublish).toBe(true);
+  });
+
   it('continues polling after failing initial fetch', async () => {
     const advanceTimersByTimeAsync = useFakeTimers();
     const pollingInterval = 300;

--- a/packages/fusion-runtime/tests/polling.test.ts
+++ b/packages/fusion-runtime/tests/polling.test.ts
@@ -190,6 +190,54 @@ describe('Polling', () => {
     // Check if transport executor is disposed on global shutdown
     expect(disposeFn).toHaveBeenCalledTimes(3);
   });
+  it('waits for each generation cache write when that generation is disposed', async () => {
+    const schemas = [
+      createSchema({ typeDefs: 'type Query { value: String }' }),
+      createSchema({ typeDefs: 'type Query { value: String, next: String }' }),
+    ];
+    const cacheWrites = [createDeferred<void>(), createDeferred<void>()];
+    let schemaIndex = 0;
+
+    const log = new Logger({ level: false });
+    const manager = new UnifiedGraphManager({
+      getUnifiedGraph: () => schemas[schemaIndex]!,
+      transportContext: {
+        log,
+        logger: LegacyLogger.from(log),
+        cache: {
+          get: () => undefined,
+          set: () => cacheWrites[schemaIndex]!.promise,
+          delete: () => true,
+          getKeysByPrefix: () => [],
+        },
+      },
+    });
+
+    await manager.getUnifiedGraph();
+    schemaIndex = 1;
+    const reloaded = manager.invalidateUnifiedGraph();
+    let reloadFinished = false;
+    Promise.resolve(reloaded).then(() => {
+      reloadFinished = true;
+    });
+    await Promise.resolve();
+    expect(reloadFinished).toBe(false);
+
+    cacheWrites[0]!.resolve();
+    await reloaded;
+
+    const disposed = manager[DisposableSymbols.asyncDispose]();
+    let disposeFinished = false;
+    Promise.resolve(disposed).then(() => {
+      disposeFinished = true;
+    });
+    await Promise.resolve();
+    expect(disposeFinished).toBe(false);
+
+    cacheWrites[1]!.resolve();
+    await disposed;
+  });
+
   it('retires the previous generation before publishing the new schema', async () => {
     const schemas = [
       createSchema({ typeDefs: 'type Query { value: String }' }),

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -243,8 +243,9 @@ export function createGatewayRuntime<
   let readinessChecker: () => MaybePromise<boolean>;
   let getExecutor: (() => MaybePromise<Executor | undefined>) | undefined;
   // Pins the schema generation an operation executes against for the operation's
-  // whole lifetime (graceful schema reload). Only set when a unified graph
-  // manager is in use; left undefined for the proxy path.
+  // whole lifetime. Only set when a unified graph manager is in use AND
+  // gracefulSchemaReload is enabled; left undefined otherwise (proxy path, or
+  // feature off — superseded generations are then disposed immediately anyway).
   let retainGenerationFor:
     | ((schema: GraphQLSchema) => SchemaGenerationLease | undefined)
     | undefined;
@@ -722,8 +723,14 @@ export function createGatewayRuntime<
     schemaInvalidator = () => unifiedGraphManager.invalidateUnifiedGraph();
     contextBuilder = (base) => unifiedGraphManager.getContext(base as any);
     getExecutor = () => unifiedGraphManager.getExecutor();
-    retainGenerationFor = (schema) =>
-      unifiedGraphManager.retainGenerationFor(schema);
+    if (gracefulSchemaReload) {
+      // Pinning only matters when superseded generations may drain; with the
+      // feature off they are disposed immediately regardless of in-flight
+      // work, so skip the per-operation bookkeeping (and its untracked-schema
+      // warning) entirely.
+      retainGenerationFor = (schema) =>
+        unifiedGraphManager.retainGenerationFor(schema);
+    }
     unifiedGraphPlugin = {
       onDispose() {
         return handleMaybePromise(

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -241,6 +241,10 @@ export function createGatewayRuntime<
   let contextBuilder: <T>(context: T) => MaybePromise<T> | undefined;
   let readinessChecker: () => MaybePromise<boolean>;
   let getExecutor: (() => MaybePromise<Executor | undefined>) | undefined;
+  // Pins the schema generation an operation executes against for the operation's
+  // whole lifetime (graceful schema reload). Only set when a unified graph
+  // manager is in use; left undefined for the proxy path.
+  let retainGenerationFor: ((schema: GraphQLSchema) => () => void) | undefined;
   let replaceSchema: (schema: GraphQLSchema) => void = (newSchema) => {
     unifiedGraph = newSchema;
   };
@@ -637,6 +641,25 @@ export function createGatewayRuntime<
         )(...args),
     };
 
+    const gracefulSchemaReload = config.gracefulSchemaReload;
+    if (gracefulSchemaReload) {
+      if (
+        typeof gracefulSchemaReload.drainTimeout !== 'number' ||
+        gracefulSchemaReload.drainTimeout <= 0
+      ) {
+        throw new Error(
+          'gracefulSchemaReload.drainTimeout must be a positive number of milliseconds',
+        );
+      }
+      if (
+        gracefulSchemaReload.maxConcurrentGenerations != null &&
+        gracefulSchemaReload.maxConcurrentGenerations < 1
+      ) {
+        throw new Error(
+          'gracefulSchemaReload.maxConcurrentGenerations must be at least 1',
+        );
+      }
+    }
     const unifiedGraphManager = new UnifiedGraphManager<GatewayContext>({
       handleUnifiedGraph: config.unifiedGraphHandler,
       getUnifiedGraph: unifiedGraphFetcher.fetch,
@@ -661,6 +684,11 @@ export function createGatewayRuntime<
       batch: config.__experimental__batchExecution,
       batchDelegateOptions: config.__experimental__batchDelegateOptions,
       handleProgressiveOverride: config.progressiveOverride,
+      // Public `gracefulSchemaReload` maps onto the manager's
+      // schemaReloadDrainTimeout / maxConcurrentSchemaGenerations opts.
+      schemaReloadDrainTimeout: gracefulSchemaReload?.drainTimeout,
+      maxConcurrentSchemaGenerations:
+        gracefulSchemaReload?.maxConcurrentGenerations,
     });
     getSchema = () => unifiedGraphManager.getUnifiedGraph();
     readinessChecker = () => {
@@ -687,6 +715,8 @@ export function createGatewayRuntime<
     schemaInvalidator = () => unifiedGraphManager.invalidateUnifiedGraph();
     contextBuilder = (base) => unifiedGraphManager.getContext(base as any);
     getExecutor = () => unifiedGraphManager.getExecutor();
+    retainGenerationFor = (schema) =>
+      unifiedGraphManager.retainGenerationFor(schema);
     unifiedGraphPlugin = {
       onDispose() {
         return handleMaybePromise(
@@ -750,20 +780,54 @@ export function createGatewayRuntime<
 
   if (getExecutor) {
     const onExecute = ({
+      args,
       setExecuteFn,
-    }: OnExecuteEventPayload<GatewayContext>) =>
-      handleMaybePromise(
+    }: OnExecuteEventPayload<GatewayContext>) => {
+      // Pin the generation this operation runs against until it fully completes,
+      // so a schema reload mid-operation does not abort it (graceful schema
+      // reload). Subscriptions go through onSubscribe and are intentionally not
+      // pinned. The release callback is idempotent.
+      const releaseGeneration = retainGenerationFor?.(args.schema);
+      return handleMaybePromise(
         () => getExecutor?.(),
         (executor) => {
           if (executor) {
             const executeFn = getExecuteFnFromExecutor(executor);
             setExecuteFn(executeFn);
           }
+          if (!releaseGeneration) {
+            return undefined;
+          }
+          return {
+            onExecuteDone({ result }: { result: unknown }) {
+              // Incremental-delivery results (@defer / @stream) keep using this
+              // generation until the stream ends; release only then. Single
+              // results are complete now.
+              if (isAsyncIterable(result)) {
+                return { onEnd: releaseGeneration };
+              }
+              releaseGeneration();
+              return undefined;
+            },
+          };
+        },
+        // getExecutor()/schema load rejected before execution started: release
+        // the pin so the generation can still drain. (A thrown execution is rare
+        // — aborts surface as error results, not rejections — and any leaked pin
+        // is reclaimed by the drain timeout.)
+        (error) => {
+          releaseGeneration?.();
+          throw error;
         },
       );
+    };
     const onSubscribe = ({
       setSubscribeFn,
     }: OnSubscribeEventPayload<GatewayContext>) =>
+      // Subscriptions are intentionally NOT pinned to a generation (no
+      // retainGenerationFor here): they are long-lived, so on a schema reload
+      // they end and the client reconnects against the new schema rather than
+      // keeping the old generation alive indefinitely.
       handleMaybePromise(
         () => getExecutor?.(),
         (executor) => {

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -339,6 +339,19 @@ export function createGatewayRuntime<
     persistedDocumentsPlugin = plugin;
   }
 
+  if (
+    ('proxy' in config || 'subgraph' in config) &&
+    'gracefulSchemaReload' in config &&
+    config['gracefulSchemaReload'] != null
+  ) {
+    // Generation overlap is a supergraph concept (executor + subgraph
+    // transports per generation); accepting the option here would silently do
+    // nothing while the operator believes in-flight operations survive reloads.
+    throw new Error(
+      'gracefulSchemaReload is only supported with a supergraph configuration',
+    );
+  }
+
   if ('proxy' in config) {
     const transportExecutorStack = new AsyncDisposableStack();
     const proxyExecutor = getProxyExecutor({

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -11,6 +11,7 @@ import type {
   OnDelegationPlanHook,
   OnDelegationStageExecuteHook,
   OnSubgraphExecuteHook,
+  SchemaGenerationLease,
 } from '@graphql-mesh/fusion-runtime';
 import {
   handleMaybePromiseMaybeAsyncIterableResult,
@@ -244,7 +245,9 @@ export function createGatewayRuntime<
   // Pins the schema generation an operation executes against for the operation's
   // whole lifetime (graceful schema reload). Only set when a unified graph
   // manager is in use; left undefined for the proxy path.
-  let retainGenerationFor: ((schema: GraphQLSchema) => () => void) | undefined;
+  let retainGenerationFor:
+    | ((schema: GraphQLSchema) => SchemaGenerationLease | undefined)
+    | undefined;
   let replaceSchema: (schema: GraphQLSchema) => void = (newSchema) => {
     unifiedGraph = newSchema;
   };
@@ -790,16 +793,20 @@ export function createGatewayRuntime<
       // Pin the generation this operation runs against until it fully completes,
       // so a schema reload mid-operation does not abort it (graceful schema
       // reload). Subscriptions go through onSubscribe and are intentionally not
-      // pinned. The release callback is idempotent.
-      const releaseGeneration = retainGenerationFor?.(args.schema);
+      // pinned. The lease's release callback is idempotent.
+      const lease = retainGenerationFor?.(args.schema);
       return handleMaybePromise(
-        () => getExecutor?.(),
+        // The operation must execute on the generation it pinned — a reload may
+        // already have made a newer generation current. Only unpinned operations
+        // (schema untracked or generation already disposed) fall back to the
+        // current generation's executor.
+        () => (lease ? lease.executor : getExecutor?.()),
         (executor) => {
           if (executor) {
             const executeFn = getExecuteFnFromExecutor(executor);
             setExecuteFn(executeFn);
           }
-          if (!releaseGeneration) {
+          if (!lease) {
             return undefined;
           }
           return {
@@ -808,9 +815,9 @@ export function createGatewayRuntime<
               // generation until the stream ends; release only then. Single
               // results are complete now.
               if (isAsyncIterable(result)) {
-                return { onEnd: releaseGeneration };
+                return { onEnd: lease.release };
               }
-              releaseGeneration();
+              lease.release();
               return undefined;
             },
           };
@@ -820,7 +827,7 @@ export function createGatewayRuntime<
         // — aborts surface as error results, not rejections — and any leaked pin
         // is reclaimed by the drain timeout.)
         (error) => {
-          releaseGeneration?.();
+          lease?.release();
           throw error;
         },
       );

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -643,20 +643,24 @@ export function createGatewayRuntime<
 
     const gracefulSchemaReload = config.gracefulSchemaReload;
     if (gracefulSchemaReload) {
+      // Number.isFinite rejects NaN, Infinity and non-numbers in one check
+      // (NaN <= 0 / NaN < 1 are both false, so a plain comparison would let an
+      // invalid value through).
       if (
-        typeof gracefulSchemaReload.drainTimeout !== 'number' ||
+        !Number.isFinite(gracefulSchemaReload.drainTimeout) ||
         gracefulSchemaReload.drainTimeout <= 0
       ) {
         throw new Error(
-          'gracefulSchemaReload.drainTimeout must be a positive number of milliseconds',
+          'gracefulSchemaReload.drainTimeout must be a finite positive number of milliseconds',
         );
       }
       if (
         gracefulSchemaReload.maxConcurrentGenerations != null &&
-        gracefulSchemaReload.maxConcurrentGenerations < 1
+        (!Number.isFinite(gracefulSchemaReload.maxConcurrentGenerations) ||
+          gracefulSchemaReload.maxConcurrentGenerations < 1)
       ) {
         throw new Error(
-          'gracefulSchemaReload.maxConcurrentGenerations must be at least 1',
+          'gracefulSchemaReload.maxConcurrentGenerations must be a finite number that is at least 1',
         );
       }
     }

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -870,9 +870,10 @@ export function createGatewayRuntime<
       setSubscribeFn,
     }: OnSubscribeEventPayload<GatewayContext>) =>
       // Subscriptions are intentionally NOT pinned to a generation (no
-      // retainGenerationFor here): they are long-lived, so on a schema reload
-      // they end and the client reconnects against the new schema rather than
-      // keeping the old generation alive indefinitely.
+      // retainGenerationFor here): they are long-lived, so rather than keeping
+      // the old generation alive indefinitely they end — when that generation
+      // is disposed (immediately on reload when idle, otherwise once it
+      // finishes draining) — and the client reconnects against the new schema.
       handleMaybePromise(
         () => getExecutor?.(),
         (executor) => {

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -788,6 +788,7 @@ export function createGatewayRuntime<
   if (getExecutor) {
     const onExecute = ({
       args,
+      executeFn,
       setExecuteFn,
     }: OnExecuteEventPayload<GatewayContext>) => {
       // Pin the generation this operation runs against until it fully completes,
@@ -802,13 +803,28 @@ export function createGatewayRuntime<
         // current generation's executor.
         () => (lease ? lease.executor : getExecutor?.()),
         (executor) => {
-          if (executor) {
-            const executeFn = getExecuteFnFromExecutor(executor);
-            setExecuteFn(executeFn);
-          }
+          const baseExecuteFn = executor
+            ? getExecuteFnFromExecutor(executor)
+            : executeFn;
           if (!lease) {
+            if (executor) {
+              setExecuteFn(baseExecuteFn);
+            }
             return undefined;
           }
+          // envelop only runs onExecuteDone when execution resolves; a rejected
+          // execution (e.g. aborted through execution cancellation) would leak
+          // the pin until the drain timeout, so release it on rejection here.
+          setExecuteFn((execArgs) =>
+            handleMaybePromise(
+              () => baseExecuteFn(execArgs),
+              (result) => result,
+              (error) => {
+                lease.release();
+                throw error;
+              },
+            ),
+          );
           return {
             onExecuteDone({ result }: { result: unknown }) {
               // Incremental-delivery results (@defer / @stream) keep using this
@@ -823,9 +839,7 @@ export function createGatewayRuntime<
           };
         },
         // getExecutor()/schema load rejected before execution started: release
-        // the pin so the generation can still drain. (A thrown execution is rare
-        // — aborts surface as error results, not rejections — and any leaked pin
-        // is reclaimed by the drain timeout.)
+        // the pin so the generation can still drain.
         (error) => {
           lease?.release();
           throw error;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -503,7 +503,55 @@ export interface GatewayHivePersistedDocumentsOptions {
   cacheKeyPrefix?: string;
 }
 
+/**
+ * Options for gracefully reloading the supergraph ("generation overlap").
+ *
+ * By default, when the supergraph schema changes, the previous generation
+ * (executor + subgraph transports) is disposed immediately, which aborts any
+ * in-flight operation still running on it with an `extensions.code:
+ * "SCHEMA_RELOAD"` / HTTP 503 error (queries are then retried on the new schema
+ * by the built-in retry-on-schema-reload plugin; mutations are not).
+ *
+ * When this option is provided, the previous generation is instead kept alive
+ * and only NEW requests are routed to the new generation. In-flight operations
+ * on the previous generation are allowed to finish ("drain") under the schema
+ * they were admitted on, and the previous generation is disposed once it is idle
+ * — or force-disposed once {@link drainTimeout} elapses, whichever comes first.
+ * Incremental-delivery operations (`@defer` / `@stream`) are kept alive until
+ * their stream ends.
+ *
+ * Subscriptions are NOT overlapped: they are long-lived, so on reload they end
+ * and the client reconnects against the new schema.
+ */
+export interface GracefulSchemaReloadConfig {
+  /**
+   * Maximum time, in milliseconds, to keep a superseded schema generation alive
+   * so that in-flight operations can finish before it is force-disposed
+   * (aborting any operations still in flight, as in the default behavior).
+   *
+   * Must be greater than 0 to enable graceful reload.
+   */
+  drainTimeout: number;
+  /**
+   * Maximum number of schema generations kept alive at the same time (the
+   * current generation plus any still-draining previous generations). When a
+   * reload would exceed this number, the oldest draining generation is
+   * force-disposed. Must be at least 1.
+   *
+   * @default 10
+   */
+  maxConcurrentGenerations?: number;
+}
+
 export interface GatewayConfigBase<TContext extends Record<string, any>> {
+  /**
+   * Gracefully reload the supergraph by letting in-flight operations finish on
+   * the previous schema generation instead of aborting them. Disabled by
+   * default (previous generation is disposed immediately on reload).
+   *
+   * @see {@link GracefulSchemaReloadConfig}
+   */
+  gracefulSchemaReload?: GracefulSchemaReloadConfig;
   /** Usage reporting options. */
   reporting?: GatewayHiveReportingOptions | GatewayGraphOSReportingOptions;
   /** Persisted documents options. */

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -534,6 +534,11 @@ export interface GatewayHivePersistedDocumentsOptions {
  * disposed — immediately on reload when it has no in-flight operations,
  * otherwise once it finishes draining (at the latest after
  * {@link drainTimeout}) — and the client reconnects against the new schema.
+ *
+ * Schema-replacing plugins must preserve the schema object supplied by the
+ * gateway. If a plugin replaces or rebuilds it, the gateway cannot associate
+ * operations with their schema generation, so graceful reload does not protect
+ * those operations. The gateway logs a warning once when this occurs.
  */
 export interface GracefulSchemaReloadConfig {
   /**

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -529,8 +529,11 @@ export interface GatewayHivePersistedDocumentsOptions {
  * Incremental-delivery operations (`@defer` / `@stream`) are kept alive until
  * their stream ends.
  *
- * Subscriptions are NOT overlapped: they are long-lived, so on reload they end
- * and the client reconnects against the new schema.
+ * Subscriptions are NOT pinned: they are long-lived, so a subscription on a
+ * superseded generation ends with `SCHEMA_RELOAD` when that generation is
+ * disposed — immediately on reload when it has no in-flight operations,
+ * otherwise once it finishes draining (at the latest after
+ * {@link drainTimeout}) — and the client reconnects against the new schema.
  */
 export interface GracefulSchemaReloadConfig {
   /**

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -273,6 +273,15 @@ export interface GatewayConfigSupergraph<
    * @experimental This option is experimental and may change in the future.
    */
   unifiedGraphHandler?: UnifiedGraphHandler;
+
+  /**
+   * Gracefully reload the supergraph by letting in-flight operations finish on
+   * the previous schema generation instead of aborting them. Disabled by
+   * default (previous generation is disposed immediately on reload).
+   *
+   * @see {@link GracefulSchemaReloadConfig}
+   */
+  gracefulSchemaReload?: GracefulSchemaReloadConfig;
 }
 
 export type ProgressiveOverrideHandler = (
@@ -544,14 +553,6 @@ export interface GracefulSchemaReloadConfig {
 }
 
 export interface GatewayConfigBase<TContext extends Record<string, any>> {
-  /**
-   * Gracefully reload the supergraph by letting in-flight operations finish on
-   * the previous schema generation instead of aborting them. Disabled by
-   * default (previous generation is disposed immediately on reload).
-   *
-   * @see {@link GracefulSchemaReloadConfig}
-   */
-  gracefulSchemaReload?: GracefulSchemaReloadConfig;
   /** Usage reporting options. */
   reporting?: GatewayHiveReportingOptions | GatewayGraphOSReportingOptions;
   /** Persisted documents options. */

--- a/packages/runtime/tests/graceful-schema-reload.test.ts
+++ b/packages/runtime/tests/graceful-schema-reload.test.ts
@@ -12,7 +12,7 @@ import {
 import { DisposableSymbols } from '@whatwg-node/disposablestack';
 import { parse } from 'graphql';
 import { createYoga } from 'graphql-yoga';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 /**
  * Behavioral (black-box) tests for graceful supergraph reload ("generation
@@ -779,5 +779,62 @@ describe('Graceful schema reload (generation overlap)', () => {
     releaseSlowA.resolve('fromA');
     const resultA = await inFlightA;
     expect(resultA.data?.['slow']).toBe('fromC');
+  });
+});
+
+describe('Graceful schema reload — config validation', () => {
+  let supergraph: string;
+  beforeAll(async () => {
+    const schema = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          ok: Boolean
+        }
+      `),
+      resolvers: { Query: { ok: () => true } },
+    });
+    supergraph = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema, url: 'http://localhost:9999/graphql' },
+    ]);
+  });
+
+  // NaN is `typeof "number"` and `NaN <= 0` / `NaN < 1` are both false, so these
+  // must be rejected explicitly rather than slipping through the bound checks.
+  it.each([0, -1, NaN, Infinity])(
+    'rejects an invalid drainTimeout (%p)',
+    (drainTimeout) => {
+      expect(() =>
+        createGatewayRuntime({
+          supergraph: () => supergraph,
+          gracefulSchemaReload: { drainTimeout },
+          logging: false,
+        }),
+      ).toThrow(/drainTimeout/);
+    },
+  );
+
+  it.each([0, -1, NaN, Infinity])(
+    'rejects an invalid maxConcurrentGenerations (%p)',
+    (maxConcurrentGenerations) => {
+      expect(() =>
+        createGatewayRuntime({
+          supergraph: () => supergraph,
+          gracefulSchemaReload: {
+            drainTimeout: 1000,
+            maxConcurrentGenerations,
+          },
+          logging: false,
+        }),
+      ).toThrow(/maxConcurrentGenerations/);
+    },
+  );
+
+  it('accepts a finite, in-range config', async () => {
+    await using gw = createGatewayRuntime({
+      supergraph: () => supergraph,
+      gracefulSchemaReload: { drainTimeout: 1000, maxConcurrentGenerations: 3 },
+      logging: false,
+    });
+    expect(gw).toBeDefined();
   });
 });

--- a/packages/runtime/tests/graceful-schema-reload.test.ts
+++ b/packages/runtime/tests/graceful-schema-reload.test.ts
@@ -1045,4 +1045,26 @@ describe('Graceful schema reload — config validation', () => {
     });
     expect(gw).toBeDefined();
   });
+
+  // Generation overlap only exists for supergraphs; in the other modes the
+  // option would be silently ignored, so it is rejected up front.
+  it('rejects gracefulSchemaReload in proxy mode', () => {
+    expect(() =>
+      createGatewayRuntime({
+        proxy: { endpoint: 'http://localhost:9999/graphql' },
+        gracefulSchemaReload: { drainTimeout: 1000 },
+        logging: false,
+      }),
+    ).toThrow(/gracefulSchemaReload/);
+  });
+
+  it('rejects gracefulSchemaReload in subgraph mode', () => {
+    expect(() =>
+      createGatewayRuntime({
+        subgraph: () => supergraph,
+        gracefulSchemaReload: { drainTimeout: 1000 },
+        logging: false,
+      }),
+    ).toThrow(/gracefulSchemaReload/);
+  });
 });

--- a/packages/runtime/tests/graceful-schema-reload.test.ts
+++ b/packages/runtime/tests/graceful-schema-reload.test.ts
@@ -4,6 +4,8 @@ import {
   createGatewayRuntime,
   type GatewayRuntime,
 } from '@graphql-hive/gateway-runtime';
+import { handleFederationSupergraph } from '@graphql-mesh/fusion-runtime';
+import { createDefaultExecutor } from '@graphql-tools/delegate';
 import { createDeferred } from '@graphql-tools/utils';
 import {
   composeLocalSchemasWithApollo,
@@ -347,6 +349,131 @@ describe('Graceful schema reload (generation overlap)', () => {
     // With only one generation allowed, the previous generation cannot overlap;
     // it is disposed at reload and the query is retried on the new generation.
     expect(result.data?.['slow']).toBe('fromB');
+  });
+
+  it('executes on the generation it pinned when the handler provides an executor (router-runtime path)', async () => {
+    const slowEntered = createDeferred<void>();
+    const releaseSlow = createDeferred<string>();
+    const victimEntered = createDeferred<void>();
+    const releaseVictim = createDeferred<void>();
+
+    const typeDefs = parse(/* GraphQL */ `
+      type Query {
+        ping: String
+        slow: String
+        pinned: String
+      }
+    `);
+    const schemaA = buildSubgraphSchema({
+      typeDefs,
+      resolvers: {
+        Query: {
+          ping: () => 'genA',
+          pinned: () => 'fromA',
+          slow: () => {
+            slowEntered.resolve();
+            return releaseSlow.promise;
+          },
+        },
+      },
+    });
+    const schemaB = buildSubgraphSchema({
+      typeDefs,
+      resolvers: {
+        Query: {
+          ping: () => 'genB',
+          pinned: () => 'fromB',
+          slow: () => 'fromB',
+        },
+      },
+    });
+
+    await using yogaA = createYoga({ schema: schemaA, logging: false });
+    await using serverA = await createDisposableServer(yogaA);
+    await using yogaB = createYoga({ schema: schemaB, logging: false });
+    await using serverB = await createDisposableServer(yogaB);
+
+    const sdlA = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaA, url: `${serverA.url}/graphql` },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaB, url: `${serverB.url}/graphql` },
+    ]);
+
+    let useSecond = false;
+    let holdVictim = false;
+    await using gw = createGatewayRuntime({
+      supergraph: () => (useSecond ? sdlB : sdlA),
+      pollingInterval: 100,
+      gracefulSchemaReload: { drainTimeout: 10_000 },
+      // The router runtime executes through a generation-scoped executor
+      // instead of the schema's own resolvers; emulate that shape by attaching
+      // an executor to the default handler's result.
+      unifiedGraphHandler: (opts) => {
+        const result = handleFederationSupergraph(opts);
+        return {
+          ...result,
+          executor: createDefaultExecutor(result.unifiedGraph),
+        };
+      },
+      plugins: () => [
+        {
+          // Hold the victim operation after it has been admitted (schema
+          // captured) but before execution, so a reload completes in between.
+          onContextBuilding({
+            context,
+          }: {
+            context: { params?: { query?: string } };
+          }) {
+            if (holdVictim && context.params?.query?.includes('pinned')) {
+              victimEntered.resolve();
+              return releaseVictim.promise;
+            }
+            return undefined;
+          },
+        },
+      ],
+      logging: false,
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+
+    // Keep generation A draining across the reload with a blocked, pinned op.
+    const inFlightSlow = runOperation(
+      gw,
+      /* GraphQL */ `
+        {
+          slow
+        }
+      `,
+    );
+    await slowEntered.promise;
+
+    // Admit the victim under generation A but hold it before execution.
+    holdVictim = true;
+    const victim = runOperation(
+      gw,
+      /* GraphQL */ `
+        {
+          pinned
+        }
+      `,
+    );
+    await victimEntered.promise;
+
+    // Reload to generation B while the victim is held pre-execution.
+    useSecond = true;
+    await waitForGeneration(gw, 'genB');
+
+    // The victim was admitted (and validated) under generation A, so it must
+    // pin AND execute generation A — not run on B's executor while pinning A.
+    releaseVictim.resolve();
+    const result = await victim;
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['pinned']).toBe('fromA');
+
+    releaseSlow.resolve('fromA');
+    expect((await inFlightSlow).data?.['slow']).toBe('fromA');
   });
 
   it('does not overlap when graceful reload is not configured (opt-in)', async () => {

--- a/packages/runtime/tests/graceful-schema-reload.test.ts
+++ b/packages/runtime/tests/graceful-schema-reload.test.ts
@@ -1,0 +1,783 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import {
+  createGatewayRuntime,
+  type GatewayRuntime,
+} from '@graphql-hive/gateway-runtime';
+import { createDeferred } from '@graphql-tools/utils';
+import {
+  composeLocalSchemasWithApollo,
+  createDisposableServer,
+} from '@internal/testing';
+import { DisposableSymbols } from '@whatwg-node/disposablestack';
+import { parse } from 'graphql';
+import { createYoga } from 'graphql-yoga';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Behavioral (black-box) tests for graceful supergraph reload ("generation
+ * overlap"). Everything is driven through the public gateway runtime against
+ * REAL upstream HTTP servers — no mocks, no inspection of internals. The only
+ * thing observed is the HTTP response a client would get.
+ *
+ * The scenario: a request is made to block inside an upstream resolver (so it is
+ * provably in-flight), the supergraph is reloaded to a DIFFERENT upstream while
+ * that request is blocked, then the blocked resolver is released. With graceful
+ * reload, the in-flight operation must finish on the OLD generation and return
+ * the OLD upstream's value (`fromA`). Without it (default), the operation is
+ * aborted with SCHEMA_RELOAD: queries are retried on the new generation
+ * (`fromB`) and mutations fail outright.
+ */
+
+const TYPE_DEFS = /* GraphQL */ `
+  type Query {
+    ping: String
+    slow: String
+  }
+  type Mutation {
+    slowMutation: String
+  }
+`;
+
+const GW_URL = 'http://gateway/graphql';
+const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
+
+async function runOperation(
+  gw: GatewayRuntime,
+  query: string,
+): Promise<{ data?: Record<string, unknown> | null; errors?: unknown[] }> {
+  const response = await gw.fetch(GW_URL, {
+    method: 'POST',
+    body: JSON.stringify({ query }),
+    headers: JSON_HEADERS,
+  });
+  return response.json() as Promise<{
+    data?: Record<string, unknown> | null;
+    errors?: unknown[];
+  }>;
+}
+
+/** Drive the lazy poller until the gateway serves the expected generation. */
+async function waitForGeneration(
+  gw: GatewayRuntime,
+  expected: string,
+  { attempts = 80, gap = 75 }: { attempts?: number; gap?: number } = {},
+): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    const result = await runOperation(
+      gw,
+      /* GraphQL */ `
+        {
+          ping
+        }
+      `,
+    );
+    if (result.data?.['ping'] === expected) {
+      return;
+    }
+    await delay(gap);
+  }
+  throw new Error(`supergraph never reloaded to "${expected}"`);
+}
+
+describe('Graceful schema reload (generation overlap)', () => {
+  it('completes an in-flight QUERY on the previous generation instead of retrying on the new one', async () => {
+    const slowEntered = createDeferred<void>();
+    const releaseSlow = createDeferred<string>();
+
+    const schemaA = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: {
+          ping: () => 'genA',
+          slow: () => {
+            slowEntered.resolve();
+            return releaseSlow.promise;
+          },
+        },
+      },
+    });
+    const schemaB = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: { ping: () => 'genB', slow: () => 'fromB' },
+      },
+    });
+
+    await using yogaA = createYoga({ schema: schemaA, logging: false });
+    await using serverA = await createDisposableServer(yogaA);
+    await using yogaB = createYoga({ schema: schemaB, logging: false });
+    await using serverB = await createDisposableServer(yogaB);
+
+    const sdlA = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaA, url: `${serverA.url}/graphql` },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaB, url: `${serverB.url}/graphql` },
+    ]);
+
+    let useSecond = false;
+    await using gw = createGatewayRuntime({
+      supergraph: () => (useSecond ? sdlB : sdlA),
+      pollingInterval: 100,
+      gracefulSchemaReload: { drainTimeout: 10_000 },
+      logging: false,
+    });
+
+    // Generation A is live.
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+
+    // Start a request that blocks inside generation A's upstream.
+    const inFlight = runOperation(
+      gw,
+      /* GraphQL */ `
+        {
+          slow
+        }
+      `,
+    );
+    await slowEntered.promise;
+
+    // Reload to generation B while the request is blocked.
+    useSecond = true;
+    await waitForGeneration(gw, 'genB');
+
+    // Release the blocked resolver; the in-flight request must finish on A.
+    releaseSlow.resolve('fromA');
+    const result = await inFlight;
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['slow']).toBe('fromA');
+  });
+
+  it('completes an in-flight MUTATION across a schema reload (mutations are never retried)', async () => {
+    const mutationEntered = createDeferred<void>();
+    const releaseMutation = createDeferred<string>();
+
+    const schemaA = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: { ping: () => 'genA' },
+        Mutation: {
+          slowMutation: () => {
+            mutationEntered.resolve();
+            return releaseMutation.promise;
+          },
+        },
+      },
+    });
+    const schemaB = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: { ping: () => 'genB' },
+        Mutation: { slowMutation: () => 'fromB' },
+      },
+    });
+
+    await using yogaA = createYoga({ schema: schemaA, logging: false });
+    await using serverA = await createDisposableServer(yogaA);
+    await using yogaB = createYoga({ schema: schemaB, logging: false });
+    await using serverB = await createDisposableServer(yogaB);
+
+    const sdlA = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaA, url: `${serverA.url}/graphql` },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaB, url: `${serverB.url}/graphql` },
+    ]);
+
+    let useSecond = false;
+    await using gw = createGatewayRuntime({
+      supergraph: () => (useSecond ? sdlB : sdlA),
+      pollingInterval: 100,
+      gracefulSchemaReload: { drainTimeout: 10_000 },
+      logging: false,
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+
+    const inFlight = runOperation(
+      gw,
+      /* GraphQL */ `
+        mutation {
+          slowMutation
+        }
+      `,
+    );
+    await mutationEntered.promise;
+
+    useSecond = true;
+    await waitForGeneration(gw, 'genB');
+
+    releaseMutation.resolve('fromA');
+    const result = await inFlight;
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['slowMutation']).toBe('fromA');
+  });
+
+  it('force-disposes the previous generation after the drain timeout', async () => {
+    const slowEntered = createDeferred<void>();
+    const releaseSlow = createDeferred<string>();
+
+    const schemaA = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: {
+          ping: () => 'genA',
+          slow: () => {
+            slowEntered.resolve();
+            return releaseSlow.promise;
+          },
+        },
+      },
+    });
+    const schemaB = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: { Query: { ping: () => 'genB', slow: () => 'fromB' } },
+    });
+
+    await using yogaA = createYoga({ schema: schemaA, logging: false });
+    await using serverA = await createDisposableServer(yogaA);
+    await using yogaB = createYoga({ schema: schemaB, logging: false });
+    await using serverB = await createDisposableServer(yogaB);
+
+    const sdlA = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaA, url: `${serverA.url}/graphql` },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaB, url: `${serverB.url}/graphql` },
+    ]);
+
+    let useSecond = false;
+    await using gw = createGatewayRuntime({
+      supergraph: () => (useSecond ? sdlB : sdlA),
+      pollingInterval: 100,
+      gracefulSchemaReload: { drainTimeout: 500 },
+      logging: false,
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+
+    const inFlight = runOperation(
+      gw,
+      /* GraphQL */ `
+        {
+          slow
+        }
+      `,
+    );
+    await slowEntered.promise;
+
+    useSecond = true;
+    await waitForGeneration(gw, 'genB');
+
+    // Do NOT release until well past the drain timeout: the previous generation
+    // must be force-disposed, aborting the in-flight query which is then retried
+    // on the new generation.
+    await delay(1500);
+    releaseSlow.resolve('fromA');
+    const result = await inFlight;
+
+    expect(result.data?.['slow']).toBe('fromB');
+  });
+
+  it('caps concurrent generations — cap of 1 disables overlap', async () => {
+    const slowEntered = createDeferred<void>();
+    const releaseSlow = createDeferred<string>();
+
+    const schemaA = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: {
+          ping: () => 'genA',
+          slow: () => {
+            slowEntered.resolve();
+            return releaseSlow.promise;
+          },
+        },
+      },
+    });
+    const schemaB = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: { Query: { ping: () => 'genB', slow: () => 'fromB' } },
+    });
+
+    await using yogaA = createYoga({ schema: schemaA, logging: false });
+    await using serverA = await createDisposableServer(yogaA);
+    await using yogaB = createYoga({ schema: schemaB, logging: false });
+    await using serverB = await createDisposableServer(yogaB);
+
+    const sdlA = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaA, url: `${serverA.url}/graphql` },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaB, url: `${serverB.url}/graphql` },
+    ]);
+
+    let useSecond = false;
+    await using gw = createGatewayRuntime({
+      supergraph: () => (useSecond ? sdlB : sdlA),
+      pollingInterval: 100,
+      gracefulSchemaReload: {
+        drainTimeout: 10_000,
+        maxConcurrentGenerations: 1,
+      },
+      logging: false,
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+
+    const inFlight = runOperation(
+      gw,
+      /* GraphQL */ `
+        {
+          slow
+        }
+      `,
+    );
+    await slowEntered.promise;
+
+    useSecond = true;
+    await waitForGeneration(gw, 'genB');
+
+    releaseSlow.resolve('fromA');
+    const result = await inFlight;
+
+    // With only one generation allowed, the previous generation cannot overlap;
+    // it is disposed at reload and the query is retried on the new generation.
+    expect(result.data?.['slow']).toBe('fromB');
+  });
+
+  it('does not overlap when graceful reload is not configured (opt-in)', async () => {
+    const slowEntered = createDeferred<void>();
+    const releaseSlow = createDeferred<string>();
+
+    const schemaA = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: {
+          ping: () => 'genA',
+          slow: () => {
+            slowEntered.resolve();
+            return releaseSlow.promise;
+          },
+        },
+      },
+    });
+    const schemaB = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: { Query: { ping: () => 'genB', slow: () => 'fromB' } },
+    });
+
+    await using yogaA = createYoga({ schema: schemaA, logging: false });
+    await using serverA = await createDisposableServer(yogaA);
+    await using yogaB = createYoga({ schema: schemaB, logging: false });
+    await using serverB = await createDisposableServer(yogaB);
+
+    const sdlA = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaA, url: `${serverA.url}/graphql` },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaB, url: `${serverB.url}/graphql` },
+    ]);
+
+    let useSecond = false;
+    await using gw = createGatewayRuntime({
+      supergraph: () => (useSecond ? sdlB : sdlA),
+      pollingInterval: 100,
+      // graceful reload intentionally NOT configured
+      logging: false,
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+
+    const inFlight = runOperation(
+      gw,
+      /* GraphQL */ `
+        {
+          slow
+        }
+      `,
+    );
+    await slowEntered.promise;
+
+    useSecond = true;
+    await waitForGeneration(gw, 'genB');
+
+    releaseSlow.resolve('fromA');
+    const result = await inFlight;
+
+    // Without graceful reload the previous generation is disposed immediately,
+    // so the in-flight query is aborted and retried on the new generation.
+    expect(result.data?.['slow']).toBe('fromB');
+  });
+
+  it('disposes draining generations on shutdown (aborts their in-flight work)', async () => {
+    const mutationEntered = createDeferred<void>();
+    const releaseMutation = createDeferred<string>();
+
+    const schemaA = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: { ping: () => 'genA' },
+        Mutation: {
+          slowMutation: () => {
+            mutationEntered.resolve();
+            return releaseMutation.promise;
+          },
+        },
+      },
+    });
+    const schemaB = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: { ping: () => 'genB' },
+        Mutation: { slowMutation: () => 'fromB' },
+      },
+    });
+
+    await using yogaA = createYoga({ schema: schemaA, logging: false });
+    await using serverA = await createDisposableServer(yogaA);
+    await using yogaB = createYoga({ schema: schemaB, logging: false });
+    await using serverB = await createDisposableServer(yogaB);
+
+    const sdlA = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaA, url: `${serverA.url}/graphql` },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaB, url: `${serverB.url}/graphql` },
+    ]);
+
+    let useSecond = false;
+    // Not `await using`: the gateway is disposed explicitly mid-test.
+    const gw = createGatewayRuntime({
+      supergraph: () => (useSecond ? sdlB : sdlA),
+      pollingInterval: 100,
+      gracefulSchemaReload: { drainTimeout: 30_000 },
+      logging: false,
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+
+    // A mutation blocks inside generation A, then a reload makes generation A a
+    // draining generation that is kept alive (drain timeout is long).
+    const inFlight = runOperation(
+      gw,
+      /* GraphQL */ `
+        mutation {
+          slowMutation
+        }
+      `,
+    );
+    await mutationEntered.promise;
+    useSecond = true;
+    await waitForGeneration(gw, 'genB');
+
+    // Shutting down must dispose ALL live generations — including the draining
+    // one — so the blocked mutation is aborted and disposal completes.
+    const disposed = gw[DisposableSymbols.asyncDispose]();
+    const result = await inFlight;
+    await disposed;
+
+    expect(result.errors).toBeDefined();
+    expect(result.data?.['slowMutation']).not.toBe('fromA');
+    // On shutdown a draining generation's in-flight work must abort with
+    // SHUTTING_DOWN (not SCHEMA_RELOAD, which would invite a retry into a
+    // shutting-down gateway).
+    expect(JSON.stringify(result.errors)).toContain('SHUTTING_DOWN');
+
+    // Release the upstream resolver so the upstream server can shut down cleanly.
+    releaseMutation.resolve('fromA');
+  });
+
+  it('completes an in-flight MULTI-HOP operation across a reload', async () => {
+    const hop1Entered = createDeferred<void>();
+    const releaseHop1 = createDeferred<void>();
+
+    // Subgraph "products": owns Product and the blocking mutation (hop 1).
+    const productsSchema = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          ping: String
+        }
+        type Mutation {
+          makeProduct: Product
+        }
+        type Product @key(fields: "id") {
+          id: ID!
+        }
+      `),
+      resolvers: {
+        Query: { ping: () => 'genA' },
+        Mutation: {
+          makeProduct: async () => {
+            hop1Entered.resolve();
+            await releaseHop1.promise;
+            return { id: '1' };
+          },
+        },
+      },
+    });
+    // Subgraph "reviews": resolves Product.review via an entity reference (hop 2).
+    const reviewsSchema = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          _reviewsPing: String
+        }
+        type Product @key(fields: "id") {
+          id: ID!
+          review: String
+        }
+      `),
+      resolvers: {
+        Product: {
+          __resolveReference: (ref: { id: string }) => ({
+            id: ref.id,
+            review: 'reviewFromReviews',
+          }),
+        },
+      },
+    });
+    // The reload target — a different, unrelated supergraph.
+    const otherSchema = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          ping: String
+        }
+      `),
+      resolvers: { Query: { ping: () => 'genB' } },
+    });
+
+    await using productsYoga = createYoga({
+      schema: productsSchema,
+      logging: false,
+    });
+    await using productsServer = await createDisposableServer(productsYoga);
+    await using reviewsYoga = createYoga({
+      schema: reviewsSchema,
+      logging: false,
+    });
+    await using reviewsServer = await createDisposableServer(reviewsYoga);
+    await using otherYoga = createYoga({ schema: otherSchema, logging: false });
+    await using otherServer = await createDisposableServer(otherYoga);
+
+    const sdlA = await composeLocalSchemasWithApollo([
+      {
+        name: 'products',
+        schema: productsSchema,
+        url: `${productsServer.url}/graphql`,
+      },
+      {
+        name: 'reviews',
+        schema: reviewsSchema,
+        url: `${reviewsServer.url}/graphql`,
+      },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'other', schema: otherSchema, url: `${otherServer.url}/graphql` },
+    ]);
+
+    let useSecond = false;
+    await using gw = createGatewayRuntime({
+      supergraph: () => (useSecond ? sdlB : sdlA),
+      pollingInterval: 100,
+      gracefulSchemaReload: { drainTimeout: 30_000 },
+      logging: false,
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+
+    // A multi-hop mutation: hop 1 in "products" (blocks), then hop 2 resolves
+    // `review` from "reviews" via an entity reference.
+    const inFlight = runOperation(
+      gw,
+      /* GraphQL */ `
+        mutation {
+          makeProduct {
+            id
+            review
+          }
+        }
+      `,
+    );
+    await hop1Entered.promise;
+
+    // Reload while the mutation is in flight on its (now previous) generation.
+    useSecond = true;
+    await waitForGeneration(gw, 'genB');
+
+    releaseHop1.resolve();
+    const result = await inFlight;
+
+    // Both hops must complete on the original generation — the generation must
+    // not be disposed in the gap between hop 1 finishing and hop 2 starting.
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['makeProduct']).toEqual({
+      id: '1',
+      review: 'reviewFromReviews',
+    });
+  });
+
+  it('does not overlap an in-flight MUTATION when graceful reload is not configured (default-off)', async () => {
+    const mutationEntered = createDeferred<void>();
+    const releaseMutation = createDeferred<string>();
+
+    const schemaA = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: { ping: () => 'genA' },
+        Mutation: {
+          slowMutation: () => {
+            mutationEntered.resolve();
+            return releaseMutation.promise;
+          },
+        },
+      },
+    });
+    const schemaB = buildSubgraphSchema({
+      typeDefs: parse(TYPE_DEFS),
+      resolvers: {
+        Query: { ping: () => 'genB' },
+        Mutation: { slowMutation: () => 'fromB' },
+      },
+    });
+
+    await using yogaA = createYoga({ schema: schemaA, logging: false });
+    await using serverA = await createDisposableServer(yogaA);
+    await using yogaB = createYoga({ schema: schemaB, logging: false });
+    await using serverB = await createDisposableServer(yogaB);
+
+    const sdlA = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaA, url: `${serverA.url}/graphql` },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaB, url: `${serverB.url}/graphql` },
+    ]);
+
+    let useSecond = false;
+    await using gw = createGatewayRuntime({
+      supergraph: () => (useSecond ? sdlB : sdlA),
+      pollingInterval: 100,
+      // graceful reload intentionally NOT configured
+      logging: false,
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+
+    const inFlight = runOperation(
+      gw,
+      /* GraphQL */ `
+        mutation {
+          slowMutation
+        }
+      `,
+    );
+    await mutationEntered.promise;
+
+    useSecond = true;
+    await waitForGeneration(gw, 'genB');
+
+    releaseMutation.resolve('fromA');
+    const result = await inFlight;
+
+    // Without graceful reload the in-flight mutation is aborted on reload and,
+    // unlike a query, is NOT retried — so it surfaces a SCHEMA_RELOAD error.
+    expect(result.data?.['slowMutation']).not.toBe('fromA');
+    expect(JSON.stringify(result.errors)).toContain('SCHEMA_RELOAD');
+  });
+
+  it('overlaps multiple generations and force-disposes the OLDEST when the cap is exceeded', async () => {
+    const slowAEntered = createDeferred<void>();
+    const releaseSlowA = createDeferred<string>();
+    const slowBEntered = createDeferred<void>();
+    const releaseSlowB = createDeferred<string>();
+
+    const makeSchema = (gen: string, slow: () => string | Promise<string>) =>
+      buildSubgraphSchema({
+        typeDefs: parse(TYPE_DEFS),
+        resolvers: { Query: { ping: () => gen, slow } },
+      });
+    const schemaA = makeSchema('genA', () => {
+      slowAEntered.resolve();
+      return releaseSlowA.promise;
+    });
+    const schemaB = makeSchema('genB', () => {
+      slowBEntered.resolve();
+      return releaseSlowB.promise;
+    });
+    const schemaC = makeSchema('genC', () => 'fromC');
+
+    await using yogaA = createYoga({ schema: schemaA, logging: false });
+    await using serverA = await createDisposableServer(yogaA);
+    await using yogaB = createYoga({ schema: schemaB, logging: false });
+    await using serverB = await createDisposableServer(yogaB);
+    await using yogaC = createYoga({ schema: schemaC, logging: false });
+    await using serverC = await createDisposableServer(yogaC);
+
+    const sdlA = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaA, url: `${serverA.url}/graphql` },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaB, url: `${serverB.url}/graphql` },
+    ]);
+    const sdlC = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaC, url: `${serverC.url}/graphql` },
+    ]);
+
+    let current = sdlA;
+    await using gw = createGatewayRuntime({
+      supergraph: () => current,
+      pollingInterval: 100,
+      // current + 1 draining generation may coexist; a 2nd draining one evicts
+      // the oldest.
+      gracefulSchemaReload: {
+        drainTimeout: 30_000,
+        maxConcurrentGenerations: 2,
+      },
+      logging: false,
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+
+    // Block an operation on generation A, then reload to B (A starts draining).
+    const inFlightA = runOperation(
+      gw,
+      /* GraphQL */ `
+        {
+          slow
+        }
+      `,
+    );
+    await slowAEntered.promise;
+    current = sdlB;
+    await waitForGeneration(gw, 'genB');
+
+    // Block an operation on generation B, then reload to C. Draining is now
+    // {A, B}, which exceeds the cap (current C + 1), so the OLDEST draining
+    // generation (A) is force-disposed while B keeps draining.
+    const inFlightB = runOperation(
+      gw,
+      /* GraphQL */ `
+        {
+          slow
+        }
+      `,
+    );
+    await slowBEntered.promise;
+    current = sdlC;
+    await waitForGeneration(gw, 'genC');
+
+    // B was within the cap, so it overlapped and completes on its own generation.
+    releaseSlowB.resolve('fromB');
+    const resultB = await inFlightB;
+    expect(resultB.errors).toBeUndefined();
+    expect(resultB.data?.['slow']).toBe('fromB');
+
+    // A was evicted (force-disposed) when the cap was exceeded, so it was aborted
+    // and retried on the current generation (C).
+    releaseSlowA.resolve('fromA');
+    const resultA = await inFlightA;
+    expect(resultA.data?.['slow']).toBe('fromC');
+  });
+});

--- a/packages/runtime/tests/graceful-schema-reload.test.ts
+++ b/packages/runtime/tests/graceful-schema-reload.test.ts
@@ -4,6 +4,7 @@ import {
   createGatewayRuntime,
   type GatewayRuntime,
 } from '@graphql-hive/gateway-runtime';
+import { Logger, MemoryLogWriter } from '@graphql-hive/logger';
 import { handleFederationSupergraph } from '@graphql-mesh/fusion-runtime';
 import { createDefaultExecutor } from '@graphql-tools/delegate';
 import { createDeferred } from '@graphql-tools/utils';
@@ -12,7 +13,7 @@ import {
   createDisposableServer,
 } from '@internal/testing';
 import { DisposableSymbols } from '@whatwg-node/disposablestack';
-import { parse } from 'graphql';
+import { lexicographicSortSchema, parse, type GraphQLSchema } from 'graphql';
 import { createYoga } from 'graphql-yoga';
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -906,6 +907,86 @@ describe('Graceful schema reload (generation overlap)', () => {
     releaseSlowA.resolve('fromA');
     const resultA = await inFlightA;
     expect(resultA.data?.['slow']).toBe('fromC');
+  });
+});
+
+describe('Graceful schema reload — untracked (plugin-replaced) schemas', () => {
+  // Emulates plugins that replace the served schema with a rebuilt copy (e.g.
+  // the NestJS integration's sortSchema), which is then not a tracked
+  // generation.
+  function schemaReplacingPlugin() {
+    const replaced = new WeakSet<GraphQLSchema>();
+    return {
+      onSchemaChange({
+        schema,
+        replaceSchema,
+      }: {
+        schema: GraphQLSchema;
+        replaceSchema: (schema: GraphQLSchema) => void;
+      }) {
+        if (!replaced.has(schema)) {
+          const next = lexicographicSortSchema(schema);
+          replaced.add(next);
+          replaceSchema(next);
+        }
+      },
+    };
+  }
+
+  async function pingUpstream() {
+    const schema = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          ping: String
+        }
+      `),
+      resolvers: { Query: { ping: () => 'pong' } },
+    });
+    const yoga = createYoga({ schema, logging: false });
+    const server = await createDisposableServer(yoga);
+    const sdl = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema, url: `${server.url}/graphql` },
+    ]);
+    return { sdl, server, yoga };
+  }
+
+  it('does not warn (nor pin) when graceful reload is not configured', async () => {
+    const { sdl, server, yoga } = await pingUpstream();
+    await using _server = server;
+    await using _yoga = yoga;
+
+    const writer = new MemoryLogWriter();
+    await using gw = createGatewayRuntime({
+      supergraph: () => sdl,
+      // graceful reload intentionally NOT configured
+      plugins: () => [schemaReplacingPlugin()],
+      logging: new Logger({ level: 'warn', writers: [writer] }),
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('pong');
+    expect(
+      writer.logs.filter((l) => l.msg?.includes('Graceful reload')),
+    ).toEqual([]);
+  });
+
+  it('warns once when graceful reload is configured but the schema is replaced by a plugin', async () => {
+    const { sdl, server, yoga } = await pingUpstream();
+    await using _server = server;
+    await using _yoga = yoga;
+
+    const writer = new MemoryLogWriter();
+    await using gw = createGatewayRuntime({
+      supergraph: () => sdl,
+      gracefulSchemaReload: { drainTimeout: 10_000 },
+      plugins: () => [schemaReplacingPlugin()],
+      logging: new Logger({ level: 'warn', writers: [writer] }),
+    });
+
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('pong');
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('pong');
+    expect(
+      writer.logs.filter((l) => l.msg?.includes('Graceful reload')),
+    ).toHaveLength(1);
   });
 });
 

--- a/packages/runtime/tests/subscriptions.test.ts
+++ b/packages/runtime/tests/subscriptions.test.ts
@@ -160,4 +160,82 @@ describe('Subscriptions', () => {
       ],
     });
   });
+
+  it('terminates subscriptions on schema update even when graceful reload is enabled', async () => {
+    let changeSchema = false;
+
+    await using serve = createGatewayTester({
+      pollingInterval: 500,
+      // Graceful reload keeps in-flight queries/mutations alive across a reload,
+      // but long-lived subscriptions are never overlapped — they must still end
+      // so the client reconnects against the new schema.
+      gracefulSchemaReload: { drainTimeout: 10_000 },
+      subgraphs: () => {
+        if (changeSchema) {
+          return [
+            {
+              name: 'upstream',
+              schema: {
+                typeDefs: /* GraphQL */ `
+                  type Query {
+                    foo: String!
+                  }
+                `,
+                resolvers: {
+                  Query: {
+                    foo: () => 'bar',
+                  },
+                },
+              },
+            },
+          ];
+        }
+        changeSchema = true;
+        return [
+          {
+            name: 'upstream',
+            schema: upstreamSchema,
+          },
+        ];
+      },
+    });
+
+    const sse = createSSEClient({
+      url: 'http://mesh/graphql',
+      fetchFn: serve.fetch,
+    });
+
+    const sub = sse.iterate({
+      query: /* GraphQL */ `
+        subscription {
+          neverEmits
+        }
+      `,
+    });
+
+    const msgs: unknown[] = [];
+    globalThis.setTimeout(() => {
+      void serve.execute({
+        query: /* GraphQL */ `
+          query {
+            foo
+          }
+        `,
+      });
+    }, 1000);
+    for await (const msg of sub) {
+      msgs.push(msg);
+    }
+
+    expect(msgs[msgs.length - 1]).toMatchObject({
+      errors: [
+        {
+          extensions: {
+            code: 'SCHEMA_RELOAD',
+          },
+          message: 'operation has been aborted due to a schema reload',
+        },
+      ],
+    });
+  });
 });

--- a/packages/runtime/tests/subscriptions.test.ts
+++ b/packages/runtime/tests/subscriptions.test.ts
@@ -241,6 +241,69 @@ describe('Subscriptions', () => {
     });
   });
 
+  it('does not pin subscriptions during graceful reload', async () => {
+    let changeSchema = false;
+    const subscribed = createDeferred<void>();
+
+    await using serve = createGatewayTester({
+      pollingInterval: 500,
+      gracefulSchemaReload: { drainTimeout: 30_000 },
+      subgraphs: () => {
+        if (changeSchema) {
+          return [
+            {
+              name: 'upstream',
+              schema: {
+                typeDefs: /* GraphQL */ `
+                  type Query {
+                    foo: String
+                  }
+                `,
+                resolvers: { Query: { foo: () => 'bar2' } },
+              },
+            },
+          ];
+        }
+        return [{ name: 'upstream', schema: upstreamSchema }];
+      },
+    });
+
+    const sse = createSSEClient({
+      url: 'http://mesh/graphql',
+      fetchFn: serve.fetch,
+      on: { connected: () => subscribed.resolve() },
+    });
+    const sub = sse.iterate({
+      query: /* GraphQL */ `
+        subscription {
+          neverEmits
+        }
+      `,
+    });
+    const msgs: unknown[] = [];
+    const consumed = (async () => {
+      for await (const msg of sub) {
+        msgs.push(msg);
+      }
+    })();
+    await subscribed.promise;
+
+    changeSchema = true;
+    globalThis.setTimeout(() => {
+      void serve.execute({ query: `{ foo }` });
+    }, 1000);
+    await consumed;
+
+    expect(msgs[msgs.length - 1]).toMatchObject({
+      errors: [
+        {
+          extensions: { code: 'SCHEMA_RELOAD' },
+          message: 'operation has been aborted due to a schema reload',
+        },
+      ],
+    });
+  });
+
   it('releases the generation pin of an aborted operation so the superseded generation still drains', async () => {
     let changeSchema = false;
     const blockingEntered = createDeferred<void>();

--- a/packages/runtime/tests/subscriptions.test.ts
+++ b/packages/runtime/tests/subscriptions.test.ts
@@ -1,5 +1,5 @@
 import { createGatewayTester } from '@graphql-hive/gateway-testing';
-import { type MaybePromise } from '@graphql-tools/utils';
+import { createDeferred, type MaybePromise } from '@graphql-tools/utils';
 import { DisposableSymbols } from '@whatwg-node/disposablestack';
 import { createClient as createSSEClient } from 'graphql-sse';
 import { createSchema, Repeater } from 'graphql-yoga';
@@ -238,4 +238,148 @@ describe('Subscriptions', () => {
       ],
     });
   });
+
+  it('releases the generation pin of an aborted operation so the superseded generation still drains', async () => {
+    let changeSchema = false;
+    const blockingEntered = createDeferred<void>();
+    const releaseBlocking = createDeferred<string>();
+    const subscribed = createDeferred<void>();
+
+    await using serve = createGatewayTester({
+      pollingInterval: 500,
+      executionCancellation: true,
+      // Long drain: if the aborted (rejected) operation leaked its pin, the
+      // superseded generation — and the subscription still running on it —
+      // would be held alive this long.
+      gracefulSchemaReload: { drainTimeout: 30_000 },
+      subgraphs: () => {
+        if (changeSchema) {
+          return [
+            {
+              name: 'upstream',
+              schema: {
+                typeDefs: /* GraphQL */ `
+                  type Query {
+                    foo: String
+                  }
+                `,
+                resolvers: {
+                  Query: {
+                    foo: () => 'bar',
+                  },
+                },
+              },
+            },
+          ];
+        }
+        return [
+          {
+            name: 'upstream',
+            schema: {
+              typeDefs: /* GraphQL */ `
+                type Query {
+                  foo: String
+                  blocking: String
+                }
+                type Subscription {
+                  neverEmits: String
+                }
+              `,
+              resolvers: {
+                Query: {
+                  foo: () => 'bar',
+                  blocking: () => {
+                    blockingEntered.resolve();
+                    return releaseBlocking.promise;
+                  },
+                },
+                Subscription: {
+                  neverEmits: {
+                    subscribe: () =>
+                      new Repeater((_push, stop) => {
+                        leftovers.push(stop);
+                      }),
+                  },
+                },
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    const sse = createSSEClient({
+      url: 'http://mesh/graphql',
+      fetchFn: serve.fetch,
+      on: {
+        connected() {
+          subscribed.resolve();
+        },
+      },
+    });
+
+    const sub = sse.iterate({
+      query: /* GraphQL */ `
+        subscription {
+          neverEmits
+        }
+      `,
+    });
+
+    const msgs: unknown[] = [];
+    const consumed = (async () => {
+      for await (const msg of sub) {
+        msgs.push(msg);
+      }
+    })();
+    await subscribed.promise;
+
+    // Pin the current generation with an operation blocked inside the
+    // upstream, then abort it: the execution rejects (execution
+    // cancellation), and the pin must be released.
+    const ctrl = new AbortController();
+    const aborted = serve
+      .fetch('http://mesh/graphql', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ query: '{ blocking }' }),
+        signal: ctrl.signal,
+      })
+      .then(
+        (res) => res.text(),
+        () => 'aborted',
+      );
+    await blockingEntered.promise;
+    ctrl.abort();
+    await aborted;
+
+    // Reload. Nothing is legitimately in flight on the previous generation
+    // anymore, so it must be disposed right away — ending the subscription
+    // with SCHEMA_RELOAD well before the 30s drain timeout.
+    changeSchema = true;
+    globalThis.setTimeout(() => {
+      void serve.execute({
+        query: /* GraphQL */ `
+          query {
+            foo
+          }
+        `,
+      });
+    }, 1000);
+    await consumed;
+
+    expect(msgs[msgs.length - 1]).toMatchObject({
+      errors: [
+        {
+          extensions: {
+            code: 'SCHEMA_RELOAD',
+          },
+          message: 'operation has been aborted due to a schema reload',
+        },
+      ],
+    });
+
+    // Unblock the upstream resolver so everything can settle.
+    releaseBlocking.resolve('late');
+  }, 20_000);
 });

--- a/packages/runtime/tests/subscriptions.test.ts
+++ b/packages/runtime/tests/subscriptions.test.ts
@@ -167,8 +167,10 @@ describe('Subscriptions', () => {
     await using serve = createGatewayTester({
       pollingInterval: 500,
       // Graceful reload keeps in-flight queries/mutations alive across a reload,
-      // but long-lived subscriptions are never overlapped — they must still end
-      // so the client reconnects against the new schema.
+      // but long-lived subscriptions are never pinned — with nothing draining
+      // here, the superseded generation is disposed at reload and the
+      // subscription must end right away so the client reconnects against the
+      // new schema.
       gracefulSchemaReload: { drainTimeout: 10_000 },
       subgraphs: () => {
         if (changeSchema) {
@@ -381,5 +383,151 @@ describe('Subscriptions', () => {
 
     // Unblock the upstream resolver so everything can settle.
     releaseBlocking.resolve('late');
+  }, 20_000);
+
+  it('keeps a subscription on a draining generation until the last pinned operation finishes', async () => {
+    let changeSchema = false;
+    const blockingEntered = createDeferred<void>();
+    const releaseBlocking = createDeferred<string>();
+    const subscribed = createDeferred<void>();
+
+    await using serve = createGatewayTester({
+      pollingInterval: 500,
+      gracefulSchemaReload: { drainTimeout: 30_000 },
+      subgraphs: () => {
+        if (changeSchema) {
+          return [
+            {
+              name: 'upstream',
+              schema: {
+                typeDefs: /* GraphQL */ `
+                  type Query {
+                    foo: String
+                  }
+                `,
+                resolvers: {
+                  Query: {
+                    foo: () => 'bar2',
+                  },
+                },
+              },
+            },
+          ];
+        }
+        return [
+          {
+            name: 'upstream',
+            schema: {
+              typeDefs: /* GraphQL */ `
+                type Query {
+                  foo: String
+                  blocking: String
+                }
+                type Subscription {
+                  neverEmits: String
+                }
+              `,
+              resolvers: {
+                Query: {
+                  foo: () => 'bar',
+                  blocking: () => {
+                    blockingEntered.resolve();
+                    return releaseBlocking.promise;
+                  },
+                },
+                Subscription: {
+                  neverEmits: {
+                    subscribe: () =>
+                      new Repeater((_push, stop) => {
+                        leftovers.push(stop);
+                      }),
+                  },
+                },
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    const sse = createSSEClient({
+      url: 'http://mesh/graphql',
+      fetchFn: serve.fetch,
+      on: {
+        connected() {
+          subscribed.resolve();
+        },
+      },
+    });
+
+    const sub = sse.iterate({
+      query: /* GraphQL */ `
+        subscription {
+          neverEmits
+        }
+      `,
+    });
+
+    const msgs: unknown[] = [];
+    let subEnded = false;
+    const consumed = (async () => {
+      for await (const msg of sub) {
+        msgs.push(msg);
+      }
+      subEnded = true;
+    })();
+    await subscribed.promise;
+
+    // Pin the current generation with an operation blocked inside the
+    // upstream, then reload: the generation drains instead of being
+    // disposed.
+    const pinned = serve.execute({
+      query: /* GraphQL */ `
+        query {
+          blocking
+        }
+      `,
+    });
+    await blockingEntered.promise;
+
+    changeSchema = true;
+    // Drive the lazy poller until the gateway serves the new generation.
+    for (let i = 0; i < 40; i++) {
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 250));
+      const result = await serve.execute({
+        query: /* GraphQL */ `
+          query {
+            foo
+          }
+        `,
+      });
+      if (!(Symbol.asyncIterator in result) && result.data?.foo === 'bar2') {
+        break;
+      }
+    }
+
+    // The old generation is draining (one pinned operation in flight), so
+    // the subscription must NOT have been terminated at reload time...
+    expect(subEnded).toBe(false);
+
+    // ...but disposing the drained generation — right after its last pinned
+    // operation completes — must end it with SCHEMA_RELOAD.
+    releaseBlocking.resolve('done');
+    const pinnedResult = await pinned;
+    if (!(Symbol.asyncIterator in pinnedResult)) {
+      expect(pinnedResult.data?.blocking).toBe('done');
+    }
+    await consumed;
+
+    expect(msgs[msgs.length - 1]).toMatchObject({
+      errors: [
+        {
+          extensions: {
+            code: 'SCHEMA_RELOAD',
+          },
+          message: 'operation has been aborted due to a schema reload',
+        },
+      ],
+    });
   }, 20_000);
 });


### PR DESCRIPTION
Closes #2448

On reload the previous generation (executor + subgraph transports) was disposed immediately, aborting any in-flight operation on it with a SCHEMA_RELOAD/503 error. Queries were retried by useRetryOnSchemaReload; mutations were not, so a mutation in flight at a reload failed.

Add opt-in graceful reload ("generation overlap"): keep a superseded generation alive and route only new requests to the new one. Operations are reference-counted per generation for their whole lifetime (across all subgraph hops) via onExecute/onExecuteDone, so in-flight queries and mutations finish on the schema they were admitted on. A superseded generation is disposed once idle, or force-disposed after a configurable drain timeout; the number of concurrently live generations is capped. Subscriptions are not overlapped and still end on reload to reconnect. On shutdown every live generation is disposed.

Configured via gracefulSchemaReload: { drainTimeout, maxConcurrentGenerations }; disabled by default (previous immediate-abort behavior preserved).