### PR TITLE
fix(batch-execute): densify sparse batch results for DataLoader

### DIFF
--- a/.changeset/batch-execute-sparse-results.md
+++ b/.changeset/batch-execute-sparse-results.md
@@ -1,0 +1,9 @@
+---
+'@graphql-tools/batch-execute': patch
+---
+
+Fix `DataLoader must be constructed with a function which accepts Array<key> and returns Promise<Array<value>>, but the function did not return a Promise of an Array` thrown when a batched subgraph response omits some of the merged sub-requests.
+
+`splitResult` builds `new Array(numResults)` and only assigns the indices present in the merged response's `data`/`errors`. When a subgraph answers only some of the batched operations — returning neither a data key nor a path-scoped error for the rest — those slots stay holes. A hole at the trailing slot fails DataLoader's `isArrayLike` check (which requires `hasOwnProperty(length - 1)`) even though `Array.isArray` is `true`, so the batching executor's DataLoader throws. The result is now densified to `numResults`, filling any missing slot with an empty `ExecutionResult`.
+
+This mirrors the sibling fix for `@graphql-tools/batch-delegate` in #2393.

--- a/packages/batch-execute/src/splitResult.ts
+++ b/packages/batch-execute/src/splitResult.ts
@@ -74,5 +74,18 @@ export function splitResult(
     }
   }
 
+  // A batched response can omit some sub-requests entirely: if the merged result
+  // carries neither a data key nor a path-scoped error for an index, that slot is
+  // never assigned and stays a hole. A hole at the final slot makes the array fail
+  // DataLoader's `isArrayLike` check (which requires `hasOwnProperty(length - 1)`),
+  // even though `Array.isArray` is true — so `getBatchingExecutor`'s DataLoader
+  // throws "did not return a Promise of an Array". Densify to `numResults` with an
+  // empty result so every caller gets a well-formed `ExecutionResult`.
+  for (let i = 0; i < numResults; i++) {
+    if (splitResults[i] == null) {
+      splitResults[i] = { data: {} };
+    }
+  }
+
   return splitResults;
 }

--- a/packages/batch-execute/tests/sparseResults.test.ts
+++ b/packages/batch-execute/tests/sparseResults.test.ts
@@ -1,0 +1,73 @@
+import { createBatchingExecutor } from '@graphql-tools/batch-execute';
+import { normalizedExecutor } from '@graphql-tools/executor';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { ExecutionResult, Executor } from '@graphql-tools/utils';
+import { parse } from 'graphql';
+import { describe, expect, it } from 'vitest';
+
+// Regression test for DataLoader throwing
+// "did not return a Promise of an Array" when a batched response omits some of
+// the merged sub-requests.
+//
+// `splitResult` builds `new Array(numResults)` and only fills the indices that
+// appear in the merged response's `data`/`errors`. A real subgraph can answer
+// only some of the batched operations (returning neither a data key nor a
+// path-scoped error for the others), leaving holes. If the *last* index is a
+// hole, the array has a hole at `length - 1`: it passes `Array.isArray` but
+// fails DataLoader's stricter `isArrayLike` check, so the batching executor's
+// DataLoader throws.
+describe('sparse batch results', () => {
+  const schema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        field1: String
+        field2: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        field1: () => '1',
+        field2: () => '2',
+      },
+    },
+  });
+
+  // Executor that drops the highest-indexed merged sub-request's keys from the
+  // response, simulating a subgraph that only answers some of the batched
+  // operations. This leaves a hole at the trailing slot of `splitResult`.
+  const lossyExecutor: Executor = async ({ document, variables }) => {
+    const result = (await normalizedExecutor({
+      schema,
+      document,
+      variableValues: variables as Record<string, unknown>,
+    })) as ExecutionResult;
+
+    if (result.data) {
+      const indices = Object.keys(result.data)
+        .map((key) => Number(/^_v(\d+)_/.exec(key)?.[1]))
+        .filter((n) => !Number.isNaN(n));
+      const maxIndex = Math.max(...indices);
+      for (const key of Object.keys(result.data)) {
+        if (new RegExp(`^_v${maxIndex}_`).test(key)) {
+          delete result.data[key];
+        }
+      }
+    }
+
+    return result;
+  };
+
+  it('does not throw when the trailing batched request is omitted', async () => {
+    const batchExec = createBatchingExecutor(lossyExecutor);
+
+    const [first, second] = (await Promise.all([
+      batchExec({ document: parse('{ field1 }') }),
+      batchExec({ document: parse('{ field2 }') }),
+    ])) as ExecutionResult[];
+
+    // The answered slice resolves normally; the omitted (trailing) slice yields
+    // an empty result instead of throwing a DataLoader error.
+    expect(first?.data).toEqual({ field1: '1' });
+    expect(second?.data ?? {}).toEqual({});
+  });
+});

--- a/packages/batch-execute/tests/sparseResults.test.ts
+++ b/packages/batch-execute/tests/sparseResults.test.ts
@@ -35,11 +35,10 @@ describe('sparse batch results', () => {
   // Executor that drops the highest-indexed merged sub-request's keys from the
   // response, simulating a subgraph that only answers some of the batched
   // operations. This leaves a hole at the trailing slot of `splitResult`.
-  const lossyExecutor: Executor = async ({ document, variables }) => {
+  const lossyExecutor: Executor = async ({ document }) => {
     const result = (await normalizedExecutor({
       schema,
       document,
-      variableValues: variables as Record<string, unknown>,
     })) as ExecutionResult;
 
     if (result.data) {


### PR DESCRIPTION
## Summary

`batchExecute`'s DataLoader can throw

```
DataLoader must be constructed with a function which accepts Array<key> and returns Promise<Array<value>>, but the function did not return a Promise of an Array: ,,,[object Object],,.
```

when a batched subgraph response omits some of the merged sub-requests.

## Root cause

`splitResult` builds `new Array(numResults)` and only assigns the indices that appear in the merged response's `data`/`errors`. A subgraph can answer only some of the batched operations — returning neither a data key nor a path-scoped error for the rest — which leaves those slots as **holes**. A hole at the final slot makes the array fail DataLoader's `isArrayLike` check (which requires `hasOwnProperty(length - 1)`) even though `Array.isArray` is `true`, so `getBatchingExecutor`'s DataLoader rejects the whole batch.

## Fix

Densify `splitResults` to `numResults` before returning, filling any missing slot with an empty `ExecutionResult` (`{ data: {} }`). Each caller then receives a well-formed result and the omitted ones resolve to empty data instead of throwing.

This mirrors the sibling fix for `@graphql-tools/batch-delegate` in #2393.

## Test

`packages/batch-execute/tests/sparseResults.test.ts` drives two batched requests through an executor that drops the trailing sub-request from the response. Without the change it fails with the exact production error above; with the change both callers resolve.

## Observed in production

This fires on real traffic when a subgraph returns partial results for a query-batched request — an entire batch of top-level fields errors together. `batch-delegate` was already fixed by #2393; `batch-execute` has the same sparse-array shape and was missed.
