### PR TITLE
fix(router-runtime): BatchFetch drops $representations for empty entity alias, failing sibling fetches

### DIFF
--- a/.changeset/batchfetch-empty-representations.md
+++ b/.changeset/batchfetch-empty-representations.md
@@ -1,0 +1,9 @@
+---
+"@graphql-hive/router-runtime": patch
+---
+
+Fix `BatchFetch` execution dropping the `$representations` variable for an entity alias that resolved to zero representations.
+
+When a `BatchFetch` plan node groups several entity fetches for the same subgraph into one aliased `_entities` request and one alias resolves to an empty representation list (e.g. a nullable federated field that is `null`), `buildBatchFetchVariables` omitted that alias's variable. The batched document still declares it as a required `[_Any!]!`, so the operation declared a variable it never provided and the subgraph rejected the whole request — failing the sibling aliases that *did* have representations.
+
+Empty aliases now send `[]`, keeping the operation valid (`_entities(representations: [])` simply returns `[]`).

--- a/packages/router-runtime/src/executor.ts
+++ b/packages/router-runtime/src/executor.ts
@@ -631,9 +631,13 @@ function buildBatchFetchVariables(
     variableName,
     state,
   ] of batchContext.representationsByVariableName.entries()) {
-    if (!state.representations.length) {
-      continue;
-    }
+    // Always attach the representations variable, even when it resolved to an
+    // empty list. The batched `_entities` document declares every alias's
+    // `$representations` as a required `[_Any!]!`, so skipping an empty alias
+    // sends an operation that declares a variable it never provides — which the
+    // subgraph rejects wholesale, failing the sibling aliases that *did* have
+    // representations. Sending `[]` keeps the operation valid
+    // (`_entities(representations: [])` simply returns `[]`).
     const targetVariables =
       variablesForFetch ?? (Object.create(null) as Record<string, any>);
     if (!variablesForFetch) {

--- a/packages/router-runtime/tests/batch-fetch.spec.ts
+++ b/packages/router-runtime/tests/batch-fetch.spec.ts
@@ -1,0 +1,137 @@
+import { createGatewayTester } from '@graphql-hive/gateway-testing';
+import type { ExecutionResult } from '@graphql-tools/utils';
+import { expect, it } from 'vitest';
+import { unifiedGraphHandler, useQueryPlan } from '../src/index';
+
+// Regression test for the `BatchFetch` empty-representations bug.
+//
+// The planner groups entity fetches for the *same* subgraph into a single
+// `BatchFetch` node. Each grouped field becomes its own aliased `_entities`
+// call with its own required `$representations: [_Any!]!` variable, e.g.:
+//
+//   query($__batch_reps_0: [_Any!]!, $__batch_reps_1: [_Any!]!) {
+//     _e0: _entities(representations: $__batch_reps_0) { ... on User { name } }
+//     _e1: _entities(representations: $__batch_reps_1) { ... on Cover { url } }
+//   }
+//
+// When one grouped field is a *nullable* entity reference that resolved to
+// `null` (here `cover`), its representations list is empty.
+// `buildBatchFetchVariables` used to skip attaching that variable entirely —
+// while the operation still declared it as required. The subgraph then rejected
+// the whole operation ("Variable $__batch_reps_1 ... was not provided"), so the
+// sibling alias that *did* have representations (`watchers`) came back `null`.
+//
+// Note the two grouped fields must be *different* entity types (`Cover` vs
+// `User`); same-typed fields get merged into a single alias by the planner and
+// never surface the empty-alias case.
+
+it('hydrates sibling entities when a grouped BatchFetch alias has empty representations', async () => {
+  await using gw = createGatewayTester({
+    unifiedGraphHandler,
+    plugins: () => [useQueryPlan({ expose: true })],
+    subgraphs: [
+      {
+        name: 'tickets',
+        schema: {
+          typeDefs: /* GraphQL */ `
+            type Query {
+              ticket: Ticket
+            }
+
+            type Ticket @key(fields: "id") {
+              id: ID!
+              cover: Cover
+              watchers: [User!]!
+            }
+
+            type Cover @key(fields: "id") {
+              id: ID!
+            }
+
+            type User @key(fields: "id") {
+              id: ID!
+            }
+          `,
+          resolvers: {
+            Query: {
+              ticket: () => ({
+                id: 't1',
+                // nullable reference resolves to null -> empty representations alias
+                cover: null,
+                // required list still needs hydration from the `assets` subgraph
+                watchers: [{ id: 'u1' }, { id: 'u2' }],
+              }),
+            },
+          },
+        },
+      },
+      {
+        name: 'assets',
+        schema: {
+          typeDefs: /* GraphQL */ `
+            type Cover @key(fields: "id") {
+              id: ID!
+              url: String!
+            }
+
+            type User @key(fields: "id") {
+              id: ID!
+              name: String!
+            }
+          `,
+          resolvers: {
+            Cover: {
+              __resolveReference: (ref: { id: string }) => ({
+                id: ref.id,
+                url: `cover-${ref.id}`,
+              }),
+            },
+            User: {
+              __resolveReference: (ref: { id: string }) => ({
+                id: ref.id,
+                name: `user-${ref.id}`,
+              }),
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  const result = (await gw.execute({
+    query: /* GraphQL */ `
+      {
+        ticket {
+          id
+          cover {
+            url
+          }
+          watchers {
+            name
+          }
+        }
+      }
+    `,
+  })) as ExecutionResult;
+
+  // Guard: the plan must actually group both `assets` fetches into one
+  // BatchFetch with two aliased `_entities` variables — otherwise this test
+  // would silently stop exercising the empty-alias path.
+  const plan = JSON.stringify(result.extensions?.queryPlan);
+  expect(plan).toContain('"kind":"BatchFetch"');
+  expect(plan).toContain('__batch_reps_0');
+  expect(plan).toContain('__batch_reps_1');
+
+  // Pre-fix, the empty `cover` alias made the subgraph reject the whole batch
+  // ("Variable $__batch_reps_1 ... was not provided") and `watchers` came back
+  // `[null, null]`. The required watchers must hydrate and the null cover must
+  // stay null without erroring.
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    ticket: {
+      id: 't1',
+      cover: null,
+      watchers: [{ name: 'user-u1' }, { name: 'user-u2' }],
+    },
+  });
+});


### PR DESCRIPTION
## Problem

When the query planner emits a `BatchFetch` node that groups multiple entity fetches for the **same subgraph** into one aliased `_entities` request, and **one alias resolves to zero representations** (e.g. a nullable federated reference that is `null` for the given parent), the batched request breaks.

`buildBatchFetchVariables` (`packages/router-runtime/src/executor.ts`) skips attaching the `$representations` variable for the empty alias, but the generated `_entities` document still **declares** it as a required `[_Any!]!`. The outgoing operation therefore declares a variable it never provides, so the subgraph rejects the **entire** operation (`Variable "$..." of required type "[_Any!]!" was not provided`) — which also fails the sibling aliases that *did* have representations. Every entity in that batch comes back `null`.

## Reproduction

Two entity types resolved by the **same** subgraph, requested in one operation, where one reference is nullable:

```graphql
type Parent {
  optionalChild: Child          # nullable, resolved by subgraph B
  requiredChildren: [Child!]!   # resolved by subgraph B
}
```

Query both `optionalChild { ... }` and `requiredChildren { ... }` for a `Parent` whose `optionalChild` is `null`. The planner batches both `Child` fetches into a single `_entities` call. At runtime the `optionalChild` alias has zero representations, so its `$representations_*` variable is not sent — but the document still declares it — and subgraph B rejects the whole request, so `requiredChildren` resolve to `null` too.

## Fix

Always attach the representations variable, using `[]` when it's empty. `_entities(representations: [])` is valid and returns `[]`, so the sibling aliases hydrate normally.

```diff
   for (const [variableName, state] of batchContext.representationsByVariableName.entries()) {
-    if (!state.representations.length) {
-      continue;
-    }
     const targetVariables = variablesForFetch ?? (Object.create(null) as Record<string, any>);
     if (!variablesForFetch) variablesForFetch = targetVariables;
     targetVariables[variableName] = state.representations;
   }
```

Reproduced through `@graphql-hive/router-runtime@1.4.14`.

## Notes

- A changeset is included (`patch` bump for `@graphql-hive/router-runtime`).
- Happy to add a regression test — a pointer to the preferred harness for exercising `BatchFetch` execution against mock subgraphs would help me place it correctly.
