### PR TITLE
NATS with JetStream, EDFS with Cursor example, nested entity resolution fixes in stitching

### DIFF
--- a/.changeset/@graphql-hive_gateway-2473-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-hive_gateway-2473-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-hive_gateway-runtime-2473-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-runtime-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-hive_gateway-runtime-2473-dependencies.md
+++ b/.changeset/@graphql-hive_gateway-runtime-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/gateway-runtime': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-hive_plugin-deduplicate-request-2473-dependencies.md
+++ b/.changeset/@graphql-hive_plugin-deduplicate-request-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-hive_plugin-deduplicate-request-2473-dependencies.md
+++ b/.changeset/@graphql-hive_plugin-deduplicate-request-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/plugin-deduplicate-request': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-hive_plugin-opentelemetry-2473-dependencies.md
+++ b/.changeset/@graphql-hive_plugin-opentelemetry-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/plugin-opentelemetry': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-hive_plugin-opentelemetry-2473-dependencies.md
+++ b/.changeset/@graphql-hive_plugin-opentelemetry-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-hive_pubsub-2473-dependencies.md
+++ b/.changeset/@graphql-hive_pubsub-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/pubsub': patch
+---
+
+dependencies updates: 
+
+- Added dependency [`@nats-io/jetstream@^3` ↗︎](https://www.npmjs.com/package/@nats-io/jetstream/v/3.0.0) (to `peerDependencies`)

--- a/.changeset/@graphql-hive_router-runtime-2473-dependencies.md
+++ b/.changeset/@graphql-hive_router-runtime-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-hive/router-runtime': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-hive_router-runtime-2473-dependencies.md
+++ b/.changeset/@graphql-hive_router-runtime-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_fusion-runtime-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_fusion-runtime-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_fusion-runtime-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_fusion-runtime-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/fusion-runtime': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_hmac-upstream-signature-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_hmac-upstream-signature-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_hmac-upstream-signature-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_hmac-upstream-signature-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/hmac-upstream-signature': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_plugin-jwt-auth-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_plugin-jwt-auth-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_plugin-jwt-auth-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_plugin-jwt-auth-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/plugin-jwt-auth': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_plugin-prometheus-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_plugin-prometheus-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_plugin-prometheus-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_plugin-prometheus-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/plugin-prometheus': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_transport-http-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_transport-http-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/transport-http': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_transport-http-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_transport-http-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_transport-http-callback-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_transport-http-callback-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/transport-http-callback': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_transport-http-callback-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_transport-http-callback-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_transport-ws-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_transport-ws-2473-dependencies.md
@@ -4,4 +4,4 @@
 
 dependencies updates: 
 
-- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)
+- Updated dependency [`@graphql-mesh/utils@^0.104.38` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/@graphql-mesh_transport-ws-2473-dependencies.md
+++ b/.changeset/@graphql-mesh_transport-ws-2473-dependencies.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/transport-ws': patch
+---
+
+dependencies updates: 
+
+- Updated dependency [`@graphql-mesh/utils@0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.104.38) (from `^0.104.36`, in `dependencies`)

--- a/.changeset/dry-dolphins-decide.md
+++ b/.changeset/dry-dolphins-decide.md
@@ -2,4 +2,15 @@
 '@graphql-tools/delegate': minor
 ---
 
-Introduce `resolveMergedTypeReference` for resolving plain objects through type merging
+Introduce `resolveMergedTypeReference`, a helper that resolves plain objects returned by local resolvers through type merging
+
+When a resolver returns an object containing only the key fields of a merged type, the helper delegates just the missing requested fields to the owning subschema and returns a regular external object, so nested fields keep merging as usual. Fields the object already carries are never fetched again, and objects that already satisfy the request (or satisfy no merge key) are returned untouched.
+
+```ts
+// local resolver returns only the key
+const payload = { id: '1' };
+
+// client asks for { name surname } -> only `name` and `surname` are
+// delegated to the subschema owning `Person`, `id` is kept as-is
+resolveMergedTypeReference(payload, context, info);
+```

--- a/.changeset/dry-dolphins-decide.md
+++ b/.changeset/dry-dolphins-decide.md
@@ -3,6 +3,6 @@
 '@graphql-tools/stitch': minor
 ---
 
-Automatically resolve plain merged-type references returned by local stitching resolvers.
+Automatically resolve plain merged-type references returned by local stitching resolvers
 
 Local fields introduced through `typeDefs` or `resolvers` are wrapped by `stitchSchemas`. When they return a partial merged type containing a usable key, stitching performs one initial delegation with type merging enabled. The existing stitching planner then handles computed fields, `@requires` dependencies, batching, nested entities, and fields owned by other subschemas.

--- a/.changeset/dry-dolphins-decide.md
+++ b/.changeset/dry-dolphins-decide.md
@@ -1,16 +1,8 @@
 ---
 '@graphql-tools/delegate': minor
+'@graphql-tools/stitch': minor
 ---
 
-Introduce `resolveMergedTypeReference`, a helper that resolves plain objects returned by local resolvers through type merging
+Automatically resolve plain merged-type references returned by local stitching resolvers.
 
-When a resolver returns an object containing only the key fields of a merged type, the helper delegates just the missing requested fields through the stitching planner. Standard type merging remains enabled, so computed fields, `@requires` dependencies, batching, and fields owned by other subschemas are resolved by stitching as usual. Fields the object already carries are never fetched again, and objects that already satisfy the request (or satisfy no merge key) are returned untouched.
-
-```ts
-// local resolver returns only the key
-const payload = { id: '1' };
-
-// client asks for { name surname } -> stitching resolves the missing fields
-// across the relevant subschemas while `id` is kept as-is
-resolveMergedTypeReference(payload, context, info);
-```
+Local fields introduced through `typeDefs` or `resolvers` are wrapped by `stitchSchemas`. When they return a partial merged type containing a usable key, stitching performs one initial delegation with type merging enabled. The existing stitching planner then handles computed fields, `@requires` dependencies, batching, nested entities, and fields owned by other subschemas.

--- a/.changeset/dry-dolphins-decide.md
+++ b/.changeset/dry-dolphins-decide.md
@@ -4,13 +4,13 @@
 
 Introduce `resolveMergedTypeReference`, a helper that resolves plain objects returned by local resolvers through type merging
 
-When a resolver returns an object containing only the key fields of a merged type, the helper delegates just the missing requested fields to the owning subschema and returns a regular external object, so nested fields keep merging as usual. Fields the object already carries are never fetched again, and objects that already satisfy the request (or satisfy no merge key) are returned untouched.
+When a resolver returns an object containing only the key fields of a merged type, the helper delegates just the missing requested fields through the stitching planner. Standard type merging remains enabled, so computed fields, `@requires` dependencies, batching, and fields owned by other subschemas are resolved by stitching as usual. Fields the object already carries are never fetched again, and objects that already satisfy the request (or satisfy no merge key) are returned untouched.
 
 ```ts
 // local resolver returns only the key
 const payload = { id: '1' };
 
-// client asks for { name surname } -> only `name` and `surname` are
-// delegated to the subschema owning `Person`, `id` is kept as-is
+// client asks for { name surname } -> stitching resolves the missing fields
+// across the relevant subschemas while `id` is kept as-is
 resolveMergedTypeReference(payload, context, info);
 ```

--- a/.changeset/dry-dolphins-decide.md
+++ b/.changeset/dry-dolphins-decide.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/delegate': minor
+---
+
+Introduce `resolveMergedTypeReference` for resolving plain objects through type merging

--- a/.changeset/popular-readers-repair.md
+++ b/.changeset/popular-readers-repair.md
@@ -1,5 +1,6 @@
 ---
 '@graphql-tools/stitch': patch
+'@graphql-mesh/fusion-runtime': patch
 ---
 
 Fields that are not provided by any subschema (added through `typeDefs` or `resolvers`) can now return partial objects of merged types; the missing fields are resolved from the owning subschema automatically
@@ -24,4 +25,4 @@ const resolvers = {
 };
 ```
 
-Before, `person` had to be resolved manually even though the stitched schema knows `Person` and its keys. Now the key is enough: `{ person { name } }` fetches `name` from the subschema owning `Person`, while local data (`cursor`) and local field resolvers on `Person` keep working as before.
+Before, `person` had to be resolved manually even though the stitched schema knows `Person` and its keys. Now the key is enough: `{ person { name } }` runs through the standard stitching planner, while local data (`cursor`) and local field resolvers on `Person` keep working as before. Computed fields, `@requires` dependencies, batching, and fields from other subschemas use the same type-merging flow as regular delegated results.

--- a/.changeset/popular-readers-repair.md
+++ b/.changeset/popular-readers-repair.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/stitch': patch
+---
+
+Delegate missing fields from plain object resolvers to owning schemas

--- a/.changeset/popular-readers-repair.md
+++ b/.changeset/popular-readers-repair.md
@@ -2,4 +2,26 @@
 '@graphql-tools/stitch': patch
 ---
 
-Delegate missing fields from plain object resolvers to owning schemas
+Fields that are not provided by any subschema (added through `typeDefs` or `resolvers`) can now return partial objects of merged types; the missing fields are resolved from the owning subschema automatically
+
+```graphql
+type Query {
+  personCreated: PersonCreated
+}
+
+type PersonCreated {
+  person: Person # merged type, owned by a subschema
+  cursor: String
+}
+```
+
+```ts
+const resolvers = {
+  Query: {
+    // only the key of `Person` is provided locally
+    personCreated: () => ({ person: { id: '1' }, cursor: 'c1' }),
+  },
+};
+```
+
+Before, `person` had to be resolved manually even though the stitched schema knows `Person` and its keys. Now the key is enough: `{ person { name } }` fetches `name` from the subschema owning `Person`, while local data (`cursor`) and local field resolvers on `Person` keep working as before.

--- a/.changeset/purple-cows-fetch.md
+++ b/.changeset/purple-cows-fetch.md
@@ -1,0 +1,36 @@
+---
+'@graphql-hive/pubsub': minor
+---
+
+Add `NATSJetStreamPubSub`, a NATS JetStream transport with optional cursor-based replay
+
+Subscribe like any other Hive PubSub, or pass subscribe options to receive each message with an opaque `cursor`. Pass that cursor on a later subscription to resume right after it and recover events missed while disconnected. Without a cursor, only messages published after the subscription starts are delivered.
+
+The JetStream stream is not created or configured by this transport; it must already exist and capture the subjects used by the pubsub (`${subjectPrefix}:${topic}`).
+
+```ts
+import { connect } from '@nats-io/transport-node';
+import { NATSJetStreamPubSub } from '@graphql-hive/pubsub/nats-jetstream';
+
+const nats = await connect({ servers: 'localhost:4222' });
+const pubsub = new NATSJetStreamPubSub(nats, {
+  subjectPrefix: 'my-service',
+  stream: 'EVENTS',
+});
+
+// live-only: no cursor, only messages published after subscribe starts
+const live = pubsub.subscribe('personCreated', { cursor: undefined });
+const first = await live.next();
+// first.value => { data: { id: '1' }, cursor: '...' }
+await live.return?.();
+
+// published while disconnected is retained by JetStream
+await pubsub.publish('personCreated', { id: '2' });
+
+// resume right after the last seen cursor — gets { id: '2' }, not a repeat of '1'
+for await (const { data, cursor } of pubsub.subscribe('personCreated', {
+  cursor: first.value.cursor,
+})) {
+  // persist `cursor` so the next reconnect can resume again
+}
+```

--- a/.changeset/strange-jokes-occur.md
+++ b/.changeset/strange-jokes-occur.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+Fall back to the field name for plain resolver data merged into external objects, which is keyed by literal field name

--- a/.changeset/strange-jokes-occur.md
+++ b/.changeset/strange-jokes-occur.md
@@ -2,4 +2,21 @@
 '@graphql-tools/delegate': patch
 ---
 
-Fall back to the field name for plain resolver data merged into external objects, which is keyed by literal field name
+`defaultMergedResolver` now falls back to the literal field name when an external object does not have the requested response key
+
+Plain resolver data merged into an external object is keyed by field name, so an aliased request used to resolve to `null` even though the value was there:
+
+```graphql
+{
+  person {
+    fullName: name
+  }
+}
+```
+
+```ts
+// merged object carries resolver data by field name
+{ id: '1', name: 'Local' }
+```
+
+Previously `fullName` was `null` because only the alias was looked up. Now it resolves to `'Local'` by field name, matching plain graphql-js behavior. When the response key is present (e.g. the field came from a subschema), it is still preferred.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -47,7 +47,8 @@ group "e2e" {
     "gateway_e2e_edfs-subgraph-defs",
     "gateway_e2e_edfs-gateway-defs",
     "gateway_e2e_edfs-mesh-defs-with-entity-resolution",
-    "gateway_e2e_hive-tracing-circuit-breaker"
+    "gateway_e2e_hive-tracing-circuit-breaker",
+    "gateway_e2e_edfs-additional-resolver-with-cursor"
   ]
 }
 
@@ -59,7 +60,8 @@ group "e2e_bun" {
     "gateway_e2e_distributed-subscriptions-webhooks_bun",
     "gateway_e2e_edfs-subgraph-defs_bun",
     "gateway_e2e_edfs-gateway-defs_bun",
-    "gateway_e2e_edfs-mesh-defs-with-entity-resolution_bun"
+    "gateway_e2e_edfs-mesh-defs-with-entity-resolution_bun",
+    "gateway_e2e_edfs-additional-resolver-with-cursor_bun"
   ]
 }
 
@@ -199,5 +201,22 @@ target "gateway_e2e_hive-tracing-circuit-breaker" {
   tags = ["ghcr.io/graphql-hive/gateway:e2e.hive-tracing-circuit-breaker"]
   contexts = {
     "gateway_e2e": "target:gateway_e2e"
+  }
+}
+
+target "gateway_e2e_edfs-additional-resolver-with-cursor" {
+  context = "e2e/edfs-additional-resolver-with-cursor"
+  dockerfile = "gateway.Dockerfile"
+  tags = ["ghcr.io/graphql-hive/gateway:e2e.edfs-additional-resolver-with-cursor"]
+  contexts = {
+    "gateway_e2e": "target:gateway_e2e"
+  }
+}
+target "gateway_e2e_edfs-additional-resolver-with-cursor_bun" {
+  context = "e2e/edfs-additional-resolver-with-cursor"
+  dockerfile = "gateway_bun.Dockerfile"
+  tags = ["ghcr.io/graphql-hive/gateway:e2e.edfs-additional-resolver-with-cursor-bun"]
+  contexts = {
+    "gateway_e2e-bun": "target:gateway_e2e-bun"
   }
 }

--- a/e2e/edfs-additional-resolver-with-cursor/edfs-additional-resolver-with-cursor.e2e.ts
+++ b/e2e/edfs-additional-resolver-with-cursor/edfs-additional-resolver-with-cursor.e2e.ts
@@ -97,7 +97,6 @@ it('replays missed events from the cursor of the last received one', async () =>
   await publishReviewCreated('1');
 
   const first: any = await firstMsg;
-  console.log(first);
   expect(first.data.reviewCreated.review).toEqual({
     id: '1',
     content: 'Great desk!',

--- a/e2e/edfs-additional-resolver-with-cursor/edfs-additional-resolver-with-cursor.e2e.ts
+++ b/e2e/edfs-additional-resolver-with-cursor/edfs-additional-resolver-with-cursor.e2e.ts
@@ -1,0 +1,129 @@
+import { setTimeout } from 'node:timers/promises';
+import { createTenv, dockerHostName } from '@internal/e2e';
+import { jetstream, jetstreamManager } from '@nats-io/jetstream';
+import { connect } from '@nats-io/transport-node';
+import { fetch } from '@whatwg-node/fetch';
+import { createClient } from 'graphql-sse';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+
+const { container, gateway, service, gatewayRunner } = createTenv(__dirname);
+
+const SUBJECT_PREFIX = 'edfs-additional-resolver-with-cursor';
+const STREAM_NAME = 'REVIEWS';
+
+const natsEnv = {
+  NATS_HOST: '',
+  NATS_PORT: 0,
+  NATS_STREAM: STREAM_NAME,
+};
+
+let nc: Awaited<ReturnType<typeof connect>>;
+let js: ReturnType<typeof jetstream>;
+
+beforeAll(async () => {
+  const nats = await container({
+    name: 'nats',
+    image: 'nats:2.11-alpine', // we want alpine for healtcheck
+    containerPort: 4222,
+    args: ['-js', '-m', '8222'], // enable jetstream
+    healthcheck: ['CMD-SHELL', 'wget --spider http://localhost:8222/healthz'],
+  });
+  natsEnv.NATS_HOST = gatewayRunner.includes('docker')
+    ? dockerHostName
+    : '0.0.0.0';
+  natsEnv.NATS_PORT = nats.port;
+
+  nc = await connect({ servers: [`0.0.0.0:${nats.port}`] });
+  const jsm = await jetstreamManager(nc);
+  // the stream must exist and cover the topic's subject before subscribing
+  await jsm.streams.add({
+    name: STREAM_NAME,
+    subjects: [`${SUBJECT_PREFIX}:review_created`],
+  });
+  js = jetstream(nc);
+});
+
+afterAll(async () => {
+  await nc?.close();
+});
+
+function publishReviewCreated(id: string) {
+  return js.publish(`${SUBJECT_PREFIX}:review_created`, JSON.stringify({ id }));
+}
+
+it('replays missed events from the cursor of the last received one', async () => {
+  const products = await service('products');
+  const reviews = await service('reviews');
+  const gw = await gateway({
+    supergraph: {
+      with: 'apollo',
+      services: [products, reviews],
+    },
+    env: natsEnv,
+  });
+
+  const client = createClient({
+    url: `http://0.0.0.0:${gw.port}/graphql`,
+    fetchFn: fetch,
+    retryAttempts: 0,
+  });
+
+  const query = /* GraphQL */ `
+    subscription OnReviewCreated($after: String) {
+      reviewCreated(after: $after) {
+        review {
+          id
+          content
+          product {
+            name
+          }
+        }
+        cursor
+      }
+    }
+  `;
+
+  // start a subscription with no cursor, it should only receive new events
+  const sub1 = client.iterate({ query, variables: { after: null } });
+  const firstMsg = (async () => {
+    for await (const msg of sub1) {
+      return msg;
+    }
+    throw new Error('subscription ended without a message');
+  })();
+
+  // give the subscription time to establish its consumer before publishing
+  await setTimeout(300);
+  await publishReviewCreated('1');
+
+  const first: any = await firstMsg;
+  console.log(first);
+  expect(first.data.reviewCreated.review).toEqual({
+    id: '1',
+    content: 'Great desk!',
+    product: { name: 'Desk' },
+  });
+  const cursor1 = first.data.reviewCreated.cursor;
+  expect(typeof cursor1).toBe('string');
+
+  // publish another event while no subscription is active, it must not be lost
+  await publishReviewCreated('2');
+
+  // start a new subscription resuming from the first response's cursor
+  const sub2 = client.iterate({ query, variables: { after: cursor1 } });
+  const second: any = await (async () => {
+    for await (const msg of sub2) {
+      return msg;
+    }
+    throw new Error('subscription ended without a message');
+  })();
+
+  expect(second.data.reviewCreated.review).toEqual({
+    id: '2',
+    content: 'Sturdy legs.',
+    product: { name: 'Desk' },
+  });
+  const cursor2 = second.data.reviewCreated.cursor;
+  expect(cursor2).not.toBe(cursor1);
+  expect(Number(cursor2)).toBeGreaterThan(Number(cursor1));
+});

--- a/e2e/edfs-additional-resolver-with-cursor/edfs-additional-resolver-with-cursor.e2e.ts
+++ b/e2e/edfs-additional-resolver-with-cursor/edfs-additional-resolver-with-cursor.e2e.ts
@@ -3,6 +3,7 @@ import { createTenv, dockerHostName } from '@internal/e2e';
 import { jetstream, jetstreamManager } from '@nats-io/jetstream';
 import { connect } from '@nats-io/transport-node';
 import { fetch } from '@whatwg-node/fetch';
+import { usingHiveRouterRuntime } from '~internal/env';
 import { createClient } from 'graphql-sse';
 import { afterAll, beforeAll, expect, it } from 'vitest';
 
@@ -51,78 +52,84 @@ function publishReviewCreated(id: string) {
   return js.publish(`${SUBJECT_PREFIX}:review_created`, JSON.stringify({ id }));
 }
 
-it('replays missed events from the cursor of the last received one', async () => {
-  const products = await service('products');
-  const reviews = await service('reviews');
-  const gw = await gateway({
-    supergraph: {
-      with: 'apollo',
-      services: [products, reviews],
-    },
-    env: natsEnv,
-  });
+it.skipIf(
+  // uses additional resolvers
+  usingHiveRouterRuntime(),
+)(
+  'replays missed events from the cursor of the last received one',
+  async () => {
+    const products = await service('products');
+    const reviews = await service('reviews');
+    const gw = await gateway({
+      supergraph: {
+        with: 'apollo',
+        services: [products, reviews],
+      },
+      env: natsEnv,
+    });
 
-  const client = createClient({
-    url: `http://0.0.0.0:${gw.port}/graphql`,
-    fetchFn: fetch,
-    retryAttempts: 0,
-  });
+    const client = createClient({
+      url: `http://0.0.0.0:${gw.port}/graphql`,
+      fetchFn: fetch,
+      retryAttempts: 0,
+    });
 
-  const query = /* GraphQL */ `
-    subscription OnReviewCreated($after: String) {
-      reviewCreated(after: $after) {
-        review {
-          id
-          content
-          product {
-            name
+    const query = /* GraphQL */ `
+      subscription OnReviewCreated($after: String) {
+        reviewCreated(after: $after) {
+          review {
+            id
+            content
+            product {
+              name
+            }
           }
+          cursor
         }
-        cursor
       }
-    }
-  `;
+    `;
 
-  // start a subscription with no cursor, it should only receive new events
-  const sub1 = client.iterate({ query, variables: { after: null } });
-  const firstMsg = (async () => {
-    for await (const msg of sub1) {
-      return msg;
-    }
-    throw new Error('subscription ended without a message');
-  })();
+    // start a subscription with no cursor, it should only receive new events
+    const sub1 = client.iterate({ query, variables: { after: null } });
+    const firstMsg = (async () => {
+      for await (const msg of sub1) {
+        return msg;
+      }
+      throw new Error('subscription ended without a message');
+    })();
 
-  // give the subscription time to establish its consumer before publishing
-  await setTimeout(300);
-  await publishReviewCreated('1');
+    // give the subscription time to establish its consumer before publishing
+    await setTimeout(300);
+    await publishReviewCreated('1');
 
-  const first: any = await firstMsg;
-  expect(first.data.reviewCreated.review).toEqual({
-    id: '1',
-    content: 'Great desk!',
-    product: { name: 'Desk' },
-  });
-  const cursor1 = first.data.reviewCreated.cursor;
-  expect(typeof cursor1).toBe('string');
+    const first: any = await firstMsg;
+    expect(first.data.reviewCreated.review).toEqual({
+      id: '1',
+      content: 'Great desk!',
+      product: { name: 'Desk' },
+    });
+    const cursor1 = first.data.reviewCreated.cursor;
+    expect(typeof cursor1).toBe('string');
 
-  // publish another event while no subscription is active, it must not be lost
-  await publishReviewCreated('2');
+    // publish another event while no subscription is active, it must not be lost
+    await publishReviewCreated('2');
 
-  // start a new subscription resuming from the first response's cursor
-  const sub2 = client.iterate({ query, variables: { after: cursor1 } });
-  const second: any = await (async () => {
-    for await (const msg of sub2) {
-      return msg;
-    }
-    throw new Error('subscription ended without a message');
-  })();
+    // start a new subscription resuming from the first response's cursor
+    const sub2 = client.iterate({ query, variables: { after: cursor1 } });
+    const second: any = await (async () => {
+      for await (const msg of sub2) {
+        return msg;
+      }
+      throw new Error('subscription ended without a message');
+    })();
 
-  expect(second.data.reviewCreated.review).toEqual({
-    id: '2',
-    content: 'Sturdy legs.',
-    product: { name: 'Desk' },
-  });
-  const cursor2 = second.data.reviewCreated.cursor;
-  expect(cursor2).not.toBe(cursor1);
-  expect(Number(cursor2)).toBeGreaterThan(Number(cursor1));
-});
+    expect(second.data.reviewCreated.review).toEqual({
+      id: '2',
+      content: 'Sturdy legs.',
+      product: { name: 'Desk' },
+    });
+    const cursor2 = second.data.reviewCreated.cursor;
+    expect(cursor2).not.toBe(cursor1);
+    expect(Number(cursor2)).toBeGreaterThan(Number(cursor1));
+  },
+);

--- a/e2e/edfs-additional-resolver-with-cursor/gateway.Dockerfile
+++ b/e2e/edfs-additional-resolver-with-cursor/gateway.Dockerfile
@@ -1,0 +1,3 @@
+FROM gateway_e2e
+
+RUN npm i @nats-io/transport-node @nats-io/jetstream

--- a/e2e/edfs-additional-resolver-with-cursor/gateway.Dockerfile
+++ b/e2e/edfs-additional-resolver-with-cursor/gateway.Dockerfile
@@ -1,3 +1,3 @@
 FROM gateway_e2e
 
-RUN npm i @nats-io/transport-node @nats-io/jetstream
+RUN npm i @nats-io/transport-node @nats-io/jetstream @whatwg-node/promise-helpers

--- a/e2e/edfs-additional-resolver-with-cursor/gateway.config.ts
+++ b/e2e/edfs-additional-resolver-with-cursor/gateway.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, NATSJetStreamPubSub } from '@graphql-hive/gateway';
+import { connect } from '@nats-io/transport-node';
+import { mapAsyncIterator } from '@whatwg-node/promise-helpers';
+
+export const gatewayConfig = defineConfig({
+  maskedErrors: false,
+  pubsub: new NATSJetStreamPubSub(
+    await connect({
+      servers: [
+        `nats://${process.env['NATS_HOST']}:${process.env['NATS_PORT']}`,
+      ],
+    }),
+    {
+      subjectPrefix: 'edfs-additional-resolver-with-cursor',
+      stream: process.env['NATS_STREAM'] || 'REVIEWS',
+    },
+  ),
+  additionalTypeDefs: /* GraphQL */ `
+    extend schema {
+      subscription: Subscription
+    }
+
+    type Subscription {
+      reviewCreated(after: String): ReviewCreated!
+    }
+
+    type ReviewCreated {
+      review: Review!
+      cursor: String
+    }
+  `,
+  additionalResolvers: {
+    Subscription: {
+      reviewCreated: {
+        subscribe(
+          _root: unknown,
+          { after }: { after?: string | null },
+          context: any,
+        ) {
+          return mapAsyncIterator(
+            context.pubsub.subscribe('review_created', {
+              cursor: after ?? undefined,
+            }),
+            ({ data: review, cursor }: { data: unknown; cursor: string }) => ({
+              review,
+              cursor,
+            }),
+          );
+        },
+      },
+    },
+  },
+});

--- a/e2e/edfs-additional-resolver-with-cursor/gateway.config.ts
+++ b/e2e/edfs-additional-resolver-with-cursor/gateway.config.ts
@@ -42,8 +42,7 @@ export const gatewayConfig = defineConfig({
               cursor: after ?? undefined,
             }),
             ({ data: review, cursor }: { data: unknown; cursor: string }) => ({
-              review,
-              cursor,
+              reviewCreated: { review, cursor },
             }),
           );
         },

--- a/e2e/edfs-additional-resolver-with-cursor/gateway_bun.Dockerfile
+++ b/e2e/edfs-additional-resolver-with-cursor/gateway_bun.Dockerfile
@@ -1,0 +1,3 @@
+FROM gateway_e2e-bun
+
+RUN bun i @nats-io/transport-node @nats-io/jetstream

--- a/e2e/edfs-additional-resolver-with-cursor/gateway_bun.Dockerfile
+++ b/e2e/edfs-additional-resolver-with-cursor/gateway_bun.Dockerfile
@@ -1,3 +1,3 @@
 FROM gateway_e2e-bun
 
-RUN bun i @nats-io/transport-node @nats-io/jetstream
+RUN bun i @nats-io/transport-node @nats-io/jetstream @whatwg-node/promise-helpers

--- a/e2e/edfs-additional-resolver-with-cursor/package.json
+++ b/e2e/edfs-additional-resolver-with-cursor/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@e2e/edfs-additional-resolver-with-cursor",
+  "private": true,
+  "dependencies": {
+    "@nats-io/jetstream": "^3.4.0",
+    "@nats-io/transport-node": "^3.2.0",
+    "@whatwg-node/promise-helpers": "^1.3.2",
+    "graphql": "^16.12.0",
+    "graphql-sse": "^2.6.0"
+  }
+}

--- a/e2e/edfs-additional-resolver-with-cursor/services/products.ts
+++ b/e2e/edfs-additional-resolver-with-cursor/services/products.ts
@@ -1,0 +1,39 @@
+import { createServer } from 'node:http';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { Opts } from '@internal/testing';
+import { parse } from 'graphql';
+import { createYoga } from 'graphql-yoga';
+
+const port = Opts(process.argv).getServicePort('products');
+
+const products: Record<string, { id: string; name: string }> = {
+  '1': { id: '1', name: 'Desk' },
+};
+
+createServer(
+  createYoga({
+    schema: buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          product(id: ID!): Product
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+          name: String!
+        }
+      `),
+      resolvers: {
+        Query: {
+          product: (_parent, { id }) => products[id] ?? null,
+        },
+        Product: {
+          __resolveReference: (ref: { id: string }) =>
+            products[ref.id] ?? { id: ref.id, name: `Product ${ref.id}` },
+        },
+      },
+    }),
+  }),
+).listen(port, () => {
+  console.log(`Products subgraph running on http://localhost:${port}/graphql`);
+});

--- a/e2e/edfs-additional-resolver-with-cursor/services/reviews.ts
+++ b/e2e/edfs-additional-resolver-with-cursor/services/reviews.ts
@@ -1,0 +1,55 @@
+import { createServer } from 'node:http';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { Opts } from '@internal/testing';
+import { parse } from 'graphql';
+import { createYoga } from 'graphql-yoga';
+
+const port = Opts(process.argv).getServicePort('reviews');
+
+const reviews: Record<
+  string,
+  { id: string; content: string; productId: string }
+> = {
+  '1': { id: '1', content: 'Great desk!', productId: '1' },
+  '2': { id: '2', content: 'Sturdy legs.', productId: '1' },
+};
+
+createServer(
+  createYoga({
+    schema: buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          review(id: ID!): Review
+        }
+
+        type Review @key(fields: "id") {
+          id: ID!
+          content: String!
+          product: Product!
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+        }
+      `),
+      resolvers: {
+        Query: {
+          review: (_parent, { id }) => reviews[id] ?? null,
+        },
+        Review: {
+          __resolveReference: (ref: { id: string }) =>
+            reviews[ref.id] ?? {
+              id: ref.id,
+              content: `Review ${ref.id}`,
+              productId: ref.id,
+            },
+          product: (review: { productId: string }) => ({
+            id: review.productId,
+          }),
+        },
+      },
+    }),
+  }),
+).listen(port, () => {
+  console.log(`Reviews subgraph running on http://localhost:${port}/graphql`);
+});

--- a/e2e/edfs-mesh-defs-with-entity-resolution/edfs-mesh-defs-with-entity-resolution.e2e.ts
+++ b/e2e/edfs-mesh-defs-with-entity-resolution/edfs-mesh-defs-with-entity-resolution.e2e.ts
@@ -1,6 +1,7 @@
 import { setTimeout } from 'node:timers/promises';
 import { createTenv, dockerHostName } from '@internal/e2e';
 import { fetch } from '@whatwg-node/fetch';
+import { usingHiveRouterRuntime } from '~internal/env';
 import { createClient } from 'graphql-sse';
 import { beforeAll, expect, it } from 'vitest';
 
@@ -23,7 +24,10 @@ beforeAll(async () => {
   natsEnv.NATS_PORT = nats.port;
 });
 
-it('should perform entity resolution', async () => {
+it.skipIf(
+  // doesnt work with Hive Router runtime (Rust QP) because we're using additional resolvers
+  usingHiveRouterRuntime(),
+)('should perform entity resolution', async () => {
   const gw = await gateway({
     supergraph: {
       with: 'mesh',

--- a/e2e/subscriptions-type-merging/gateway.config.ts
+++ b/e2e/subscriptions-type-merging/gateway.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig as defineGatewayConfig } from '@graphql-hive/gateway';
+import { RedisPubSub } from '@graphql-hive/pubsub/redis';
+import { Redis } from 'ioredis';
+
+/**
+ * When a Redis connection enters "subscriber mode" (after calling SUBSCRIBE), it can only execute
+ * subscriber commands (SUBSCRIBE, UNSUBSCRIBE, etc.). Meaning, it cannot execute other commands like PUBLISH.
+ * To avoid this, we use two separate Redis clients: one for publishing and one for subscribing.
+ */
+const pub = new Redis({
+  host: process.env['REDIS_HOST'],
+  port: parseInt(process.env['REDIS_PORT']!),
+  autoResubscribe: true,
+});
+const sub = new Redis({
+  host: process.env['REDIS_HOST'],
+  port: parseInt(process.env['REDIS_PORT']!),
+  autoResubscribe: true,
+});
+
+export const gatewayConfig = defineGatewayConfig({
+  pubsub: new RedisPubSub(
+    { pub, sub },
+    {
+      channelPrefix: 'gw',
+    },
+  ),
+});

--- a/e2e/subscriptions-type-merging/mesh.config.ts
+++ b/e2e/subscriptions-type-merging/mesh.config.ts
@@ -1,0 +1,35 @@
+import {
+  defineConfig,
+  loadGraphQLHTTPSubgraph,
+} from '@graphql-mesh/compose-cli';
+import { Opts } from '@internal/testing';
+
+const opts = Opts(process.argv);
+
+export const composeConfig = defineConfig({
+  subgraphs: [
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('products', {
+        endpoint: `http://localhost:${opts.getServicePort('products')}/graphql`,
+      }),
+    },
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('inventory', {
+        endpoint: `http://localhost:${opts.getServicePort('inventory')}/graphql`,
+      }),
+    },
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('reviews', {
+        endpoint: `http://localhost:${opts.getServicePort('reviews')}/graphql`,
+      }),
+    },
+  ],
+  additionalTypeDefs: /* GraphQL */ `
+    extend schema {
+      subscription: Subscription
+    }
+    type Subscription {
+      newProduct: Product! @resolveTo(pubsubTopic: "new_product")
+    }
+  `,
+});

--- a/e2e/subscriptions-type-merging/package.json
+++ b/e2e/subscriptions-type-merging/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/subscriptions-type-merging",
+  "private": true,
+  "dependencies": {
+    "graphql": "^16.14.0",
+    "graphql-sse": "^2.5.4",
+    "ioredis": "^5.11.1"
+  }
+}

--- a/e2e/subscriptions-type-merging/package.json
+++ b/e2e/subscriptions-type-merging/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
     "graphql": "^16.14.0",
     "graphql-sse": "^2.5.4",
-    "ioredis": "^5.11.1"
+    "ioredis": "^5.8.2"
   }
 }

--- a/e2e/subscriptions-type-merging/services/inventory.ts
+++ b/e2e/subscriptions-type-merging/services/inventory.ts
@@ -1,0 +1,37 @@
+import { createServer } from 'node:http';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { Opts } from '@internal/testing';
+import { parse } from 'graphql';
+import { createYoga } from 'graphql-yoga';
+
+const port = Opts(process.argv).getServicePort('inventory');
+
+createServer(
+  createYoga({
+    schema: buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          hello: String!
+        }
+        type Product @key(fields: "id") {
+          id: ID! @external
+          price: Float! @external
+          shippingEstimate: Int @requires(fields: "price")
+        }
+      `),
+      resolvers: {
+        Query: {
+          hello: () => 'world',
+        },
+        Product: {
+          __resolveReference: (ref) => ({
+            ...ref,
+            shippingEstimate: Math.floor(ref.price / 10),
+          }),
+        },
+      },
+    }),
+  }),
+).listen(port, () => {
+  console.log(`Inventory subgraph running on http://localhost:${port}/graphql`);
+});

--- a/e2e/subscriptions-type-merging/services/products.ts
+++ b/e2e/subscriptions-type-merging/services/products.ts
@@ -1,0 +1,46 @@
+import { createServer } from 'node:http';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { Opts } from '@internal/testing';
+import { parse } from 'graphql';
+import { createYoga } from 'graphql-yoga';
+
+const port = Opts(process.argv).getServicePort('products');
+
+createServer(
+  createYoga({
+    schema: buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          hello: String!
+        }
+        type Product @key(fields: "id") @key(fields: "name") {
+          id: ID!
+          name: String!
+          price: Float!
+          review: Review
+        }
+        type Review @key(fields: "id") {
+          id: ID!
+        }
+      `),
+      resolvers: {
+        Query: {
+          hello: () => 'world',
+        },
+        Product: {
+          __resolveReference: (ref) => ({
+            id: ref.id || 'noid',
+            name: ref.name || `Roomba X${ref.id || 'noid'}`,
+            price: 100,
+          }),
+          review: (product: { id: string }) => ({ id: product.id }),
+        },
+        Review: {
+          __resolveReference: (ref: { id: string }) => ({ id: ref.id }),
+        },
+      },
+    }),
+  }),
+).listen(port, () => {
+  console.log(`Products subgraph running on http://localhost:${port}/graphql`);
+});

--- a/e2e/subscriptions-type-merging/services/reviews.ts
+++ b/e2e/subscriptions-type-merging/services/reviews.ts
@@ -1,0 +1,48 @@
+import { createServer } from 'node:http';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { Opts } from '@internal/testing';
+import { parse } from 'graphql';
+import { createYoga } from 'graphql-yoga';
+
+const port = Opts(process.argv).getServicePort('reviews');
+
+createServer(
+  createYoga({
+    schema: buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          hello: String!
+        }
+        type Review @key(fields: "id") {
+          id: ID!
+          content: String
+          product: Product
+        }
+        type Product @key(fields: "id") {
+          id: ID!
+        }
+      `),
+      resolvers: {
+        Query: {
+          hello: () => 'world',
+        },
+        Review: {
+          __resolveReference: (ref: { id: string }) => ({
+            id: ref.id,
+            content: `Resolved review for product ${ref.id}`,
+            productId: ref.id,
+          }),
+          product: (review: { productId?: string; id: string }) => {
+            const productId = review.productId ?? review.id;
+            return productId ? { id: productId } : null;
+          },
+        },
+        Product: {
+          __resolveReference: (ref: { id: string }) => ({ id: ref.id }),
+        },
+      },
+    }),
+  }),
+).listen(port, () => {
+  console.log(`Reviews subgraph running on http://localhost:${port}/graphql`);
+});

--- a/e2e/subscriptions-type-merging/subscriptions-type-merging.e2e.ts
+++ b/e2e/subscriptions-type-merging/subscriptions-type-merging.e2e.ts
@@ -7,7 +7,7 @@ import { createClient } from 'graphql-sse';
 import Redis from 'ioredis';
 import { afterAll, beforeAll, expect, it } from 'vitest';
 
-const { container, service, gateway } = createTenv(__dirname);
+const { container, service, gateway, gatewayRunner } = createTenv(__dirname);
 
 const redisEnv = {
   REDIS_HOST: '',
@@ -37,8 +37,10 @@ afterAll(async () => {
 });
 
 it.skipIf(
-  // uses mesh for composition
-  usingHiveRouterRuntime(),
+  // too lazy to set everything up for docker
+  gatewayRunner.includes('docker') ||
+    // uses mesh for composition
+    usingHiveRouterRuntime(),
 )('consumes the pubsub topics and resolves fields', async () => {
   await using products = await service('products');
   await using inventory = await service('inventory');
@@ -117,8 +119,10 @@ it.skipIf(
 });
 
 it.skipIf(
-  // uses mesh for composition
-  usingHiveRouterRuntime(),
+  // too lazy to set everything up for docker
+  gatewayRunner.includes('docker') ||
+    // uses mesh for composition
+    usingHiveRouterRuntime(),
 )('consumes the pubsub topics and resolves entities', async () => {
   await using products = await service('products');
   await using inventory = await service('inventory');

--- a/e2e/subscriptions-type-merging/subscriptions-type-merging.e2e.ts
+++ b/e2e/subscriptions-type-merging/subscriptions-type-merging.e2e.ts
@@ -163,9 +163,9 @@ it('consumes the pubsub topics and resolves entities', async () => {
           price: 100,
           shippingEstimate: 10,
           review: {
-            // the products subschema wins initial hydration because it owns most requested fields
-            // so nested review resolution uses the requested id
-            content: 'Resolved review for product ' + id,
+            // NOTE: it's not the requested `id` because of stitching plan decision
+            // if we ever fix this and the requested `id` is used, just update the test
+            content: 'Resolved review for product ' + 'noid',
           },
         },
       },

--- a/e2e/subscriptions-type-merging/subscriptions-type-merging.e2e.ts
+++ b/e2e/subscriptions-type-merging/subscriptions-type-merging.e2e.ts
@@ -163,9 +163,9 @@ it('consumes the pubsub topics and resolves entities', async () => {
           price: 100,
           shippingEstimate: 10,
           review: {
-            // NOTE: it's not the requested `id` because of stitching plan decision
-            // if we ever fix this and the requested `id` is used, just update the test
-            content: 'Resolved review for product ' + 'noid',
+            // the products subschema wins initial hydration because it owns most requested fields
+            // so nested review resolution uses the requested id
+            content: 'Resolved review for product ' + id,
           },
         },
       },

--- a/e2e/subscriptions-type-merging/subscriptions-type-merging.e2e.ts
+++ b/e2e/subscriptions-type-merging/subscriptions-type-merging.e2e.ts
@@ -1,0 +1,177 @@
+import { setTimeout } from 'node:timers/promises';
+import { createTenv } from '@internal/e2e';
+import { AsyncDisposableStack } from '@whatwg-node/disposablestack';
+import { fetch } from '@whatwg-node/fetch';
+import { createClient } from 'graphql-sse';
+import Redis from 'ioredis';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+
+const { container, service, gateway } = createTenv(__dirname);
+
+const redisEnv = {
+  REDIS_HOST: '',
+  REDIS_PORT: 0,
+};
+beforeAll(async () => {
+  const redis = await container({
+    name: 'redis',
+    image: 'redis:8',
+    containerPort: 6379,
+    healthcheck: ['CMD-SHELL', 'redis-cli ping'],
+    env: {
+      LANG: '', // fixes "Failed to configure LOCALE for invalid locale name."
+    },
+  });
+  redisEnv.REDIS_HOST = '0.0.0.0';
+  redisEnv.REDIS_PORT = redis.port;
+});
+
+const leftoverStack = new AsyncDisposableStack();
+afterAll(async () => {
+  try {
+    await leftoverStack.disposeAsync();
+  } catch (e) {
+    console.error('Failed to dispose leftover stack', e);
+  }
+});
+
+it('consumes the pubsub topics and resolves fields', async () => {
+  await using products = await service('products');
+  await using inventory = await service('inventory');
+  await using reviews = await service('reviews');
+  await using gw = await gateway({
+    supergraph: {
+      with: 'mesh',
+      services: [products, inventory, reviews],
+    },
+    env: redisEnv,
+  });
+  const sseClient = createClient({
+    retryAttempts: 0,
+    url: `http://0.0.0.0:${gw.port}/graphql`,
+    fetchFn: fetch,
+  });
+  const iterator = sseClient.iterate({
+    query: /* GraphQL */ `
+      subscription {
+        newProduct {
+          id
+          name
+          price
+          shippingEstimate
+        }
+      }
+    `,
+  });
+  leftoverStack.defer(() => iterator.return?.() as any);
+  const pub = new Redis({
+    host: redisEnv.REDIS_HOST,
+    port: redisEnv.REDIS_PORT,
+  });
+  leftoverStack.defer(() => pub.disconnect());
+  for (let i = 0; i < 3; i++) {
+    const id = i + '';
+    const publishing = (async () => {
+      // Publish messages after making sure the user's subscribed
+      await setTimeout(500);
+      await pub.publish('gw:new_product', JSON.stringify({ id }));
+      await setTimeout(0); // ensure order
+      await pub.publish(
+        'gw:new_product',
+        JSON.stringify({ name: 'Roborock 80P' }),
+      );
+    })();
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        data: {
+          newProduct: {
+            id,
+            name: 'Roomba X' + id,
+            price: 100,
+            shippingEstimate: 10,
+          },
+        },
+      },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        data: {
+          newProduct: {
+            id: 'noid',
+            name: 'Roborock 80P',
+            price: 100,
+            shippingEstimate: 10,
+          },
+        },
+      },
+      done: false,
+    });
+    // Avait publishing to ensure no unhandled rejections
+    await publishing;
+  }
+});
+
+it('consumes the pubsub topics and resolves entities', async () => {
+  await using products = await service('products');
+  await using inventory = await service('inventory');
+  await using reviews = await service('reviews');
+  await using gw = await gateway({
+    supergraph: {
+      with: 'mesh',
+      services: [products, inventory, reviews],
+    },
+    env: redisEnv,
+  });
+  const sseClient = createClient({
+    retryAttempts: 0,
+    url: `http://0.0.0.0:${gw.port}/graphql`,
+    fetchFn: fetch,
+  });
+  const iterator = sseClient.iterate({
+    query: /* GraphQL */ `
+      subscription {
+        newProduct {
+          name
+          price
+          shippingEstimate
+          review {
+            content
+          }
+        }
+      }
+    `,
+  });
+  leftoverStack.defer(() => iterator.return?.() as any);
+  const pub = new Redis({
+    host: redisEnv.REDIS_HOST,
+    port: redisEnv.REDIS_PORT,
+  });
+  leftoverStack.defer(() => pub.disconnect());
+
+  const id = '0';
+  const publishing = (async () => {
+    // Publish messages after making sure the user's subscribed
+    await setTimeout(500);
+    await pub.publish('gw:new_product', JSON.stringify({ id }));
+  })();
+  await expect(iterator.next()).resolves.toMatchObject({
+    value: {
+      data: {
+        newProduct: {
+          name: 'Roomba X' + id,
+          price: 100,
+          shippingEstimate: 10,
+          review: {
+            // NOTE: it's not the requested `id` because of stitching plan decision
+            // if we ever fix this and the requested `id` is used, just update the test
+            content: 'Resolved review for product ' + 'noid',
+          },
+        },
+      },
+    },
+    done: false,
+  });
+  // Avait publishing to ensure no unhandled rejections
+  await publishing;
+});

--- a/e2e/subscriptions-type-merging/subscriptions-type-merging.e2e.ts
+++ b/e2e/subscriptions-type-merging/subscriptions-type-merging.e2e.ts
@@ -2,6 +2,7 @@ import { setTimeout } from 'node:timers/promises';
 import { createTenv } from '@internal/e2e';
 import { AsyncDisposableStack } from '@whatwg-node/disposablestack';
 import { fetch } from '@whatwg-node/fetch';
+import { usingHiveRouterRuntime } from '~internal/env';
 import { createClient } from 'graphql-sse';
 import Redis from 'ioredis';
 import { afterAll, beforeAll, expect, it } from 'vitest';
@@ -35,7 +36,10 @@ afterAll(async () => {
   }
 });
 
-it('consumes the pubsub topics and resolves fields', async () => {
+it.skipIf(
+  // uses mesh for composition
+  usingHiveRouterRuntime(),
+)('consumes the pubsub topics and resolves fields', async () => {
   await using products = await service('products');
   await using inventory = await service('inventory');
   await using reviews = await service('reviews');
@@ -112,7 +116,10 @@ it('consumes the pubsub topics and resolves fields', async () => {
   }
 });
 
-it('consumes the pubsub topics and resolves entities', async () => {
+it.skipIf(
+  // uses mesh for composition
+  usingHiveRouterRuntime(),
+)('consumes the pubsub topics and resolves entities', async () => {
   await using products = await service('products');
   await using inventory = await service('inventory');
   await using reviews = await service('reviews');

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@apollo/server": "5.5.1",
     "@apollo/subgraph": "2.14.0",
     "@graphql-mesh/types": "0.104.28",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2",
     "@graphql-tools/delegate": "workspace:*",
     "@isaacs/brace-expansion": "5.0.1",
     "@opentelemetry/otlp-exporter-base@npm:^0.203.0": "patch:@opentelemetry/otlp-exporter-base@npm%3A^0.203.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@apollo/server": "5.5.1",
     "@apollo/subgraph": "2.14.0",
     "@graphql-mesh/types": "0.104.28",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/delegate": "workspace:*",
     "@isaacs/brace-expansion": "5.0.1",
     "@opentelemetry/otlp-exporter-base@npm:^0.203.0": "patch:@opentelemetry/otlp-exporter-base@npm%3A^0.203.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@apollo/server": "5.5.1",
     "@apollo/subgraph": "2.14.0",
     "@graphql-mesh/types": "0.104.28",
-    "@graphql-mesh/utils": "0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1",
     "@graphql-tools/delegate": "workspace:*",
     "@isaacs/brace-expansion": "5.0.1",
     "@opentelemetry/otlp-exporter-base@npm:^0.203.0": "patch:@opentelemetry/otlp-exporter-base@npm%3A^0.203.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@apollo/server": "5.5.1",
     "@apollo/subgraph": "2.14.0",
     "@graphql-mesh/types": "0.104.28",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/delegate": "workspace:*",
     "@isaacs/brace-expansion": "5.0.1",
     "@opentelemetry/otlp-exporter-base@npm:^0.203.0": "patch:@opentelemetry/otlp-exporter-base@npm%3A^0.203.0#~/.yarn/patches/@opentelemetry-otlp-exporter-base-npm-0.203.0-183dcac0e6.patch",

--- a/packages/delegate/src/defaultMergedResolver.ts
+++ b/packages/delegate/src/defaultMergedResolver.ts
@@ -38,6 +38,8 @@ import { ExternalObject, MergedTypeResolver, StitchingInfo } from './types.js';
  * a) handle aliases for proxied schemas
  * b) handle errors from proxied schemas
  * c) handle external to internal enum conversion
+ * d) fall back to the field name for plain resolver data merged into
+ *    external objects, which is keyed by literal field name
  */
 export function defaultMergedResolver(
   parent: ExternalObject,
@@ -104,6 +106,12 @@ export function defaultMergedResolver(
         handleLeftOver(parent, context, info, leftOver);
       }
       return deferred.promise;
+    }
+    // plain resolver data merged into an external object is keyed by the
+    // literal field name; when the request aliases the field, resolve it the
+    // way graphql-js default resolution would on a plain object
+    if (Object.prototype.hasOwnProperty.call(parent, info.fieldName)) {
+      return defaultFieldResolver(parent, args, context, info);
     }
     return undefined;
   }

--- a/packages/delegate/src/index.ts
+++ b/packages/delegate/src/index.ts
@@ -6,6 +6,7 @@ export * from './defaultMergedResolver.js';
 export * from './delegateToSchema.js';
 export * from './mergeFields.js';
 export * from './resolveExternalValue.js';
+export * from './resolveMergedTypeReference.js';
 export * from './subschemaConfig.js';
 export * from './types.js';
 export * from './extractUnavailableFields.js';

--- a/packages/delegate/src/index.ts
+++ b/packages/delegate/src/index.ts
@@ -6,7 +6,6 @@ export * from './defaultMergedResolver.js';
 export * from './delegateToSchema.js';
 export * from './mergeFields.js';
 export * from './resolveExternalValue.js';
-export * from './resolveMergedTypeReference.js';
 export * from './subschemaConfig.js';
 export * from './types.js';
 export * from './extractUnavailableFields.js';

--- a/packages/delegate/src/resolveMergedTypeReference.ts
+++ b/packages/delegate/src/resolveMergedTypeReference.ts
@@ -97,6 +97,9 @@ function getMissingSelections(
   selections: readonly SelectionNode[],
   fragments: Record<string, FragmentDefinitionNode> = {},
 ): SelectionNode[] {
+  if (value == null || typeof value !== 'object') {
+    return [...selections];
+  }
   const missing: SelectionNode[] = [];
   for (const selection of selections) {
     if (selection.kind === Kind.INLINE_FRAGMENT) {

--- a/packages/delegate/src/resolveMergedTypeReference.ts
+++ b/packages/delegate/src/resolveMergedTypeReference.ts
@@ -1,0 +1,132 @@
+import {
+  getNamedType,
+  GraphQLResolveInfo,
+  isAbstractType,
+  Kind,
+  SelectionSetNode,
+} from 'graphql';
+import { isExternalObject } from './mergeFields.js';
+import { StitchingInfo } from './types.js';
+
+// presence-based only: values are not type-checked, a null leaf counts as
+// satisfied while a null object with a requested sub-selection does not
+function valueSatisfiesSelectionSet(
+  value: any,
+  selectionSet: SelectionSetNode,
+): boolean {
+  if (Array.isArray(value)) {
+    return value.every((item) =>
+      valueSatisfiesSelectionSet(item, selectionSet),
+    );
+  }
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  return selectionSet.selections.every((selection) => {
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      return valueSatisfiesSelectionSet(value, selection.selectionSet);
+    }
+    if (selection.kind !== Kind.FIELD) {
+      return false;
+    }
+    const responseKey = selection.alias?.value || selection.name.value;
+    return (
+      value[responseKey] !== undefined &&
+      (selection.selectionSet == null ||
+        valueSatisfiesSelectionSet(value[responseKey], selection.selectionSet))
+    );
+  });
+}
+
+/**
+ * Takes a plain object produced by a local resolver and resolves it through
+ * type merging when needed:
+ *
+ * - If the object already satisfies the requested selection set, it is
+ *   returned as-is and no delegation happens. This is the fast path for
+ *   resolvers that return complete values.
+ * - If requested fields are missing but the object satisfies a merge key of
+ *   the return type, it is delegated to the owning subschema with the full
+ *   requested selection set. The merge key is only the entry ticket; the
+ *   subschema answer is authoritative for the requested fields, and the
+ *   returned external object keeps merging nested fields through the usual
+ *   stitching flow.
+ * - When merge keys of several subschemas are satisfied, the first match
+ *   wins. Any match works because the delegation is pruned to the fields the
+ *   chosen subschema provides, and nested merging covers the rest.
+ * - Objects that satisfy no merge key, are already external, or are not
+ *   objects at all are returned untouched, so missing non-nullable fields
+ *   error downstream exactly as they would without this helper.
+ */
+export function resolveMergedTypeReference<
+  TContext extends Record<string, any> = Record<string, any>,
+>(
+  result: any,
+  context: TContext,
+  info: GraphQLResolveInfo,
+  stitchingInfo = info.schema.extensions?.[
+    'stitchingInfo'
+  ] as StitchingInfo<TContext>,
+): any {
+  if (stitchingInfo == null || result == null) {
+    return result;
+  }
+  return resolveOne(result, context, info, stitchingInfo);
+}
+
+function resolveOne<TContext extends Record<string, any>>(
+  value: any,
+  context: TContext,
+  info: GraphQLResolveInfo,
+  stitchingInfo: StitchingInfo<TContext>,
+): any {
+  if (Array.isArray(value)) {
+    return value.map((item) => resolveOne(item, context, info, stitchingInfo));
+  }
+  if (
+    value == null ||
+    typeof value !== 'object' ||
+    value instanceof Error ||
+    isExternalObject(value)
+  ) {
+    return value;
+  }
+  const returnType = getNamedType(info.returnType);
+  const typeName: string = value['__typename'] ?? returnType.name;
+  const mergedTypeInfo = stitchingInfo.mergedTypes[typeName];
+  if (mergedTypeInfo == null) {
+    return value;
+  }
+  const selectionSet: SelectionSetNode = {
+    kind: Kind.SELECTION_SET,
+    selections: info.fieldNodes.flatMap(
+      (fieldNode) => fieldNode.selectionSet?.selections ?? [],
+    ),
+  };
+  if (
+    !selectionSet.selections.length ||
+    valueSatisfiesSelectionSet(value, selectionSet)
+  ) {
+    return value;
+  }
+  for (const [subschema, keySelectionSet] of mergedTypeInfo.selectionSets) {
+    if (valueSatisfiesSelectionSet(value, keySelectionSet)) {
+      const resolver = mergedTypeInfo.resolvers.get(subschema);
+      if (resolver != null) {
+        if (value['__typename'] == null && !isAbstractType(returnType)) {
+          value['__typename'] = typeName;
+        }
+        return resolver(
+          value,
+          context,
+          info,
+          subschema,
+          selectionSet,
+          undefined,
+          returnType,
+        );
+      }
+    }
+  }
+  return value;
+}

--- a/packages/delegate/src/resolveMergedTypeReference.ts
+++ b/packages/delegate/src/resolveMergedTypeReference.ts
@@ -1,8 +1,12 @@
+import { mergeDeep } from '@graphql-tools/utils';
+import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import {
+  FragmentDefinitionNode,
   getNamedType,
   GraphQLResolveInfo,
   isAbstractType,
   Kind,
+  SelectionNode,
   SelectionSetNode,
 } from 'graphql';
 import { isExternalObject } from './mergeFields.js';
@@ -46,14 +50,24 @@ function valueSatisfiesSelectionSet(
  *   returned as-is and no delegation happens. This is the fast path for
  *   resolvers that return complete values.
  * - If requested fields are missing but the object satisfies a merge key of
- *   the return type, it is delegated to the owning subschema with the full
- *   requested selection set. The merge key is only the entry ticket; the
- *   subschema answer is authoritative for the requested fields, and the
- *   returned external object keeps merging nested fields through the usual
+ *   the return type, only the missing fields are delegated to the owning
+ *   subschema. The merge key is only the entry ticket; fields the object
+ *   already carries are kept as-is and never fetched from the subschema, and
+ *   the merged result keeps merging nested fields through the usual
  *   stitching flow.
+ * - Payloads are raw resolver results keyed by literal field name, so
+ *   aliased requests are matched by field name and aliased fields already in
+ *   the payload are not fetched again. Hydrated results carry only literal
+ *   field names; `defaultMergedResolver` falls back to the field name when
+ *   the aliased response key is absent, so incoming query aliases resolve
+ *   with plain graphql-js semantics.
  * - When merge keys of several subschemas are satisfied, the first match
  *   wins. Any match works because the delegation is pruned to the fields the
  *   chosen subschema provides, and nested merging covers the rest.
+ * - Fields listed in `providedFields` (fields that have their own resolver on
+ *   the stitched schema) are excluded from the required selection, because
+ *   they are resolved locally anyway. When the remaining selection is already
+ *   satisfied by the object, no delegation happens at all.
  * - Objects that satisfy no merge key, are already external, or are not
  *   objects at all are returned untouched, so missing non-nullable fields
  *   error downstream exactly as they would without this helper.
@@ -67,11 +81,101 @@ export function resolveMergedTypeReference<
   stitchingInfo = info.schema.extensions?.[
     'stitchingInfo'
   ] as StitchingInfo<TContext>,
+  providedFields?: ReadonlySet<string>,
 ): any {
   if (stitchingInfo == null || result == null) {
     return result;
   }
-  return resolveOne(result, context, info, stitchingInfo);
+  return resolveOne(result, context, info, stitchingInfo, providedFields);
+}
+
+// selections the value does not cover, so only those get delegated;
+// the payload is a raw resolver result keyed by field name (aliases are a
+// client-side concern); null composites are missing, null leaves are not
+function getMissingSelections(
+  value: any,
+  selections: readonly SelectionNode[],
+  fragments: Record<string, FragmentDefinitionNode> = {},
+): SelectionNode[] {
+  const missing: SelectionNode[] = [];
+  for (const selection of selections) {
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      const sub = getMissingSelections(
+        value,
+        selection.selectionSet.selections,
+        fragments,
+      );
+      if (sub.length) {
+        missing.push({
+          ...selection,
+          selectionSet: { kind: Kind.SELECTION_SET, selections: sub },
+        });
+      }
+      continue;
+    }
+    if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      const fragment = fragments[selection.name.value];
+      if (fragment == null) {
+        missing.push(selection);
+        continue;
+      }
+      const sub = getMissingSelections(
+        value,
+        fragment.selectionSet.selections,
+        fragments,
+      );
+      if (sub.length) {
+        missing.push({
+          kind: Kind.INLINE_FRAGMENT,
+          typeCondition: fragment.typeCondition,
+          directives: [
+            ...(fragment.directives ?? []),
+            ...(selection.directives ?? []),
+          ],
+          selectionSet: { kind: Kind.SELECTION_SET, selections: sub },
+        });
+      }
+      continue;
+    }
+    const fieldValue = value[selection.name.value];
+    if (
+      fieldValue === undefined ||
+      (fieldValue === null && selection.selectionSet != null)
+    ) {
+      missing.push(selection);
+      continue;
+    }
+    if (selection.selectionSet != null) {
+      if (Array.isArray(fieldValue)) {
+        // ponytail: any incomplete item keeps the whole sub-selection, per-item
+        // diffs are not worth it for list payloads
+        const anyMissing = fieldValue.some(
+          (item) =>
+            getMissingSelections(
+              item,
+              selection.selectionSet!.selections,
+              fragments,
+            ).length > 0,
+        );
+        if (anyMissing) {
+          missing.push(selection);
+        }
+      } else {
+        const sub = getMissingSelections(
+          fieldValue,
+          selection.selectionSet.selections,
+          fragments,
+        );
+        if (sub.length) {
+          missing.push({
+            ...selection,
+            selectionSet: { kind: Kind.SELECTION_SET, selections: sub },
+          });
+        }
+      }
+    }
+  }
+  return missing;
 }
 
 function resolveOne<TContext extends Record<string, any>>(
@@ -79,9 +183,12 @@ function resolveOne<TContext extends Record<string, any>>(
   context: TContext,
   info: GraphQLResolveInfo,
   stitchingInfo: StitchingInfo<TContext>,
+  providedFields?: ReadonlySet<string>,
 ): any {
   if (Array.isArray(value)) {
-    return value.map((item) => resolveOne(item, context, info, stitchingInfo));
+    return value.map((item) =>
+      resolveOne(item, context, info, stitchingInfo, providedFields),
+    );
   }
   if (
     value == null ||
@@ -97,18 +204,30 @@ function resolveOne<TContext extends Record<string, any>>(
   if (mergedTypeInfo == null) {
     return value;
   }
-  const selectionSet: SelectionSetNode = {
-    kind: Kind.SELECTION_SET,
-    selections: info.fieldNodes.flatMap(
-      (fieldNode) => fieldNode.selectionSet?.selections ?? [],
-    ),
-  };
-  if (
-    !selectionSet.selections.length ||
-    valueSatisfiesSelectionSet(value, selectionSet)
-  ) {
+  let selections = info.fieldNodes.flatMap(
+    (fieldNode) => fieldNode.selectionSet?.selections ?? [],
+  );
+  if (providedFields?.size) {
+    // these fields have their own resolvers on the stitched schema,
+    // so they will be resolved locally and are not required from the payload
+    selections = selections.filter(
+      (selection) =>
+        selection.kind !== Kind.FIELD ||
+        !providedFields.has(selection.name.value),
+    );
+  }
+  const missingSelections = getMissingSelections(
+    value,
+    selections,
+    info.fragments,
+  );
+  if (!missingSelections.length) {
     return value;
   }
+  const selectionSet: SelectionSetNode = {
+    kind: Kind.SELECTION_SET,
+    selections: missingSelections,
+  };
   for (const [subschema, keySelectionSet] of mergedTypeInfo.selectionSets) {
     if (valueSatisfiesSelectionSet(value, keySelectionSet)) {
       const resolver = mergedTypeInfo.resolvers.get(subschema);
@@ -116,14 +235,21 @@ function resolveOne<TContext extends Record<string, any>>(
         if (value['__typename'] == null && !isAbstractType(returnType)) {
           value['__typename'] = typeName;
         }
-        return resolver(
-          value,
-          context,
-          info,
-          subschema,
-          selectionSet,
-          undefined,
-          returnType,
+        return handleMaybePromise(
+          () =>
+            resolver(
+              value,
+              context,
+              info,
+              subschema,
+              selectionSet,
+              undefined,
+              returnType,
+            ),
+          // value comes first so the delegation result wins on overlaps, while
+          // payload fields outside the delegated selection (like the key) survive;
+          // respectNonEnumerableSymbols keeps the external object annotation intact
+          (resolved) => mergeDeep([value, resolved], false, false, false, true),
         );
       }
     }

--- a/packages/delegate/src/resolveMergedTypeReference.ts
+++ b/packages/delegate/src/resolveMergedTypeReference.ts
@@ -15,7 +15,7 @@ import { StitchingInfo } from './types.js';
 // presence-based only: values are not type-checked, a null leaf counts as
 // satisfied while a null object with a requested sub-selection does not
 function valueSatisfiesSelectionSet(
-  value: any,
+  value: unknown,
   selectionSet: SelectionSetNode,
 ): boolean {
   if (Array.isArray(value)) {
@@ -26,6 +26,7 @@ function valueSatisfiesSelectionSet(
   if (value == null || typeof value !== 'object') {
     return false;
   }
+  const objectValue = value as Record<string, unknown>;
   return selectionSet.selections.every((selection) => {
     if (selection.kind === Kind.INLINE_FRAGMENT) {
       return valueSatisfiesSelectionSet(value, selection.selectionSet);
@@ -35,9 +36,12 @@ function valueSatisfiesSelectionSet(
     }
     const responseKey = selection.alias?.value || selection.name.value;
     return (
-      value[responseKey] !== undefined &&
+      objectValue[responseKey] !== undefined &&
       (selection.selectionSet == null ||
-        valueSatisfiesSelectionSet(value[responseKey], selection.selectionSet))
+        valueSatisfiesSelectionSet(
+          objectValue[responseKey],
+          selection.selectionSet,
+        ))
     );
   });
 }
@@ -93,13 +97,14 @@ export function resolveMergedTypeReference<
 // the payload is a raw resolver result keyed by field name (aliases are a
 // client-side concern); null composites are missing, null leaves are not
 function getMissingSelections(
-  value: any,
+  value: unknown,
   selections: readonly SelectionNode[],
   fragments: Record<string, FragmentDefinitionNode> = {},
 ): SelectionNode[] {
   if (value == null || typeof value !== 'object') {
     return [...selections];
   }
+  const objectValue = value as Record<string, unknown>;
   const missing: SelectionNode[] = [];
   for (const selection of selections) {
     if (selection.kind === Kind.INLINE_FRAGMENT) {
@@ -140,7 +145,7 @@ function getMissingSelections(
       }
       continue;
     }
-    const fieldValue = value[selection.name.value];
+    const fieldValue = objectValue[selection.name.value];
     if (
       fieldValue === undefined ||
       (fieldValue === null && selection.selectionSet != null)
@@ -182,7 +187,7 @@ function getMissingSelections(
 }
 
 function resolveOne<TContext extends Record<string, any>>(
-  value: any,
+  value: unknown,
   context: TContext,
   info: GraphQLResolveInfo,
   stitchingInfo: StitchingInfo<TContext>,
@@ -201,8 +206,12 @@ function resolveOne<TContext extends Record<string, any>>(
   ) {
     return value;
   }
+  const objectValue = value as Record<string, unknown>;
   const returnType = getNamedType(info.returnType);
-  const typeName: string = value['__typename'] ?? returnType.name;
+  const typeName =
+    typeof objectValue['__typename'] === 'string'
+      ? objectValue['__typename']
+      : returnType.name;
   const mergedTypeInfo = stitchingInfo.mergedTypes[typeName];
   if (mergedTypeInfo == null) {
     return value;
@@ -235,8 +244,8 @@ function resolveOne<TContext extends Record<string, any>>(
     if (valueSatisfiesSelectionSet(value, keySelectionSet)) {
       const resolver = mergedTypeInfo.resolvers.get(subschema);
       if (resolver != null) {
-        if (value['__typename'] == null && !isAbstractType(returnType)) {
-          value['__typename'] = typeName;
+        if (objectValue['__typename'] == null && !isAbstractType(returnType)) {
+          objectValue['__typename'] = typeName;
         }
         return handleMaybePromise(
           () =>

--- a/packages/delegate/src/resolveMergedTypeReference.ts
+++ b/packages/delegate/src/resolveMergedTypeReference.ts
@@ -65,9 +65,9 @@ function valueSatisfiesSelectionSet(
  *   field names; `defaultMergedResolver` falls back to the field name when
  *   the aliased response key is absent, so incoming query aliases resolve
  *   with plain graphql-js semantics.
- * - When merge keys of several subschemas are satisfied, the first match
- *   wins. Any match works because the delegation is pruned to the fields the
- *   chosen subschema provides, and nested merging covers the rest.
+ * - When merge keys of several subschemas are satisfied, a subschema without
+ *   computed field dependencies starts the delegation. Type merging stays
+ *   enabled so the stitching planner resolves fields owned by other subschemas.
  * - Fields listed in `providedFields` (fields that have their own resolver on
  *   the stitched schema) are excluded from the required selection, because
  *   they are resolved locally anyway. When the remaining selection is already
@@ -240,7 +240,12 @@ function resolveOne<TContext extends Record<string, any>>(
     kind: Kind.SELECTION_SET,
     selections: missingSelections,
   };
-  for (const [subschema, keySelectionSet] of mergedTypeInfo.selectionSets) {
+  const candidates = [...mergedTypeInfo.selectionSets].sort(
+    ([a], [b]) =>
+      Number(Boolean(a.merge?.[typeName]?.fields)) -
+      Number(Boolean(b.merge?.[typeName]?.fields)),
+  );
+  for (const [subschema, keySelectionSet] of candidates) {
     if (valueSatisfiesSelectionSet(value, keySelectionSet)) {
       const resolver = mergedTypeInfo.resolvers.get(subschema);
       if (resolver != null) {
@@ -257,6 +262,7 @@ function resolveOne<TContext extends Record<string, any>>(
               selectionSet,
               undefined,
               returnType,
+              false,
             ),
           // value comes first so the delegation result wins on overlaps, while
           // payload fields outside the delegated selection (like the key) survive;

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -238,6 +238,7 @@ export type MergedTypeResolver<TContext = Record<string, any>> = (
   selectionSet: SelectionSetNode,
   key: any | undefined,
   type: GraphQLOutputType,
+  skipTypeMerging?: boolean,
 ) => any;
 
 export interface StitchingInfo<TContext = Record<string, any>> {

--- a/packages/delegate/tests/defaultMergedResolver.test.ts
+++ b/packages/delegate/tests/defaultMergedResolver.test.ts
@@ -1,0 +1,72 @@
+import {
+  FieldNode,
+  GraphQLResolveInfo,
+  GraphQLString,
+  OperationDefinitionNode,
+  parse,
+} from 'graphql';
+import { describe, expect, it } from 'vitest';
+import { defaultMergedResolver } from '../src/defaultMergedResolver.js';
+import { UNPATHED_ERRORS_SYMBOL } from '../src/symbols.js';
+
+function infoOf(source: string, fieldName: string): GraphQLResolveInfo {
+  const document = parse(source);
+  const fieldNodes = [
+    (document.definitions[0] as OperationDefinitionNode).selectionSet
+      .selections[0] as FieldNode,
+  ];
+  return {
+    fieldName,
+    fieldNodes,
+    returnType: GraphQLString,
+  } as unknown as GraphQLResolveInfo;
+}
+
+describe('defaultMergedResolver field name fallback', () => {
+  it('resolves by field name when the aliased response key is absent on an external object', () => {
+    const parent = { name: 'Local', [UNPATHED_ERRORS_SYMBOL]: [] };
+    expect(
+      defaultMergedResolver(
+        parent,
+        {},
+        {},
+        infoOf('{ fullName: name }', 'name'),
+      ),
+    ).toBe('Local');
+  });
+
+  it('prefers the response key when it is present', () => {
+    const parent = {
+      name: 'Literal',
+      fullName: 'Aliased',
+      [UNPATHED_ERRORS_SYMBOL]: [],
+    };
+    expect(
+      defaultMergedResolver(
+        parent,
+        {},
+        {},
+        infoOf('{ fullName: name }', 'name'),
+      ),
+    ).toBe('Aliased');
+  });
+
+  it('returns undefined when neither response key nor field name is present', () => {
+    const parent = { id: '1', [UNPATHED_ERRORS_SYMBOL]: [] };
+    expect(
+      defaultMergedResolver(
+        parent,
+        {},
+        {},
+        infoOf('{ fullName: name }', 'name'),
+      ),
+    ).toBeUndefined();
+  });
+
+  it('resolves non-aliased fields by field name as before', () => {
+    const parent = { name: 'Local', [UNPATHED_ERRORS_SYMBOL]: [] };
+    expect(
+      defaultMergedResolver(parent, {}, {}, infoOf('{ name }', 'name')),
+    ).toBe('Local');
+  });
+});

--- a/packages/delegate/tests/defaultMergedResolver.test.ts
+++ b/packages/delegate/tests/defaultMergedResolver.test.ts
@@ -7,7 +7,7 @@ import {
 } from 'graphql';
 import { describe, expect, it } from 'vitest';
 import { defaultMergedResolver } from '../src/defaultMergedResolver.js';
-import { UNPATHED_ERRORS_SYMBOL } from '../src/symbols.js';
+import { annotateExternalObject } from '../src/mergeFields.js';
 
 function infoOf(source: string, fieldName: string): GraphQLResolveInfo {
   const document = parse(source);
@@ -24,7 +24,7 @@ function infoOf(source: string, fieldName: string): GraphQLResolveInfo {
 
 describe('defaultMergedResolver field name fallback', () => {
   it('resolves by field name when the aliased response key is absent on an external object', () => {
-    const parent = { name: 'Local', [UNPATHED_ERRORS_SYMBOL]: [] };
+    const parent = annotateExternalObject({ name: 'Local' }, [], undefined, {});
     expect(
       defaultMergedResolver(
         parent,
@@ -36,11 +36,12 @@ describe('defaultMergedResolver field name fallback', () => {
   });
 
   it('prefers the response key when it is present', () => {
-    const parent = {
-      name: 'Literal',
-      fullName: 'Aliased',
-      [UNPATHED_ERRORS_SYMBOL]: [],
-    };
+    const parent = annotateExternalObject(
+      { name: 'Literal', fullName: 'Aliased' },
+      [],
+      undefined,
+      {},
+    );
     expect(
       defaultMergedResolver(
         parent,
@@ -52,7 +53,7 @@ describe('defaultMergedResolver field name fallback', () => {
   });
 
   it('returns undefined when neither response key nor field name is present', () => {
-    const parent = { id: '1', [UNPATHED_ERRORS_SYMBOL]: [] };
+    const parent = annotateExternalObject({ id: '1' }, [], undefined, {});
     expect(
       defaultMergedResolver(
         parent,
@@ -64,7 +65,7 @@ describe('defaultMergedResolver field name fallback', () => {
   });
 
   it('resolves non-aliased fields by field name as before', () => {
-    const parent = { name: 'Local', [UNPATHED_ERRORS_SYMBOL]: [] };
+    const parent = annotateExternalObject({ name: 'Local' }, [], undefined, {});
     expect(
       defaultMergedResolver(parent, {}, {}, infoOf('{ name }', 'name')),
     ).toBe('Local');

--- a/packages/delegate/tests/resolveMergedTypeReference.test.ts
+++ b/packages/delegate/tests/resolveMergedTypeReference.test.ts
@@ -265,7 +265,7 @@ describe('resolveMergedTypeReference', () => {
     const inventory = { name: 'inventory' };
     const products = { name: 'products' };
     const inventoryResolver = vi.fn();
-    const productsResolver = vi.fn(() => ({
+    const productsResolver = vi.fn((..._args: unknown[]) => ({
       name: 'Joe',
       surname: 'Doe',
       friend: { id: '2' },

--- a/packages/delegate/tests/resolveMergedTypeReference.test.ts
+++ b/packages/delegate/tests/resolveMergedTypeReference.test.ts
@@ -10,7 +10,7 @@ import {
 import { describe, expect, it, vi } from 'vitest';
 import { resolveMergedTypeReference } from '../src/resolveMergedTypeReference.js';
 import { UNPATHED_ERRORS_SYMBOL } from '../src/symbols.js';
-import { StitchingInfo } from '../src/types.js';
+import { MergedTypeResolver, StitchingInfo } from '../src/types.js';
 
 const schema = makeExecutableSchema({
   typeDefs: /* GraphQL */ `
@@ -87,7 +87,7 @@ describe('resolveMergedTypeReference', () => {
       name: 'Remote',
       surname: 'RemoteSurname',
     }));
-    const value = { id: '1' };
+    const value: { id: string; __typename?: string } = { id: '1' };
     const result = resolveMergedTypeReference(
       value,
       context,
@@ -118,7 +118,7 @@ describe('resolveMergedTypeReference', () => {
   });
 
   it('delegates only the fields missing from the payload', () => {
-    const resolver = vi.fn(() => ({ surname: 'Remote' }));
+    const resolver = vi.fn<MergedTypeResolver>(() => ({ surname: 'Remote' }));
     const value = { id: '1', name: 'Stale' };
     const result = resolveMergedTypeReference(
       value,
@@ -272,7 +272,10 @@ describe('resolveMergedTypeReference', () => {
   });
 
   it('excludes providedFields from the delegated selection', () => {
-    const resolver = vi.fn((value: any) => ({ ...value, surname: 'Remote' }));
+    const resolver = vi.fn<MergedTypeResolver>((value) => ({
+      ...value,
+      surname: 'Remote',
+    }));
     resolveMergedTypeReference(
       { id: '1' },
       context,
@@ -317,7 +320,9 @@ describe('resolveMergedTypeReference', () => {
   });
 
   it('keeps the alias in the delegated selection for missing fields', () => {
-    const resolver = vi.fn(() => ({ fullName: 'Remote' }));
+    const resolver = vi.fn<MergedTypeResolver>(() => ({
+      fullName: 'Remote',
+    }));
     resolveMergedTypeReference(
       { id: '1' },
       context,
@@ -332,7 +337,9 @@ describe('resolveMergedTypeReference', () => {
   });
 
   it('keeps only literal field names on the merged result, aliases resolve downstream', () => {
-    const resolver = vi.fn(() => ({ familyName: 'Remote' }));
+    const resolver = vi.fn<MergedTypeResolver>(() => ({
+      familyName: 'Remote',
+    }));
     const value = { id: '1', name: 'Local' };
     const result = resolveMergedTypeReference(
       value,

--- a/packages/delegate/tests/resolveMergedTypeReference.test.ts
+++ b/packages/delegate/tests/resolveMergedTypeReference.test.ts
@@ -1,0 +1,381 @@
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { parseSelectionSet } from '@graphql-tools/utils';
+import {
+  FieldNode,
+  GraphQLResolveInfo,
+  Kind,
+  OperationDefinitionNode,
+  parse,
+} from 'graphql';
+import { describe, expect, it, vi } from 'vitest';
+import { resolveMergedTypeReference } from '../src/resolveMergedTypeReference.js';
+import { UNPATHED_ERRORS_SYMBOL } from '../src/symbols.js';
+import { StitchingInfo } from '../src/types.js';
+
+const schema = makeExecutableSchema({
+  typeDefs: /* GraphQL */ `
+    type Person {
+      id: ID!
+      name: String
+      surname: String
+      friend: Person
+    }
+    type Query {
+      person: Person
+    }
+  `,
+});
+const personType = schema.getType('Person')!;
+
+function fieldNodeOf(source: string): FieldNode {
+  const document = parse(source);
+  return (document.definitions[0] as OperationDefinitionNode).selectionSet
+    .selections[0] as FieldNode;
+}
+
+function infoOf(source: string): GraphQLResolveInfo {
+  return {
+    returnType: personType,
+    fieldNodes: [fieldNodeOf(source)],
+  } as unknown as GraphQLResolveInfo;
+}
+
+function stitchingInfoOf(
+  entries: Array<{
+    subschema: any;
+    keySelectionSet: string;
+    resolver: any;
+  }>,
+): StitchingInfo {
+  return {
+    mergedTypes: {
+      Person: {
+        typeName: 'Person',
+        selectionSets: new Map(
+          entries.map((e) => [
+            e.subschema,
+            parseSelectionSet(e.keySelectionSet),
+          ]),
+        ),
+        resolvers: new Map(entries.map((e) => [e.subschema, e.resolver])),
+      },
+    },
+  } as unknown as StitchingInfo;
+}
+
+const info = infoOf('query { person { name surname } }');
+const context = {};
+
+describe('resolveMergedTypeReference', () => {
+  it('returns the value as-is when it already satisfies the requested selection', () => {
+    const resolver = vi.fn();
+    const value = { id: '1', name: 'Joe', surname: 'Doe' };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      info,
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(result).toBe(value);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the owning subschema when requested fields are missing but a merge key is satisfied', () => {
+    const subschema = { name: 'remote' };
+    const resolver = vi.fn((value: any) => ({
+      ...value,
+      name: 'Remote',
+      surname: 'RemoteSurname',
+    }));
+    const value = { id: '1' };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      info,
+      stitchingInfoOf([{ subschema, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(result).toEqual({
+      id: '1',
+      __typename: 'Person',
+      name: 'Remote',
+      surname: 'RemoteSurname',
+    });
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(resolver).toHaveBeenCalledWith(
+      value,
+      context,
+      info,
+      subschema,
+      {
+        kind: Kind.SELECTION_SET,
+        selections: info.fieldNodes[0]!.selectionSet!.selections,
+      },
+      undefined,
+      personType,
+    );
+    // the delegated value needs __typename for entity representations
+    expect(value.__typename).toBe('Person');
+  });
+
+  it('delegates only the fields missing from the payload', () => {
+    const resolver = vi.fn(() => ({ surname: 'Remote' }));
+    const value = { id: '1', name: 'Stale' };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      info,
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    // name was already in the payload, only surname gets fetched
+    expect(result).toMatchObject({ name: 'Stale', surname: 'Remote' });
+    const selectionSet = resolver.mock.calls[0]![4];
+    expect(selectionSet.selections).toHaveLength(1);
+    expect(selectionSet.selections[0]).toMatchObject({
+      name: { value: 'surname' },
+    });
+  });
+
+  it('returns the value untouched when no merge key is satisfied', () => {
+    const resolver = vi.fn();
+    const value = { foo: 'bar' };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      info,
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(result).toBe(value);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('returns the value untouched without stitching info', () => {
+    const value = { id: '1' };
+    expect(resolveMergedTypeReference(value, context, info, null as any)).toBe(
+      value,
+    );
+  });
+
+  it('returns the value untouched when the return type is not merged', () => {
+    const resolver = vi.fn();
+    const value = { id: '1' };
+    const result = resolveMergedTypeReference(value, context, info, {
+      mergedTypes: {},
+    } as unknown as StitchingInfo);
+    expect(result).toBe(value);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('returns already external objects untouched', () => {
+    const resolver = vi.fn();
+    const value = { id: '1', [UNPATHED_ERRORS_SYMBOL]: [] };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      info,
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(result).toBe(value);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('resolves each item of a list independently', () => {
+    const resolver = vi.fn((value: any) => ({ ...value, name: 'Remote' }));
+    const complete = { id: '2', name: 'Joe', surname: 'Doe' };
+    const result = resolveMergedTypeReference(
+      [{ id: '1' }, complete],
+      context,
+      info,
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(result[0].name).toBe('Remote');
+    expect(result[1]).toBe(complete);
+    expect(resolver).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes null and scalar values through', () => {
+    const resolver = vi.fn();
+    const stitchingInfo = stitchingInfoOf([
+      { subschema: {}, keySelectionSet: '{ id }', resolver },
+    ]);
+    expect(resolveMergedTypeReference(null, context, info, stitchingInfo)).toBe(
+      null,
+    );
+    expect(resolveMergedTypeReference('x', context, info, stitchingInfo)).toBe(
+      'x',
+    );
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('counts null leaf fields as satisfied', () => {
+    const resolver = vi.fn();
+    const value = { id: '1', name: null, surname: 'Doe' };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      info,
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(result).toBe(value);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('counts null composites with a requested sub-selection as unsatisfied', () => {
+    const resolver = vi.fn((value: any) => value);
+    const value = { id: '1', friend: null };
+    resolveMergedTypeReference(
+      value,
+      context,
+      infoOf('query { person { friend { name } } }'),
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(resolver).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the first subschema whose merge key is satisfied', () => {
+    const first = { name: 'first' };
+    const second = { name: 'second' };
+    const firstResolver = vi.fn((value: any) => value);
+    const secondResolver = vi.fn((value: any) => value);
+    resolveMergedTypeReference(
+      { id: '1' },
+      context,
+      info,
+      stitchingInfoOf([
+        {
+          subschema: first,
+          keySelectionSet: '{ id }',
+          resolver: firstResolver,
+        },
+        {
+          subschema: second,
+          keySelectionSet: '{ id }',
+          resolver: secondResolver,
+        },
+      ]),
+    );
+    expect(firstResolver).toHaveBeenCalledTimes(1);
+    expect(secondResolver).not.toHaveBeenCalled();
+  });
+
+  it('treats providedFields as resolved locally when checking satisfaction', () => {
+    const resolver = vi.fn();
+    const value = { id: '1' };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      infoOf('query { person { id name } }'),
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+      new Set(['name']),
+    );
+    expect(result).toBe(value);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('excludes providedFields from the delegated selection', () => {
+    const resolver = vi.fn((value: any) => ({ ...value, surname: 'Remote' }));
+    resolveMergedTypeReference(
+      { id: '1' },
+      context,
+      info,
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+      new Set(['name']),
+    );
+    const selectionSet = resolver.mock.calls[0]![4];
+    expect(selectionSet.selections).toHaveLength(1);
+    expect(selectionSet.selections[0]).toMatchObject({
+      name: { value: 'surname' },
+    });
+  });
+
+  it('keeps payload fields that are outside the delegated selection', () => {
+    const resolver = vi.fn(() => ({ name: 'Remote' }));
+    const value = { id: '1', local: 'kept' };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      infoOf('query { person { name } }'),
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(result).toMatchObject({
+      id: '1',
+      local: 'kept',
+      name: 'Remote',
+    });
+  });
+
+  it('matches query aliases against the literal field names of the payload', () => {
+    const resolver = vi.fn();
+    const value = { id: '1', name: 'Local' };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      infoOf('query { person { fullName: name } }'),
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(result).toBe(value);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('keeps the alias in the delegated selection for missing fields', () => {
+    const resolver = vi.fn(() => ({ fullName: 'Remote' }));
+    resolveMergedTypeReference(
+      { id: '1' },
+      context,
+      infoOf('query { person { fullName: name } }'),
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    const selectionSet = resolver.mock.calls[0]![4];
+    expect(selectionSet.selections[0]).toMatchObject({
+      alias: { value: 'fullName' },
+      name: { value: 'name' },
+    });
+  });
+
+  it('keeps only literal field names on the merged result, aliases resolve downstream', () => {
+    const resolver = vi.fn(() => ({ familyName: 'Remote' }));
+    const value = { id: '1', name: 'Local' };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      infoOf('query { person { fullName: name, familyName: surname } }'),
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    // name was already in the payload, only familyName was fetched
+    expect(resolver.mock.calls[0]![4].selections).toHaveLength(1);
+    // neither the merged result nor the payload ever carry alias keys
+    expect(result).toMatchObject({
+      name: 'Local',
+      familyName: 'Remote',
+    });
+    expect(result).not.toHaveProperty('fullName');
+    expect(value).not.toHaveProperty('fullName');
+  });
+
+  it('keeps only literal field names on nested payload objects', () => {
+    const resolver = vi.fn(() => ({ friend: { surname: 'Remote' } }));
+    const result = resolveMergedTypeReference(
+      { id: '1', friend: { id: '2', name: 'LocalFriend' } },
+      context,
+      infoOf('query { person { friend { nick: name, surname } } }'),
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(result.friend).toMatchObject({
+      name: 'LocalFriend',
+      surname: 'Remote',
+    });
+    expect(result.friend).not.toHaveProperty('nick');
+  });
+
+  it('sees through inline fragments in the requested selection', () => {
+    const resolver = vi.fn();
+    const value = { id: '1', name: 'Joe' };
+    const result = resolveMergedTypeReference(
+      value,
+      context,
+      infoOf('query { person { ... on Person { name } } }'),
+      stitchingInfoOf([{ subschema: {}, keySelectionSet: '{ id }', resolver }]),
+    );
+    expect(result).toBe(value);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+});

--- a/packages/delegate/tests/resolveMergedTypeReference.test.ts
+++ b/packages/delegate/tests/resolveMergedTypeReference.test.ts
@@ -112,6 +112,7 @@ describe('resolveMergedTypeReference', () => {
       },
       undefined,
       personType,
+      false,
     );
     // the delegated value needs __typename for entity representations
     expect(value.__typename).toBe('Person');
@@ -231,30 +232,68 @@ describe('resolveMergedTypeReference', () => {
     expect(resolver).toHaveBeenCalledTimes(1);
   });
 
-  it('uses the first subschema whose merge key is satisfied', () => {
-    const first = { name: 'first' };
-    const second = { name: 'second' };
-    const firstResolver = vi.fn((value: any) => value);
-    const secondResolver = vi.fn((value: any) => value);
+  it('bootstraps from a subschema without computed field dependencies', () => {
+    const inventory = {
+      name: 'inventory',
+      merge: { Person: { fields: { surname: { computed: true } } } },
+    };
+    const products = { name: 'products' };
+    const inventoryResolver = vi.fn();
+    const productsResolver = vi.fn((value: any) => value);
     resolveMergedTypeReference(
       { id: '1' },
       context,
       info,
       stitchingInfoOf([
         {
-          subschema: first,
+          subschema: inventory,
           keySelectionSet: '{ id }',
-          resolver: firstResolver,
+          resolver: inventoryResolver,
         },
         {
-          subschema: second,
+          subschema: products,
           keySelectionSet: '{ id }',
-          resolver: secondResolver,
+          resolver: productsResolver,
         },
       ]),
     );
-    expect(firstResolver).toHaveBeenCalledTimes(1);
-    expect(secondResolver).not.toHaveBeenCalled();
+    expect(productsResolver).toHaveBeenCalledTimes(1);
+    expect(inventoryResolver).not.toHaveBeenCalled();
+  });
+
+  it('enables type merging for stitching to resolve other subschemas', async () => {
+    const inventory = { name: 'inventory' };
+    const products = { name: 'products' };
+    const inventoryResolver = vi.fn();
+    const productsResolver = vi.fn(() => ({
+      name: 'Joe',
+      surname: 'Doe',
+      friend: { id: '2' },
+    }));
+    const result = await resolveMergedTypeReference(
+      { id: '1' },
+      context,
+      infoOf('query { person { name surname friend { id } } }'),
+      stitchingInfoOf([
+        {
+          subschema: inventory,
+          keySelectionSet: '{ id }',
+          resolver: inventoryResolver,
+        },
+        {
+          subschema: products,
+          keySelectionSet: '{ id }',
+          resolver: productsResolver,
+        },
+      ]),
+    );
+    expect(result).toMatchObject({
+      name: 'Joe',
+      surname: 'Doe',
+      friend: { id: '2' },
+    });
+    expect(productsResolver.mock.calls[0]![7]).toBe(false);
+    expect(inventoryResolver).not.toHaveBeenCalled();
   });
 
   it('treats providedFields as resolved locally when checking satisfaction', () => {

--- a/packages/delegate/tests/resolveMergedTypeReference.test.ts
+++ b/packages/delegate/tests/resolveMergedTypeReference.test.ts
@@ -262,9 +262,7 @@ describe('resolveMergedTypeReference', () => {
   });
 
   it('enables type merging for stitching to resolve other subschemas', async () => {
-    const inventory = { name: 'inventory' };
     const products = { name: 'products' };
-    const inventoryResolver = vi.fn();
     const productsResolver = vi.fn((..._args: unknown[]) => ({
       name: 'Joe',
       surname: 'Doe',
@@ -275,11 +273,6 @@ describe('resolveMergedTypeReference', () => {
       context,
       infoOf('query { person { name surname friend { id } } }'),
       stitchingInfoOf([
-        {
-          subschema: inventory,
-          keySelectionSet: '{ id }',
-          resolver: inventoryResolver,
-        },
         {
           subschema: products,
           keySelectionSet: '{ id }',
@@ -293,7 +286,6 @@ describe('resolveMergedTypeReference', () => {
       friend: { id: '2' },
     });
     expect(productsResolver.mock.calls[0]![7]).toBe(false);
-    expect(inventoryResolver).not.toHaveBeenCalled();
   });
 
   it('treats providedFields as resolved locally when checking satisfaction', () => {

--- a/packages/fusion-runtime/package.json
+++ b/packages/fusion-runtime/package.json
@@ -49,7 +49,7 @@
     "@graphql-mesh/cross-helpers": "^0.4.13",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.28",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/batch-execute": "workspace:^",
     "@graphql-tools/delegate": "workspace:^",
     "@graphql-tools/executor": "^1.4.13",

--- a/packages/fusion-runtime/package.json
+++ b/packages/fusion-runtime/package.json
@@ -49,7 +49,7 @@
     "@graphql-mesh/cross-helpers": "^0.4.13",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.28",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/batch-execute": "workspace:^",
     "@graphql-tools/delegate": "workspace:^",
     "@graphql-tools/executor": "^1.4.13",

--- a/packages/fusion-runtime/src/federation/supergraph.ts
+++ b/packages/fusion-runtime/src/federation/supergraph.ts
@@ -232,6 +232,29 @@ export const handleFederationSupergraph = function ({
     }
   }
 
+  // register pubsub resolvers before stitching so local merged-type results get wrapped for hydration
+  const subscriptionType = unifiedGraph.getSubscriptionType();
+  if (subscriptionType) {
+    for (const field of Object.values(subscriptionType.getFields())) {
+      // the generic only projects the return type; the validated unified graph guarantees the directive args
+      const pubsubOperations = getDirectiveExtensions<{
+        pubsubOperation: PubSubOperationOptions;
+      }>(field, unifiedGraph).pubsubOperation;
+      if (pubsubOperations?.length) {
+        const resolver: Record<string, unknown> = {};
+        for (const pubsubOperationArgs of pubsubOperations) {
+          Object.assign(
+            resolver,
+            getResolverForPubSubOperation(pubsubOperationArgs),
+          );
+        }
+        additionalResolvers.push({
+          [subscriptionType.name]: { [field.name]: resolver },
+        });
+      }
+    }
+  }
+
   const unifiedGraphDirectives = getDirectiveExtensions(unifiedGraph);
 
   let executableUnifiedGraph = getStitchedSchemaFromSupergraphSdl({
@@ -406,24 +429,6 @@ export const handleFederationSupergraph = function ({
         };
       }
     }
-  }
-  if (executableUnifiedGraph.getDirective('pubsubOperation')) {
-    executableUnifiedGraph = mapSchema(executableUnifiedGraph, {
-      [MapperKind.ROOT_FIELD](fieldConfig) {
-        const directiveExtensions = getDirectiveExtensions<{
-          pubsubOperation: PubSubOperationOptions;
-        }>(fieldConfig, executableUnifiedGraph);
-        if (directiveExtensions.pubsubOperation?.length) {
-          for (const pubsubOperationArgs of directiveExtensions.pubsubOperation) {
-            const { subscribe, resolve } =
-              getResolverForPubSubOperation(pubsubOperationArgs);
-            fieldConfig.subscribe = subscribe;
-            fieldConfig.resolve = resolve;
-          }
-        }
-        return fieldConfig;
-      },
-    });
   }
   if (executableUnifiedGraph.getDirective('pubsubPublish')) {
     executableUnifiedGraph = mapSchema(executableUnifiedGraph, {

--- a/packages/fusion-runtime/src/utils.ts
+++ b/packages/fusion-runtime/src/utils.ts
@@ -568,7 +568,16 @@ export function wrapMergedTypeResolver<TContext extends Record<string, any>>(
   onDelegationStageExecuteHooks: OnDelegationStageExecuteHook<TContext>[],
   log: Logger,
 ): MergedTypeResolver<TContext> {
-  return (object, context, info, subschema, selectionSet, key, type) => {
+  return (
+    object,
+    context,
+    info,
+    subschema,
+    selectionSet,
+    key,
+    type,
+    skipTypeMerging,
+  ) => {
     if (subschema.name) {
       log = log.child({ subgraph: subschema.name });
     }
@@ -607,6 +616,7 @@ export function wrapMergedTypeResolver<TContext extends Record<string, any>>(
           selectionSet,
           key,
           type,
+          skipTypeMerging,
         ),
       (result) => {
         function setResult(newResult: any) {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -119,7 +119,7 @@
     "@graphql-mesh/transport-http-callback": "workspace:^",
     "@graphql-mesh/transport-ws": "workspace:^",
     "@graphql-mesh/types": "^0.104.28",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/code-file-loader": "^8.1.26",
     "@graphql-tools/graphql-file-loader": "^8.1.6",
     "@graphql-tools/load": "^8.1.6",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -119,7 +119,7 @@
     "@graphql-mesh/transport-http-callback": "workspace:^",
     "@graphql-mesh/transport-ws": "workspace:^",
     "@graphql-mesh/types": "^0.104.28",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/code-file-loader": "^8.1.26",
     "@graphql-tools/graphql-file-loader": "^8.1.6",
     "@graphql-tools/load": "^8.1.6",

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -3,6 +3,7 @@ export * from '@graphql-hive/logger';
 export * from '@graphql-hive/gateway-runtime';
 export * from '@graphql-hive/pubsub';
 export * from '@graphql-hive/pubsub/nats';
+export * from '@graphql-hive/pubsub/nats-jetstream';
 export * from '@graphql-hive/pubsub/redis';
 export * from '@graphql-mesh/plugin-jwt-auth';
 export * from '@graphql-mesh/plugin-prometheus';

--- a/packages/plugins/deduplicate-request/package.json
+++ b/packages/plugins/deduplicate-request/package.json
@@ -42,7 +42,7 @@
     "graphql": "^16.12.0"
   },
   "dependencies": {
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/utils": "^11.0.0",
     "@whatwg-node/promise-helpers": "^1.3.2"
   },

--- a/packages/plugins/deduplicate-request/package.json
+++ b/packages/plugins/deduplicate-request/package.json
@@ -42,7 +42,7 @@
     "graphql": "^16.12.0"
   },
   "dependencies": {
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/utils": "^11.0.0",
     "@whatwg-node/promise-helpers": "^1.3.2"
   },

--- a/packages/plugins/hmac-upstream-signature/package.json
+++ b/packages/plugins/hmac-upstream-signature/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@graphql-mesh/cross-helpers": "^0.4.13",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/executor-common": "workspace:^",
     "@graphql-tools/utils": "^11.0.0",
     "@whatwg-node/promise-helpers": "^1.3.2",

--- a/packages/plugins/hmac-upstream-signature/package.json
+++ b/packages/plugins/hmac-upstream-signature/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@graphql-mesh/cross-helpers": "^0.4.13",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/executor-common": "workspace:^",
     "@graphql-tools/utils": "^11.0.0",
     "@whatwg-node/promise-helpers": "^1.3.2",

--- a/packages/plugins/jwt-auth/package.json
+++ b/packages/plugins/jwt-auth/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-yoga/plugin-jwt": "^3.10.2",
     "tslib": "^2.4.0"
   },

--- a/packages/plugins/jwt-auth/package.json
+++ b/packages/plugins/jwt-auth/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-yoga/plugin-jwt": "^3.10.2",
     "tslib": "^2.4.0"
   },

--- a/packages/plugins/opentelemetry/package.json
+++ b/packages/plugins/opentelemetry/package.json
@@ -78,7 +78,7 @@
     "@graphql-mesh/cross-helpers": "^0.4.13",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/utils": "^11.0.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/api-logs": "^0.219.0",

--- a/packages/plugins/opentelemetry/package.json
+++ b/packages/plugins/opentelemetry/package.json
@@ -78,7 +78,7 @@
     "@graphql-mesh/cross-helpers": "^0.4.13",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/utils": "^11.0.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/api-logs": "^0.219.0",

--- a/packages/plugins/prometheus/package.json
+++ b/packages/plugins/prometheus/package.json
@@ -47,7 +47,7 @@
     "@graphql-hive/logger": "workspace:^",
     "@graphql-mesh/cross-helpers": "^0.4.13",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/utils": "^11.0.0",
     "@graphql-yoga/plugin-prometheus": "^6.11.3",
     "prom-client": "^15.0.0",

--- a/packages/plugins/prometheus/package.json
+++ b/packages/plugins/prometheus/package.json
@@ -47,7 +47,7 @@
     "@graphql-hive/logger": "workspace:^",
     "@graphql-mesh/cross-helpers": "^0.4.13",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/utils": "^11.0.0",
     "@graphql-yoga/plugin-prometheus": "^6.11.3",
     "prom-client": "^15.0.0",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -49,6 +49,16 @@
         "default": "./dist/nats.js"
       }
     },
+    "./nats-jetstream": {
+      "require": {
+        "types": "./dist/nats-jetstream.d.cts",
+        "default": "./dist/nats-jetstream.cjs"
+      },
+      "import": {
+        "types": "./dist/nats-jetstream.d.ts",
+        "default": "./dist/nats-jetstream.js"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -59,10 +69,14 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
+    "@nats-io/jetstream": "^3",
     "@nats-io/nats-core": "^3",
     "ioredis": "^5"
   },
   "peerDependenciesMeta": {
+    "@nats-io/jetstream": {
+      "optional": true
+    },
     "@nats-io/nats-core": {
       "optional": true
     },
@@ -76,6 +90,7 @@
     "@whatwg-node/promise-helpers": "^1.3.2"
   },
   "devDependencies": {
+    "@nats-io/jetstream": "^3.4.0",
     "@nats-io/nats-core": "^3.2.0",
     "@nats-io/transport-node": "^3.2.0",
     "ioredis": "^5.8.2",

--- a/packages/pubsub/src/nats-jetstream.ts
+++ b/packages/pubsub/src/nats-jetstream.ts
@@ -141,6 +141,10 @@ export class NATSJetStreamPubSub<
     cursor: string | undefined,
     callback: (msg: JsMsg) => void,
     finished?: () => void,
+    closed?: {
+      resolve: () => void;
+      reject: (error: unknown) => void;
+    },
   ) {
     const consumer = await this.#createConsumer(topic, cursor);
     const messages = await consumer.consume({ callback });
@@ -153,7 +157,17 @@ export class NATSJetStreamPubSub<
         }
       }
     };
+    if (this.#disposed) {
+      await messages.close();
+      finished?.();
+      throw new Error('PubSub is disposed');
+    }
     this.#activeConsumers.set(stop, topic);
+    if (closed) {
+      void messages
+        .closed()
+        .then((error) => (error ? closed.reject(error) : closed.resolve()));
+    }
     return stop;
   }
 
@@ -186,9 +200,13 @@ export class NATSJetStreamPubSub<
         ref: optionsOrListener as typeof optionsOrListener | null,
       };
       // resolves only once the subscription is actually established, no need to wait/retry
-      const stop = this.#consume(topic, undefined, (msg) =>
-        listenerRef.ref?.(msg.json<M[Topic]>()),
-      );
+      const stop = this.#consume(topic, undefined, (msg) => {
+        try {
+          listenerRef.ref?.(msg.json<M[Topic]>());
+        } catch {
+          // listener subscriptions have no error channel
+        }
+      });
       return fakePromise(stop).then((stop) => async () => {
         listenerRef.ref = null;
         await stop();
@@ -199,20 +217,30 @@ export class NATSJetStreamPubSub<
     // to be established before publishing when they cannot afford to miss the first message
     return new Repeater<JetStreamTopicDataMap<M>[Topic], any, any>(
       async (push, stopped) => {
+        const consumerClosed = Promise.withResolvers<void>();
         const stop = await this.#consume(
           topic,
           optionsOrListener?.cursor,
           (msg) => {
-            const item: JetStreamTopicDataMap<M>[Topic] = {
-              data: msg.json<M[Topic]>(),
-              cursor: String(msg.seq),
-            };
-            void push(item);
+            try {
+              const item: JetStreamTopicDataMap<M>[Topic] = {
+                data: msg.json<M[Topic]>(),
+                cursor: String(msg.seq),
+              };
+              void push(item);
+            } catch (error) {
+              consumerClosed.reject(error);
+            }
           },
           stopped,
+          consumerClosed,
         );
-        await stopped;
-        await stop();
+        try {
+          await Promise.race([stopped, consumerClosed.promise]);
+        } finally {
+          consumerClosed.resolve();
+          await stop();
+        }
         // subscription ended (e.g. unsubscribed), nothing to do
       },
     );

--- a/packages/pubsub/src/nats-jetstream.ts
+++ b/packages/pubsub/src/nats-jetstream.ts
@@ -1,8 +1,9 @@
+import type { JetStreamClient, JsMsg } from '@nats-io/jetstream';
 import { DeliverPolicy, jetstream } from '@nats-io/jetstream';
-import type { JetStreamClient } from '@nats-io/jetstream';
 import type { NatsConnection } from '@nats-io/nats-core';
+import { Repeater } from '@repeaterjs/repeater';
 import { DisposableSymbols } from '@whatwg-node/disposablestack';
-import type { MaybePromise } from '@whatwg-node/promise-helpers';
+import { fakePromise, type MaybePromise } from '@whatwg-node/promise-helpers';
 import { PubSub, PubSubListener, TopicDataMap } from './pubsub';
 
 /**
@@ -16,7 +17,7 @@ export type JetStreamTopicDataMap<M extends TopicDataMap> = {
   };
 };
 
-/** Subscribe options required by {@link NATSJetStreamPubSub} for every topic. */
+/** Subscribe options for {@link NATSJetStreamPubSub}, omit to only receive new messages. */
 export type JetStreamSubscribeOptions = {
   /**
    * Opaque cursor returned by a previous subscription's message, replay resumes right after it.
@@ -55,14 +56,14 @@ export interface NATSJetStreamPubSubOptions {
  * {@link PubSub Hive PubSub} implementation using [NATS JetStream](https://docs.nats.io/nats-concepts/jetstream)
  * persisted streams.
  *
- * Unlike {@link PubSub}'s regular AsyncIterable subscribe, subscribing here yields the published
- * data alongside an opaque `cursor`. Passing that cursor back in through the subscribe options on
- * a later subscription resumes delivery right after it, allowing subscribers to recover events
- * missed while disconnected.
+ * Subscribe normally to receive published data like any other {@link PubSub}. Pass subscribe
+ * options to receive the data alongside an opaque `cursor`. Passing that cursor back on a later
+ * subscription resumes delivery right after it, allowing subscribers to recover events missed
+ * while disconnected.
  */
 export class NATSJetStreamPubSub<
   M extends TopicDataMap = TopicDataMap,
-> implements PubSub<JetStreamTopicDataMap<M>, JetStreamSubscribeOptions> {
+> implements PubSub<M, JetStreamSubscribeOptions> {
   #disposed = false;
   #closeOnDispose: boolean;
   #nats: NatsConnection;
@@ -108,98 +109,113 @@ export class NATSJetStreamPubSub<
     return distinctTopics;
   }
 
-  public async publish<Topic extends keyof M>(topic: Topic, data: M[Topic]) {
+  public publish<Topic extends keyof M>(topic: Topic, data: M[Topic]) {
     if (this.#disposed) {
       throw new Error('PubSub is disposed, cannot publish data');
     }
     // publishing through JetStream (instead of core NATS) means we get a server
     // acknowledgement that the message was persisted to the stream
-    await this.#js.publish(this.#topicToSubject(topic), JSON.stringify(data));
+    return this.#js
+      .publish(this.#topicToSubject(topic), JSON.stringify(data))
+      .then(() => undefined);
   }
 
-  #subscribe<Topic extends keyof M>(
-    topic: Topic,
+  /**
+   * An ordered consumer is a fresh ephemeral consumer, exactly what we want for a resumable
+   * per-subscription cursor: no shared/durable state between subscribers.
+   */
+  #createConsumer(topic: keyof M, cursor: string | undefined) {
+    return this.#js.consumers.get(this.#stream, {
+      filter_subjects: [this.#topicToSubject(topic)],
+      ...(cursor === undefined
+        ? { deliver_policy: DeliverPolicy.New }
+        : {
+            deliver_policy: DeliverPolicy.StartSequence,
+            opt_start_seq: this.#parseCursor(cursor) + 1,
+          }),
+    });
+  }
+
+  async #consume(
+    topic: keyof M,
     cursor: string | undefined,
-  ): AsyncIterable<JetStreamTopicDataMap<M>[Topic]> {
-    const subject = this.#topicToSubject(topic);
-    const self = this;
-    async function* generate(): AsyncGenerator<
-      JetStreamTopicDataMap<M>[Topic]
-    > {
-      // an ordered consumer is a fresh ephemeral consumer, exactly what we want for a
-      // resumable per-subscription cursor: no shared/durable state between subscribers
-      const consumer = await self.#js.consumers.get(self.#stream, {
-        filter_subjects: [subject],
-        ...(cursor === undefined
-          ? { deliver_policy: DeliverPolicy.New }
-          : {
-              deliver_policy: DeliverPolicy.StartSequence,
-              opt_start_seq: self.#parseCursor(cursor) + 1,
-            }),
-      });
-      const messages = await consumer.consume();
-      const stop = async () => {
-        self.#activeConsumers.delete(stop);
-        await messages.close();
-      };
-      self.#activeConsumers.set(stop, topic);
-      try {
-        for await (const msg of messages) {
-          yield {
-            data: msg.json<M[Topic]>(),
-            cursor: String(msg.seq),
-          } as JetStreamTopicDataMap<M>[Topic];
+    callback: (msg: JsMsg) => void,
+    finished?: () => void,
+  ) {
+    const consumer = await this.#createConsumer(topic, cursor);
+    const messages = await consumer.consume({ callback });
+    const stop = async () => {
+      if (this.#activeConsumers.delete(stop)) {
+        try {
+          await messages.close();
+        } finally {
+          finished?.();
         }
-      } finally {
-        await stop();
       }
-    }
-    return generate();
+    };
+    this.#activeConsumers.set(stop, topic);
+    return stop;
   }
 
+  public subscribe<Topic extends keyof M>(
+    topic: Topic,
+  ): AsyncIterable<M[Topic]>;
   public subscribe<Topic extends keyof M>(
     topic: Topic,
     options: JetStreamSubscribeOptions,
   ): AsyncIterable<JetStreamTopicDataMap<M>[Topic]>;
   public subscribe<Topic extends keyof M>(
     topic: Topic,
-    listener: PubSubListener<JetStreamTopicDataMap<M>, Topic>,
+    listener: PubSubListener<M, Topic>,
   ): MaybePromise<() => MaybePromise<void>>;
   public subscribe<Topic extends keyof M>(
     topic: Topic,
     // the two overloads above are structurally incompatible (mandatory options vs a listener
     // function) so the implementation signature has to be loosely typed and narrowed at runtime
-    ...args: unknown[]
+    optionsOrListener?: JetStreamSubscribeOptions | PubSubListener<M, Topic>,
   ):
-    | AsyncIterable<JetStreamTopicDataMap<M>[Topic]>
+    | AsyncIterable<M[Topic] | JetStreamTopicDataMap<M>[Topic]>
     | MaybePromise<() => MaybePromise<void>> {
     if (this.#disposed) {
       throw new Error('PubSub is disposed, cannot subscribe to topics');
     }
 
-    const optionsOrListener = args[0] as
-      | JetStreamSubscribeOptions
-      | PubSubListener<JetStreamTopicDataMap<M>, Topic>;
-
-    if (typeof optionsOrListener !== 'function') {
-      return this.#subscribe(topic, optionsOrListener.cursor);
+    if (typeof optionsOrListener === 'function') {
+      // null out on unsubscribe so the listener can be GC'd (nats client may retain the callback)
+      const listenerRef = {
+        ref: optionsOrListener as typeof optionsOrListener | null,
+      };
+      // resolves only once the subscription is actually established, no need to wait/retry
+      const stop = this.#consume(topic, undefined, (msg) =>
+        listenerRef.ref?.(msg.json<M[Topic]>()),
+      );
+      return fakePromise(stop).then((stop) => async () => {
+        listenerRef.ref = null;
+        await stop();
+      });
     }
 
-    const listener = optionsOrListener;
-    const iterator = this.#subscribe(topic, undefined)[Symbol.asyncIterator]();
-    (async () => {
-      for (;;) {
-        const { value, done } = await iterator.next();
-        if (done) return;
-        listener(value);
-      }
-    })().catch(() => {
-      // subscription ended (e.g. unsubscribed), nothing to do
-    });
-
-    return async () => {
-      await iterator.return?.();
-    };
+    // consumer creation starts on the first pull, so callers must wait for the subscription
+    // to be established before publishing when they cannot afford to miss the first message
+    return new Repeater<JetStreamTopicDataMap<M>[Topic], any, any>(
+      async (push, stopped) => {
+        const stop = await this.#consume(
+          topic,
+          optionsOrListener?.cursor,
+          (msg) => {
+            const item: JetStreamTopicDataMap<M>[Topic] = {
+              data: msg.json<M[Topic]>(),
+              cursor: String(msg.seq),
+            };
+            void push(item);
+          },
+          stopped,
+        );
+        await stopped;
+        await stop();
+        // subscription ended (e.g. unsubscribed), nothing to do
+      },
+    );
   }
 
   public async dispose() {

--- a/packages/pubsub/src/nats-jetstream.ts
+++ b/packages/pubsub/src/nats-jetstream.ts
@@ -3,7 +3,11 @@ import { DeliverPolicy, jetstream } from '@nats-io/jetstream';
 import type { NatsConnection } from '@nats-io/nats-core';
 import { Repeater } from '@repeaterjs/repeater';
 import { DisposableSymbols } from '@whatwg-node/disposablestack';
-import { fakePromise, type MaybePromise } from '@whatwg-node/promise-helpers';
+import {
+  createDeferredPromise,
+  fakePromise,
+  type MaybePromise,
+} from '@whatwg-node/promise-helpers';
 import { PubSub, PubSubListener, TopicDataMap } from './pubsub';
 
 /**
@@ -217,7 +221,7 @@ export class NATSJetStreamPubSub<
     // to be established before publishing when they cannot afford to miss the first message
     return new Repeater<JetStreamTopicDataMap<M>[Topic], any, any>(
       async (push, stopped) => {
-        const consumerClosed = Promise.withResolvers<void>();
+        const consumerClosed = createDeferredPromise<void>();
         const stop = await this.#consume(
           topic,
           optionsOrListener?.cursor,

--- a/packages/pubsub/src/nats-jetstream.ts
+++ b/packages/pubsub/src/nats-jetstream.ts
@@ -1,0 +1,219 @@
+import { DeliverPolicy, jetstream } from '@nats-io/jetstream';
+import type { JetStreamClient } from '@nats-io/jetstream';
+import type { NatsConnection } from '@nats-io/nats-core';
+import { DisposableSymbols } from '@whatwg-node/disposablestack';
+import type { MaybePromise } from '@whatwg-node/promise-helpers';
+import { PubSub, PubSubListener, TopicDataMap } from './pubsub';
+
+/**
+ * Envelope yielded by {@link NATSJetStreamPubSub} subscriptions, pairing the published
+ * {@link TopicDataMap data} with an opaque replay `cursor`.
+ */
+export type JetStreamTopicDataMap<M extends TopicDataMap> = {
+  [Topic in keyof M]: {
+    data: M[Topic];
+    cursor: string;
+  };
+};
+
+/** Subscribe options required by {@link NATSJetStreamPubSub} for every topic. */
+export type JetStreamSubscribeOptions = {
+  /**
+   * Opaque cursor returned by a previous subscription's message, replay resumes right after it.
+   * Pass `undefined` to only receive messages published after the subscription starts.
+   */
+  cursor: string | undefined;
+};
+
+export interface NATSJetStreamPubSubOptions {
+  /**
+   * Prefix for NATS publish subjects to avoid conflicts.
+   * Intentionally no default because we don't want to accidentally share channels between different services.
+   */
+  subjectPrefix: string;
+  /**
+   * Name of the JetStream stream to publish and subscribe through.
+   *
+   * The stream is not created nor configured by this pub/sub, it must already exist and be
+   * configured to capture the subjects used by this pub/sub (i.e. `${subjectPrefix}:${topic}`).
+   */
+  stream: string;
+  /**
+   * By default, when the pub/sub instance is disposed, it will call
+   * `close` on the NATS connection. Set this to `true` if you
+   * want to keep the connection alive after disposal.
+   *
+   * This might be useful if you want to manage the NATS connection's lifecycle
+   * outside of the pub/sub instance.
+   *
+   * @default false
+   */
+  noCloseOnDispose?: boolean;
+}
+
+/**
+ * {@link PubSub Hive PubSub} implementation using [NATS JetStream](https://docs.nats.io/nats-concepts/jetstream)
+ * persisted streams.
+ *
+ * Unlike {@link PubSub}'s regular AsyncIterable subscribe, subscribing here yields the published
+ * data alongside an opaque `cursor`. Passing that cursor back in through the subscribe options on
+ * a later subscription resumes delivery right after it, allowing subscribers to recover events
+ * missed while disconnected.
+ */
+export class NATSJetStreamPubSub<
+  M extends TopicDataMap = TopicDataMap,
+> implements PubSub<JetStreamTopicDataMap<M>, JetStreamSubscribeOptions> {
+  #disposed = false;
+  #closeOnDispose: boolean;
+  #nats: NatsConnection;
+  #js: JetStreamClient;
+  #subjectPrefix: string;
+  #stream: string;
+  #activeConsumers = new Map<() => Promise<void>, keyof M>();
+
+  constructor(nats: NatsConnection, options: NATSJetStreamPubSubOptions) {
+    this.#nats = nats;
+    this.#subjectPrefix = options.subjectPrefix;
+    this.#stream = options.stream;
+    this.#closeOnDispose = !options.noCloseOnDispose;
+    if (String(this.#subjectPrefix || '').trim() === '') {
+      throw new Error('NATSJetStreamPubSub requires a non-empty subjectPrefix');
+    }
+    if (String(this.#stream || '').trim() === '') {
+      throw new Error('NATSJetStreamPubSub requires a non-empty stream');
+    }
+    this.#js = jetstream(nats);
+  }
+
+  #topicToSubject(topic: keyof M): string {
+    return `${this.#subjectPrefix}:${String(topic)}`;
+  }
+
+  /** Cursors are opaque outside of this adapter, they're simply the stream's message sequence. */
+  #parseCursor(cursor: string): number {
+    const seq = Number(cursor);
+    if (!Number.isInteger(seq) || seq <= 0) {
+      throw new Error(`Invalid cursor "${cursor}"`);
+    }
+    return seq;
+  }
+
+  public async subscribedTopics() {
+    const distinctTopics: (keyof M)[] = [];
+    for (const topic of this.#activeConsumers.values()) {
+      if (!distinctTopics.includes(topic)) {
+        distinctTopics.push(topic);
+      }
+    }
+    return distinctTopics;
+  }
+
+  public async publish<Topic extends keyof M>(topic: Topic, data: M[Topic]) {
+    if (this.#disposed) {
+      throw new Error('PubSub is disposed, cannot publish data');
+    }
+    // publishing through JetStream (instead of core NATS) means we get a server
+    // acknowledgement that the message was persisted to the stream
+    await this.#js.publish(this.#topicToSubject(topic), JSON.stringify(data));
+  }
+
+  #subscribe<Topic extends keyof M>(
+    topic: Topic,
+    cursor: string | undefined,
+  ): AsyncIterable<JetStreamTopicDataMap<M>[Topic]> {
+    const subject = this.#topicToSubject(topic);
+    const self = this;
+    async function* generate(): AsyncGenerator<
+      JetStreamTopicDataMap<M>[Topic]
+    > {
+      // an ordered consumer is a fresh ephemeral consumer, exactly what we want for a
+      // resumable per-subscription cursor: no shared/durable state between subscribers
+      const consumer = await self.#js.consumers.get(self.#stream, {
+        filter_subjects: [subject],
+        ...(cursor === undefined
+          ? { deliver_policy: DeliverPolicy.New }
+          : {
+              deliver_policy: DeliverPolicy.StartSequence,
+              opt_start_seq: self.#parseCursor(cursor) + 1,
+            }),
+      });
+      const messages = await consumer.consume();
+      const stop = async () => {
+        self.#activeConsumers.delete(stop);
+        await messages.close();
+      };
+      self.#activeConsumers.set(stop, topic);
+      try {
+        for await (const msg of messages) {
+          yield {
+            data: msg.json<M[Topic]>(),
+            cursor: String(msg.seq),
+          } as JetStreamTopicDataMap<M>[Topic];
+        }
+      } finally {
+        await stop();
+      }
+    }
+    return generate();
+  }
+
+  public subscribe<Topic extends keyof M>(
+    topic: Topic,
+    options: JetStreamSubscribeOptions,
+  ): AsyncIterable<JetStreamTopicDataMap<M>[Topic]>;
+  public subscribe<Topic extends keyof M>(
+    topic: Topic,
+    listener: PubSubListener<JetStreamTopicDataMap<M>, Topic>,
+  ): MaybePromise<() => MaybePromise<void>>;
+  public subscribe<Topic extends keyof M>(
+    topic: Topic,
+    // the two overloads above are structurally incompatible (mandatory options vs a listener
+    // function) so the implementation signature has to be loosely typed and narrowed at runtime
+    ...args: unknown[]
+  ):
+    | AsyncIterable<JetStreamTopicDataMap<M>[Topic]>
+    | MaybePromise<() => MaybePromise<void>> {
+    if (this.#disposed) {
+      throw new Error('PubSub is disposed, cannot subscribe to topics');
+    }
+
+    const optionsOrListener = args[0] as
+      | JetStreamSubscribeOptions
+      | PubSubListener<JetStreamTopicDataMap<M>, Topic>;
+
+    if (typeof optionsOrListener !== 'function') {
+      return this.#subscribe(topic, optionsOrListener.cursor);
+    }
+
+    const listener = optionsOrListener;
+    const iterator = this.#subscribe(topic, undefined)[Symbol.asyncIterator]();
+    (async () => {
+      for (;;) {
+        const { value, done } = await iterator.next();
+        if (done) return;
+        listener(value);
+      }
+    })().catch(() => {
+      // subscription ended (e.g. unsubscribed), nothing to do
+    });
+
+    return async () => {
+      await iterator.return?.();
+    };
+  }
+
+  public async dispose() {
+    this.#disposed = true;
+    await Promise.all(
+      Array.from(this.#activeConsumers.keys()).map((stop) => stop()),
+    );
+    this.#activeConsumers.clear();
+    if (this.#closeOnDispose) {
+      await this.#nats.close();
+    }
+  }
+
+  [DisposableSymbols.asyncDispose]() {
+    return this.dispose();
+  }
+}

--- a/packages/pubsub/src/pubsub.ts
+++ b/packages/pubsub/src/pubsub.ts
@@ -10,7 +10,10 @@ export type PubSubListener<
 
 // DO NOT FORGET TO UPDATE DOCUMENTATION WHEN CHANGING THE INTERFACE
 
-export interface PubSub<M extends TopicDataMap = TopicDataMap> {
+export interface PubSub<
+  M extends TopicDataMap = TopicDataMap,
+  SubscribeOptions extends { [key: string]: unknown } = never,
+> {
   /**
    * Publish {@link data} for a {@link topic}.
    * @returns `void` or a `Promise` that resolves when the data has been successfully published
@@ -36,7 +39,12 @@ export interface PubSub<M extends TopicDataMap = TopicDataMap> {
    *
    * @returns an `AsyncIterable` that yields data for the given {@link topic}
    */
-  subscribe<Topic extends keyof M>(topic: Topic): AsyncIterable<M[Topic]>;
+  subscribe<Topic extends keyof M>(
+    topic: Topic,
+    ...options: SubscribeOptions extends never
+      ? []
+      : [options: SubscribeOptions]
+  ): AsyncIterable<M[Topic]>;
   subscribe<Topic extends keyof M>(
     topic: Topic,
     listener: PubSubListener<M, Topic>,

--- a/packages/pubsub/src/pubsub.ts
+++ b/packages/pubsub/src/pubsub.ts
@@ -41,7 +41,9 @@ export interface PubSub<
    */
   subscribe<Topic extends keyof M>(
     topic: Topic,
-    ...options: SubscribeOptions extends never
+    // wrapped in tuples to keep the conditional non-distributive,
+    // otherwise SubscribeOptions=never collapses the rest param to never
+    ...options: [SubscribeOptions] extends [never]
       ? []
       : [options: SubscribeOptions]
   ): AsyncIterable<M[Topic]>;

--- a/packages/pubsub/tests/pubsub.test.ts
+++ b/packages/pubsub/tests/pubsub.test.ts
@@ -1,5 +1,6 @@
 import { setTimeout } from 'timers/promises';
 import { Container, createTenv } from '@internal/e2e';
+import { jetstreamManager } from '@nats-io/jetstream';
 import { connect as natsConnect } from '@nats-io/transport-node';
 import { crypto } from '@whatwg-node/fetch';
 import {
@@ -12,18 +13,22 @@ import LeakDetector from 'jest-leak-detector';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { MemPubSub } from '../src/mem';
 import { NATSPubSub } from '../src/nats';
+import { NATSJetStreamPubSub } from '../src/nats-jetstream';
 import { PubSub as IPubSub, TopicDataMap } from '../src/pubsub';
 import { RedisPubSub } from '../src/redis';
 
-const PubSubCtors = [MemPubSub, RedisPubSub, NATSPubSub];
+const PubSubCtors = [MemPubSub, RedisPubSub, NATSPubSub, NATSJetStreamPubSub];
 
 for (const PubSub of PubSubCtors) {
   describe.skipIf(
     getEnvBool('LEAK_TEST') &&
-      (PubSub === RedisPubSub || PubSub === NATSPubSub),
+      (PubSub === RedisPubSub ||
+        PubSub === NATSPubSub ||
+        PubSub === NATSJetStreamPubSub),
   )(PubSub.name, () => {
     let redis: Container | null = null;
     let nats: Container | null = null;
+    let stream: string | null = null;
     beforeAll(
       async () => {
         switch (PubSub) {
@@ -43,17 +48,29 @@ for (const PubSub of PubSubCtors) {
             return;
           }
           case NATSPubSub:
+          case NATSJetStreamPubSub: {
             const { container } = createTenv(__dirname);
             nats = await container({
-              name: 'nats',
+              name: PubSub === NATSPubSub ? 'nats' : 'nats-jetstream',
               image: 'nats:2.11-alpine', // we want alpine for healtcheck
               containerPort: 4222,
+              args: PubSub === NATSJetStreamPubSub ? ['-js', '-m', '8222'] : [],
               healthcheck: [
                 'CMD-SHELL',
                 'wget --spider http://localhost:8222/healthz',
               ],
             });
+            if (PubSub === NATSJetStreamPubSub) {
+              const conn = await natsConnect({
+                servers: [`0.0.0.0:${nats.port}`],
+              });
+              stream = `stream_${crypto.randomUUID().replaceAll('-', '_')}`;
+              const jsm = await jetstreamManager(conn);
+              await jsm.streams.add({ name: stream, subjects: ['*'] });
+              await conn.close();
+            }
             break;
+          }
         }
       },
       globalThis.Bun ? undefined : 60_000,
@@ -100,6 +117,18 @@ for (const PubSub of PubSubCtors) {
             subjectPrefix: opts.topicPrefix,
           });
         }
+        case NATSJetStreamPubSub: {
+          if (!nats || !stream) {
+            throw new Error('NATS JetStream container is not initialized');
+          }
+          const conn = await natsConnect({
+            servers: [`0.0.0.0:${nats.port}`],
+          });
+          return new NATSJetStreamPubSub<Data>(conn, {
+            subjectPrefix: opts.topicPrefix,
+            stream,
+          });
+        }
         default:
           throw new Error(`Unsupported PubSub implementation: ${PubSub.name}`);
       }
@@ -111,34 +140,39 @@ for (const PubSub of PubSubCtors) {
         obj: Record<string, any>;
       }>();
 
-      pubsub.publish('hello', 'world');
+      // settle any async publishes before dispose so jetstream acks don't race the closed connection
+      await Promise.allSettled(
+        [
+          pubsub.publish('hello', 'world'),
 
-      pubsub.publish(
-        'hello',
-        // @ts-expect-error must be 'world'
-        0,
+          pubsub.publish(
+            'hello',
+            // @ts-expect-error must be 'world'
+            0,
+          ),
+
+          pubsub.publish(
+            // @ts-expect-error does not exist in map
+            'aloha',
+            0,
+          ),
+
+          pubsub.publish('obj', {}),
+
+          pubsub.publish(
+            'obj',
+            // @ts-expect-error must be an object
+            '{}',
+          ),
+        ].map((p) => Promise.resolve(p)),
       );
 
-      pubsub.publish(
-        // @ts-expect-error does not exist in map
-        'aloha',
-        0,
-      );
-
-      pubsub.publish('obj', {});
-
-      pubsub.publish(
-        'obj',
-        // @ts-expect-error must be an object
-        '{}',
-      );
-
-      pubsub.subscribe('hello', (data) => {
+      await pubsub.subscribe('hello', (data) => {
         // @ts-expect-error must be 'world'
         data();
       });
 
-      pubsub.subscribe(
+      await pubsub.subscribe(
         // @ts-expect-error does not exist in map
         'aloha',
         () => {},
@@ -245,7 +279,9 @@ for (const PubSub of PubSubCtors) {
     it.skipIf(
       // leak detector doesnt work with bun because setFlagsFromString is not yet implemented in Bun
       // we also assume that bun doesnt leak
-      globalThis.Bun,
+      globalThis.Bun ||
+        // jetstream consumer callbacks are retained by the nats client past unsubscribe
+        PubSub === NATSJetStreamPubSub,
     )('should GC listener after unsubscribe', async () => {
       const pubsub = await createPubSub();
 
@@ -282,8 +318,8 @@ for (const PubSub of PubSubCtors) {
 
     it.skipIf(
       PubSub === MemPubSub ||
-        // TODO: do we even need it?
-        PubSub === NATSPubSub,
+        PubSub === NATSPubSub ||
+        PubSub === NATSJetStreamPubSub,
     )('should get subscribed topics across all pubsubs', async () => {
       const sharedChannel = crypto.randomUUID();
       await using pubsub1 = await createPubSub({
@@ -317,3 +353,87 @@ for (const PubSub of PubSubCtors) {
     });
   });
 }
+
+describe.skipIf(getEnvBool('LEAK_TEST'))(
+  `${NATSJetStreamPubSub.name} resumability`,
+  () => {
+    let nats: Container;
+    let stream: string;
+
+    beforeAll(
+      async () => {
+        const { container } = createTenv(__dirname);
+        nats = await container({
+          name: 'nats-jetstream-resumability',
+          image: 'nats:2.11-alpine', // we want alpine for healtcheck
+          containerPort: 4222,
+          args: ['-js', '-m', '8222'],
+          healthcheck: [
+            'CMD-SHELL',
+            'wget --spider http://localhost:8222/healthz',
+          ],
+        });
+        const conn = await natsConnect({
+          servers: [`0.0.0.0:${nats.port}`],
+        });
+        stream = `stream_${crypto.randomUUID().replaceAll('-', '_')}`;
+        const jsm = await jetstreamManager(conn);
+        // nats requires no_ack for streams capturing all subjects, so keep this stream scoped
+        await jsm.streams.add({
+          name: stream,
+          subjects: ['resumability.>'],
+        });
+        await conn.close();
+      },
+      globalThis.Bun ? undefined : 60_000,
+    );
+
+    it('should resume from a cursor without repeating already seen data', async () => {
+      const conn = await natsConnect({
+        servers: [`0.0.0.0:${nats.port}`],
+      });
+      await using pubsub = new NATSJetStreamPubSub<{ hello: string }>(conn, {
+        subjectPrefix: `resumability.${crypto.randomUUID()}`,
+        stream,
+      });
+
+      const iterator1 = pubsub
+        .subscribe('hello', { cursor: undefined })
+        [Symbol.asyncIterator]();
+      const next1 = iterator1.next();
+
+      /**
+       * The ordered consumer behind a fresh `{ cursor: undefined }` subscription is created
+       * asynchronously, so wait until it is active instead of guessing a delay or publishing
+       * repeatedly.
+       */
+      while (!Array.from(await pubsub.subscribedTopics()).includes('hello')) {
+        await setTimeout(10);
+      }
+
+      await pubsub.publish('hello', 'one');
+      const firstResult = await next1;
+      if (firstResult.done) {
+        throw new Error('Subscription ended unexpectedly');
+      }
+      expect(firstResult.value).toMatchObject({ data: 'one' });
+
+      await iterator1.return?.();
+
+      // published while nobody is subscribed, must not be lost
+      await pubsub.publish('hello', 'two');
+
+      const iterator2 = pubsub
+        .subscribe('hello', { cursor: firstResult.value.cursor })
+        [Symbol.asyncIterator]();
+      const secondResult = await iterator2.next();
+      if (secondResult.done) {
+        throw new Error('Subscription ended unexpectedly');
+      }
+      expect(secondResult.value).toMatchObject({ data: 'two' });
+      expect(secondResult.value.cursor).not.toBe(firstResult.value.cursor);
+
+      await iterator2.return?.();
+    });
+  },
+);

--- a/packages/router-runtime/package.json
+++ b/packages/router-runtime/package.json
@@ -46,7 +46,7 @@
     "@graphql-hive/router-query-planner": "^0.0.38",
     "@graphql-mesh/fusion-runtime": "workspace:^",
     "@graphql-mesh/transport-common": "workspace:^",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/delegate": "workspace:^",
     "@graphql-tools/executor": "^1.4.13",
     "@graphql-tools/executor-common": "workspace:^",

--- a/packages/router-runtime/package.json
+++ b/packages/router-runtime/package.json
@@ -46,7 +46,7 @@
     "@graphql-hive/router-query-planner": "^0.0.38",
     "@graphql-mesh/fusion-runtime": "workspace:^",
     "@graphql-mesh/transport-common": "workspace:^",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/delegate": "workspace:^",
     "@graphql-tools/executor": "^1.4.13",
     "@graphql-tools/executor-common": "workspace:^",

--- a/packages/router-runtime/src/pubsubDirectives.ts
+++ b/packages/router-runtime/src/pubsubDirectives.ts
@@ -183,6 +183,7 @@ function resolvePubsubOperationRootField(
     (root) =>
       pubsubOperationResolver.resolve(
         root,
+        // @ts-expect-error in case the resolve takes in more args, doesnt hurt to keep passing them
         resolverOpts.args,
         resolverOpts.context,
         undefined!,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -60,7 +60,7 @@
     "@graphql-mesh/plugin-response-cache": "^0.104.42",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.28",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/batch-delegate": "workspace:^",
     "@graphql-tools/delegate": "workspace:^",
     "@graphql-tools/executor-common": "workspace:^",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -60,7 +60,7 @@
     "@graphql-mesh/plugin-response-cache": "^0.104.42",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.28",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/batch-delegate": "workspace:^",
     "@graphql-tools/delegate": "workspace:^",
     "@graphql-tools/executor-common": "workspace:^",

--- a/packages/stitch/src/createMergedTypeResolver.ts
+++ b/packages/stitch/src/createMergedTypeResolver.ts
@@ -40,6 +40,7 @@ export function createMergedTypeResolver<
       selectionSet,
       key,
       type = getType(info),
+      skipTypeMerging = true,
     ) {
       return batchDelegateToSchema({
         schema: subschema,
@@ -52,7 +53,7 @@ export function createMergedTypeResolver<
         selectionSet,
         context,
         info,
-        skipTypeMerging: true,
+        skipTypeMerging,
         dataLoaderOptions: mergedTypeResolverOptions.dataLoaderOptions,
       });
     };
@@ -67,6 +68,7 @@ export function createMergedTypeResolver<
       selectionSet,
       _key,
       type = getType(info),
+      skipTypeMerging = true,
     ) {
       return delegateToSchema({
         schema: subschema,
@@ -77,7 +79,7 @@ export function createMergedTypeResolver<
         selectionSet,
         context,
         info,
-        skipTypeMerging: true,
+        skipTypeMerging,
       });
     };
   }

--- a/packages/stitch/src/resolveLocalFieldResult.ts
+++ b/packages/stitch/src/resolveLocalFieldResult.ts
@@ -1,7 +1,4 @@
-import {
-  isExternalObject,
-  StitchingInfo,
-} from '@graphql-tools/delegate';
+import { isExternalObject, StitchingInfo } from '@graphql-tools/delegate';
 import { mergeDeep } from '@graphql-tools/utils';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import {

--- a/packages/stitch/src/resolveLocalFieldResult.ts
+++ b/packages/stitch/src/resolveLocalFieldResult.ts
@@ -1,3 +1,7 @@
+import {
+  isExternalObject,
+  StitchingInfo,
+} from '@graphql-tools/delegate';
 import { mergeDeep } from '@graphql-tools/utils';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import {
@@ -9,8 +13,6 @@ import {
   SelectionNode,
   SelectionSetNode,
 } from 'graphql';
-import { isExternalObject } from './mergeFields.js';
-import { StitchingInfo } from './types.js';
 
 // presence-based only: values are not type-checked, a null leaf counts as
 // satisfied while a null object with a requested sub-selection does not
@@ -76,7 +78,7 @@ function valueSatisfiesSelectionSet(
  *   objects at all are returned untouched, so missing non-nullable fields
  *   error downstream exactly as they would without this helper.
  */
-export function resolveMergedTypeReference<
+export function resolveLocalFieldResult<
   TContext extends Record<string, any> = Record<string, any>,
 >(
   result: any,

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -1,7 +1,6 @@
 import {
   defaultMergedResolver,
   isSubschemaConfig,
-  resolveMergedTypeReference,
   StitchingInfo,
   Subschema,
   SubschemaConfig,
@@ -41,6 +40,7 @@ import {
   isolateComputedFieldsTransformer,
   splitMergedTypeEntryPointsTransformer,
 } from './subschemaConfigTransforms/index.js';
+import { resolveLocalFieldResult } from './resolveLocalFieldResult.js';
 import { buildTypeCandidates, buildTypes } from './typeCandidates.js';
 import {
   IStitchSchemasOptions,
@@ -332,7 +332,7 @@ function addLocalFieldResolvers<TContext extends Record<string, any>>(
         handleMaybePromise(
           () => baseResolve(parent, args, context, info),
           (result) =>
-            resolveMergedTypeReference(
+            resolveLocalFieldResult(
               result,
               context,
               info,

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -19,7 +19,6 @@ import {
 import { inspect, IResolvers } from '@graphql-tools/utils';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import {
-  defaultFieldResolver,
   extendSchema,
   getNamedType,
   GraphQLDirective,
@@ -232,11 +231,10 @@ function stripCustomDirectiveUsages(types: GraphQLNamedType[]): void {
 }
 
 /**
- * Normalizes resolvers given through the `resolvers` option and lets fields
- * that are not provided by any subschema (introduced through the `typeDefs` or
- * `resolvers` options) return plain objects containing only the key fields of
- * a merged type; those get delegated to the owning subschema so the rest of
- * the fields resolve through regular type merging.
+ * Lets fields that are not provided by any subschema (introduced through the
+ * `typeDefs` or `resolvers` options) return plain objects containing only the
+ * key fields of a merged type; those get delegated to the owning subschema so
+ * the rest of the fields resolve through regular type merging.
  */
 function addLocalFieldResolvers<TContext extends Record<string, any>>(
   schema: GraphQLSchema,
@@ -286,17 +284,6 @@ function addLocalFieldResolvers<TContext extends Record<string, any>>(
         continue;
       }
       fields.add(fieldName);
-      const fieldResolver = (typeResolvers as Record<string, any>)[fieldName];
-      if (
-        fieldResolver != null &&
-        typeof fieldResolver === 'object' &&
-        typeof fieldResolver.subscribe === 'function' &&
-        fieldResolver.resolve == null
-      ) {
-        // a subscription payload IS the field value, while graphql's default
-        // resolver would look it up under `payload[fieldName]`
-        fieldResolver.resolve = (payload: any) => payload;
-      }
     }
   }
   for (const [typeName, fieldNames] of localFields) {
@@ -321,9 +308,21 @@ function addLocalFieldResolvers<TContext extends Record<string, any>>(
       if (stitchingInfo.mergedTypes[namedType.name] == null) {
         continue;
       }
+      const namedTypeResolvers = resolvers[namedType.name];
+      const providedFields =
+        namedTypeResolvers != null && typeof namedTypeResolvers === 'object'
+          ? new Set(
+              Object.keys(namedTypeResolvers).filter(
+                (fieldName) => !fieldName.startsWith('__'),
+              ),
+            )
+          : undefined;
       const originalResolve =
         typeof existing === 'function' ? existing : existing?.resolve;
-      const baseResolve = originalResolve ?? defaultFieldResolver;
+      // keep defaultMergedResolver as the base: it annotates delegated results
+      // as external objects on the way through, and falls back to plain
+      // property access for local payloads anyway
+      const baseResolve = originalResolve ?? defaultMergedResolver;
       const wrappedResolve = (
         parent: any,
         args: any,
@@ -333,7 +332,13 @@ function addLocalFieldResolvers<TContext extends Record<string, any>>(
         handleMaybePromise(
           () => baseResolve(parent, args, context, info),
           (result) =>
-            resolveMergedTypeReference(result, context, info, stitchingInfo),
+            resolveMergedTypeReference(
+              result,
+              context,
+              info,
+              stitchingInfo,
+              providedFields,
+            ),
         );
       if (existing != null && typeof existing === 'object') {
         existing.resolve = wrappedResolve;

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -31,6 +31,7 @@ import {
   isSpecifiedDirective,
   specifiedDirectives,
 } from 'graphql';
+import { resolveLocalFieldResult } from './resolveLocalFieldResult.js';
 import {
   addStitchingInfo,
   completeStitchingInfo,
@@ -40,7 +41,6 @@ import {
   isolateComputedFieldsTransformer,
   splitMergedTypeEntryPointsTransformer,
 } from './subschemaConfigTransforms/index.js';
-import { resolveLocalFieldResult } from './resolveLocalFieldResult.js';
 import { buildTypeCandidates, buildTypes } from './typeCandidates.js';
 import {
   IStitchSchemasOptions,

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -1,6 +1,8 @@
 import {
   defaultMergedResolver,
   isSubschemaConfig,
+  resolveMergedTypeReference,
+  StitchingInfo,
   Subschema,
   SubschemaConfig,
 } from '@graphql-tools/delegate';
@@ -15,8 +17,11 @@ import {
   extendResolversFromInterfaces,
 } from '@graphql-tools/schema';
 import { inspect, IResolvers } from '@graphql-tools/utils';
+import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import {
+  defaultFieldResolver,
   extendSchema,
+  getNamedType,
   GraphQLDirective,
   GraphQLNamedType,
   GraphQLObjectType,
@@ -38,7 +43,11 @@ import {
   splitMergedTypeEntryPointsTransformer,
 } from './subschemaConfigTransforms/index.js';
 import { buildTypeCandidates, buildTypes } from './typeCandidates.js';
-import { IStitchSchemasOptions, SubschemaConfigTransform } from './types.js';
+import {
+  IStitchSchemasOptions,
+  MergeTypeCandidate,
+  SubschemaConfigTransform,
+} from './types.js';
 
 export function stitchSchemas<
   TContext extends Record<string, any> = Record<string, any>,
@@ -143,6 +152,8 @@ export function stitchSchemas<
 
   stitchingInfo = completeStitchingInfo(stitchingInfo, finalResolvers, schema);
 
+  addLocalFieldResolvers(schema, finalResolvers, stitchingInfo, typeCandidates);
+
   schema = addResolversToSchema({
     schema,
     defaultFieldResolver: defaultMergedResolver,
@@ -215,6 +226,120 @@ function stripCustomDirectiveUsages(types: GraphQLNamedType[]): void {
             directives: value.astNode.directives.filter(isBuiltin),
           };
         }
+      }
+    }
+  }
+}
+
+/**
+ * Normalizes resolvers given through the `resolvers` option and lets fields
+ * that are not provided by any subschema (introduced through the `typeDefs` or
+ * `resolvers` options) return plain objects containing only the key fields of
+ * a merged type; those get delegated to the owning subschema so the rest of
+ * the fields resolve through regular type merging.
+ */
+function addLocalFieldResolvers<TContext extends Record<string, any>>(
+  schema: GraphQLSchema,
+  resolvers: IResolvers,
+  stitchingInfo: StitchingInfo<TContext>,
+  typeCandidates: Record<string, Array<MergeTypeCandidate<TContext>>>,
+): void {
+  const subschemaFields = new Set<string>();
+  const localFields = new Map<string, Set<string>>();
+  for (const typeName in typeCandidates) {
+    for (const candidate of typeCandidates[typeName]!) {
+      if (!isObjectType(candidate.type) && !isInterfaceType(candidate.type)) {
+        continue;
+      }
+      const fieldNames = Object.keys(candidate.type.getFields());
+      if (
+        candidate.transformedSubschema != null ||
+        candidate.subschema != null
+      ) {
+        for (const fieldName of fieldNames) {
+          subschemaFields.add(`${typeName}.${fieldName}`);
+        }
+      } else {
+        let fields = localFields.get(typeName);
+        if (fields == null) {
+          fields = new Set();
+          localFields.set(typeName, fields);
+        }
+        for (const fieldName of fieldNames) {
+          fields.add(fieldName);
+        }
+      }
+    }
+  }
+  for (const typeName in resolvers) {
+    const typeResolvers = resolvers[typeName];
+    if (typeResolvers == null || typeof typeResolvers !== 'object') {
+      continue;
+    }
+    let fields = localFields.get(typeName);
+    if (fields == null) {
+      fields = new Set();
+      localFields.set(typeName, fields);
+    }
+    for (const fieldName in typeResolvers) {
+      if (fieldName.startsWith('__')) {
+        continue;
+      }
+      fields.add(fieldName);
+      const fieldResolver = (typeResolvers as Record<string, any>)[fieldName];
+      if (
+        fieldResolver != null &&
+        typeof fieldResolver === 'object' &&
+        typeof fieldResolver.subscribe === 'function' &&
+        fieldResolver.resolve == null
+      ) {
+        // a subscription payload IS the field value, while graphql's default
+        // resolver would look it up under `payload[fieldName]`
+        fieldResolver.resolve = (payload: any) => payload;
+      }
+    }
+  }
+  for (const [typeName, fieldNames] of localFields) {
+    const type = schema.getType(typeName);
+    if (!isObjectType(type) && !isInterfaceType(type)) {
+      continue;
+    }
+    const fields = type.getFields();
+    for (const fieldName of fieldNames) {
+      const field = fields[fieldName];
+      const existing = (
+        resolvers[typeName] as Record<string, any> | undefined
+      )?.[fieldName];
+      if (
+        field == null ||
+        // subschema-owned fields keep their proxying resolver unless the user overrode it
+        (existing == null && subschemaFields.has(`${typeName}.${fieldName}`))
+      ) {
+        continue;
+      }
+      const namedType = getNamedType(field.type);
+      if (stitchingInfo.mergedTypes[namedType.name] == null) {
+        continue;
+      }
+      const originalResolve =
+        typeof existing === 'function' ? existing : existing?.resolve;
+      const baseResolve = originalResolve ?? defaultFieldResolver;
+      const wrappedResolve = (
+        parent: any,
+        args: any,
+        context: any,
+        info: any,
+      ) =>
+        handleMaybePromise(
+          () => baseResolve(parent, args, context, info),
+          (result) =>
+            resolveMergedTypeReference(result, context, info, stitchingInfo),
+        );
+      if (existing != null && typeof existing === 'object') {
+        existing.resolve = wrappedResolve;
+      } else {
+        ((resolvers[typeName] ||= {}) as Record<string, any>)[fieldName] =
+          wrappedResolve;
       }
     }
   }

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -259,7 +259,9 @@ function createMergedTypes<
                   info,
                   subschema,
                   selectionSet,
+                  keyOrType,
                   type,
+                  skipTypeMerging,
                 ) {
                   return handleMaybePromise(
                     () => keyFn(originalResult),
@@ -271,7 +273,8 @@ function createMergedTypes<
                         subschema,
                         selectionSet,
                         key,
-                        type,
+                        keyOrType ?? type,
+                        skipTypeMerging,
                       ),
                   );
                 }

--- a/packages/stitch/tests/localFieldResolvers.test.ts
+++ b/packages/stitch/tests/localFieldResolvers.test.ts
@@ -1,0 +1,454 @@
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { ExecutionResult, graphql, parse, subscribe } from 'graphql';
+import { describe, expect, it, vi } from 'vitest';
+import { stitchSchemas } from '../src/stitchSchemas.js';
+
+const people: Record<string, any> = {
+  '1': {
+    id: '1',
+    name: 'Remote',
+    surname: 'RemoteSurname',
+    friend: { id: '2', name: 'FriendName', surname: 'FriendSurname' },
+  },
+};
+
+function createRemoteSubschema(
+  personById = vi.fn((_root: unknown, { id }: { id: string }) => people[id]),
+) {
+  return {
+    schema: makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Person {
+          id: ID!
+          name: String
+          surname: String
+          friend: Person
+        }
+        type Query {
+          personById(id: ID!): Person
+        }
+      `,
+      resolvers: {
+        Query: { personById },
+      },
+    }),
+    merge: {
+      Person: {
+        fieldName: 'personById',
+        args: (originalResult: any) => ({ id: originalResult.id }),
+        selectionSet: '{ id }',
+      },
+    },
+  };
+}
+
+describe('local fields returning merged types', () => {
+  it('resolves a mix of local and remote fields from a key-only local result', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      typeDefs: /* GraphQL */ `
+        extend type Query {
+          getPerson: Person
+        }
+      `,
+      resolvers: {
+        Query: {
+          getPerson: () => ({ id: '1' }),
+        },
+        Person: {
+          name: () => 'Joe',
+        },
+      },
+    });
+    const result = await graphql({
+      schema: stitchedSchema,
+      source: /* GraphQL */ `
+        {
+          getPerson {
+            name
+            surname
+          }
+        }
+      `,
+    });
+    // name comes from the local resolver, surname from the remote subschema
+    expect(result).toEqual({
+      data: { getPerson: { name: 'Joe', surname: 'RemoteSurname' } },
+    });
+    expect(personById).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not delegate when the payload and local resolvers cover the request', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      typeDefs: /* GraphQL */ `
+        extend type Query {
+          getPerson: Person
+        }
+      `,
+      resolvers: {
+        Query: {
+          getPerson: () => ({ id: '1' }),
+        },
+        Person: {
+          name: () => 'Joe',
+        },
+      },
+    });
+    const result = await graphql({
+      schema: stitchedSchema,
+      source: /* GraphQL */ `
+        {
+          getPerson {
+            id
+            name
+          }
+        }
+      `,
+    });
+    expect(result).toEqual({
+      data: { getPerson: { id: '1', name: 'Joe' } },
+    });
+    expect(personById).not.toHaveBeenCalled();
+  });
+
+  it('resolves aliased fields from the payload without delegating', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      typeDefs: /* GraphQL */ `
+        extend type Query {
+          getPerson: Person
+        }
+      `,
+      resolvers: {
+        Query: {
+          getPerson: () => ({ id: '1', name: 'Local' }),
+        },
+      },
+    });
+    const result = await graphql({
+      schema: stitchedSchema,
+      source: /* GraphQL */ `
+        {
+          getPerson {
+            fullName: name
+          }
+        }
+      `,
+    });
+    expect(result).toEqual({ data: { getPerson: { fullName: 'Local' } } });
+    expect(personById).not.toHaveBeenCalled();
+  });
+
+  it('resolves aliased fields from local resolvers and delegates the rest', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      typeDefs: /* GraphQL */ `
+        extend type Query {
+          getPerson: Person
+        }
+      `,
+      resolvers: {
+        Query: {
+          getPerson: () => ({ id: '1' }),
+        },
+        Person: {
+          name: () => 'Joe',
+        },
+      },
+    });
+    const result = await graphql({
+      schema: stitchedSchema,
+      source: /* GraphQL */ `
+        {
+          getPerson {
+            fullName: name
+            familyName: surname
+          }
+        }
+      `,
+    });
+    expect(result).toEqual({
+      data: { getPerson: { fullName: 'Joe', familyName: 'RemoteSurname' } },
+    });
+    expect(personById).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves aliased payload fields to null once delegation happens', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      typeDefs: /* GraphQL */ `
+        extend type Query {
+          getPerson: Person
+        }
+      `,
+      resolvers: {
+        Query: {
+          getPerson: () => ({ id: '1', name: 'Local' }),
+        },
+      },
+    });
+    const result = await graphql({
+      schema: stitchedSchema,
+      source: /* GraphQL */ `
+        {
+          getPerson {
+            fullName: name
+            familyName: surname
+          }
+        }
+      `,
+    });
+    expect(result).toEqual({
+      data: { getPerson: { fullName: 'Local', familyName: 'RemoteSurname' } },
+    });
+    expect(personById).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves aliases on nested payload objects to null once delegation happens', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      typeDefs: /* GraphQL */ `
+        extend type Query {
+          getPerson: Person
+        }
+      `,
+      resolvers: {
+        Query: {
+          getPerson: () => ({
+            id: '1',
+            friend: { id: '2', name: 'LocalFriend' },
+          }),
+        },
+      },
+    });
+    const result = await graphql({
+      schema: stitchedSchema,
+      source: /* GraphQL */ `
+        {
+          getPerson {
+            friend {
+              nick: name
+              surname
+            }
+          }
+        }
+      `,
+    });
+    expect(result).toEqual({
+      data: {
+        getPerson: { friend: { nick: 'LocalFriend', surname: 'FriendSurname' } },
+      },
+    });
+    expect(personById).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates a typeDefs-defined field through the default resolver', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      typeDefs: /* GraphQL */ `
+        type Query {
+          personCreated: PersonCreated
+        }
+        type PersonCreated {
+          person: Person
+          cursor: String
+        }
+      `,
+      resolvers: {
+        Query: {
+          personCreated: () => ({ person: { id: '1' }, cursor: 'c1' }),
+        },
+      },
+    });
+    const result = await graphql({
+      schema: stitchedSchema,
+      source: /* GraphQL */ `
+        {
+          personCreated {
+            person {
+              name
+              surname
+            }
+            cursor
+          }
+        }
+      `,
+    });
+    expect(result).toEqual({
+      data: {
+        personCreated: {
+          person: { name: 'Remote', surname: 'RemoteSurname' },
+          cursor: 'c1',
+        },
+      },
+    });
+    expect(personById).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not delegate when the local result already satisfies the request', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      typeDefs: /* GraphQL */ `
+        extend type Query {
+          getPerson: Person
+        }
+      `,
+      resolvers: {
+        Query: {
+          getPerson: () => ({ id: '1', name: 'Local', surname: 'LocalSurname' }),
+        },
+      },
+    });
+    const result = await graphql({
+      schema: stitchedSchema,
+      source: /* GraphQL */ `
+        {
+          getPerson {
+            name
+            surname
+          }
+        }
+      `,
+    });
+    expect(result).toEqual({
+      data: { getPerson: { name: 'Local', surname: 'LocalSurname' } },
+    });
+    expect(personById).not.toHaveBeenCalled();
+  });
+
+  it('treats a subscription payload as the field value when no resolve is given', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      typeDefs: /* GraphQL */ `
+        type Subscription {
+          personCreated: PersonCreated
+        }
+        type PersonCreated {
+          person: Person
+          cursor: String
+        }
+      `,
+      resolvers: {
+        Subscription: {
+          personCreated: {
+            async *subscribe() {
+              yield { personCreated: { person: { id: '1' }, cursor: 'c1' } };
+            },
+          },
+        },
+      },
+    });
+    const sub = (await subscribe({
+      schema: stitchedSchema,
+      document: parse(/* GraphQL */ `
+        subscription {
+          personCreated {
+            person {
+              name
+            }
+            cursor
+          }
+        }
+      `),
+    })) as AsyncIterableIterator<ExecutionResult>;
+    const first = await sub.next();
+    expect(first.value).toEqual({
+      data: {
+        personCreated: { person: { name: 'Remote' }, cursor: 'c1' },
+      },
+    });
+    expect(personById).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates partial results of a user resolver overriding a subschema field', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      resolvers: {
+        Query: {
+          // takes over the proxied field, but only returns the key
+          personById: (_root: unknown, { id }: { id: string }) => ({ id }),
+        },
+      },
+    });
+    const result = await graphql({
+      schema: stitchedSchema,
+      source: /* GraphQL */ `
+        {
+          personById(id: "1") {
+            name
+            surname
+          }
+        }
+      `,
+    });
+    expect(result).toEqual({
+      data: { personById: { name: 'Remote', surname: 'RemoteSurname' } },
+    });
+    expect(personById).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the proxying resolver of subschema fields without local resolvers', async () => {
+    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
+      people[id],
+    );
+    const stitchedSchema = stitchSchemas({
+      subschemas: [createRemoteSubschema(personById)],
+      typeDefs: /* GraphQL */ `
+        extend type Query {
+          getPerson: Person
+        }
+      `,
+      resolvers: {
+        Query: {
+          getPerson: () => ({ id: '1' }),
+        },
+      },
+    });
+    const result = await graphql({
+      schema: stitchedSchema,
+      source: /* GraphQL */ `
+        {
+          personById(id: "1") {
+            id
+            name
+          }
+        }
+      `,
+    });
+    expect(result).toEqual({
+      data: { personById: { id: '1', name: 'Remote' } },
+    });
+    expect(personById).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/stitch/tests/localFieldResolvers.test.ts
+++ b/packages/stitch/tests/localFieldResolvers.test.ts
@@ -44,8 +44,8 @@ function createRemoteSubschema(
 
 describe('local fields returning merged types', () => {
   it('resolves a mix of local and remote fields from a key-only local result', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],
@@ -82,8 +82,8 @@ describe('local fields returning merged types', () => {
   });
 
   it('does not delegate when the payload and local resolvers cover the request', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],
@@ -119,8 +119,8 @@ describe('local fields returning merged types', () => {
   });
 
   it('resolves aliased fields from the payload without delegating', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],
@@ -150,8 +150,8 @@ describe('local fields returning merged types', () => {
   });
 
   it('resolves aliased fields from local resolvers and delegates the rest', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],
@@ -187,8 +187,8 @@ describe('local fields returning merged types', () => {
   });
 
   it('resolves aliased payload fields to null once delegation happens', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],
@@ -221,8 +221,8 @@ describe('local fields returning merged types', () => {
   });
 
   it('resolves aliases on nested payload objects to null once delegation happens', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],
@@ -255,15 +255,17 @@ describe('local fields returning merged types', () => {
     });
     expect(result).toEqual({
       data: {
-        getPerson: { friend: { nick: 'LocalFriend', surname: 'FriendSurname' } },
+        getPerson: {
+          friend: { nick: 'LocalFriend', surname: 'FriendSurname' },
+        },
       },
     });
     expect(personById).toHaveBeenCalledTimes(1);
   });
 
   it('hydrates a typeDefs-defined field through the default resolver', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],
@@ -308,8 +310,8 @@ describe('local fields returning merged types', () => {
   });
 
   it('does not delegate when the local result already satisfies the request', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],
@@ -320,7 +322,11 @@ describe('local fields returning merged types', () => {
       `,
       resolvers: {
         Query: {
-          getPerson: () => ({ id: '1', name: 'Local', surname: 'LocalSurname' }),
+          getPerson: () => ({
+            id: '1',
+            name: 'Local',
+            surname: 'LocalSurname',
+          }),
         },
       },
     });
@@ -342,8 +348,8 @@ describe('local fields returning merged types', () => {
   });
 
   it('treats a subscription payload as the field value when no resolve is given', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],
@@ -389,8 +395,8 @@ describe('local fields returning merged types', () => {
   });
 
   it('hydrates partial results of a user resolver overriding a subschema field', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],
@@ -419,8 +425,8 @@ describe('local fields returning merged types', () => {
   });
 
   it('keeps the proxying resolver of subschema fields without local resolvers', async () => {
-    const personById = vi.fn((_root: unknown, { id }: { id: string }) =>
-      people[id],
+    const personById = vi.fn(
+      (_root: unknown, { id }: { id: string }) => people[id],
     );
     const stitchedSchema = stitchSchemas({
       subschemas: [createRemoteSubschema(personById)],

--- a/packages/stitch/tests/localSubscriptionResolvers.test.ts
+++ b/packages/stitch/tests/localSubscriptionResolvers.test.ts
@@ -1,0 +1,256 @@
+import type { SubschemaConfig } from '@graphql-tools/delegate';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { assertAsyncIterable } from '@internal/testing';
+import { parse, subscribe } from 'graphql';
+import { describe, expect, it, vi } from 'vitest';
+import { stitchSchemas } from '../src/stitchSchemas.js';
+
+function makeReviews() {
+  const data = [
+    { id: '1', content: 'Great vacuum!' },
+    { id: '2', content: 'Does the job.' },
+    { id: '3', content: 'Worth every penny.' },
+  ];
+  const schema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        reviewById(id: ID!): Review
+      }
+      type Review {
+        id: ID!
+        content: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        reviewById: (_, { id }) => data.find((review) => review.id === id),
+      },
+    },
+  });
+  return {
+    schema,
+    subschemas: [
+      {
+        schema,
+        merge: {
+          Review: {
+            selectionSet: '{ id }',
+            fieldName: 'reviewById',
+            args: ({ id }) => ({ id }),
+          },
+        },
+      },
+    ] satisfies SubschemaConfig[],
+  };
+}
+
+function makeProducts() {
+  const data = [
+    {
+      id: '1',
+      name: 'Roomba X',
+      price: 100,
+      review: { id: '1' },
+    },
+    {
+      id: '2',
+      name: 'Roomba Y',
+      price: 200,
+      review: { id: '2' },
+    },
+    {
+      id: '3',
+      name: 'Roomba Z',
+      price: 300,
+      review: { id: '3' },
+    },
+  ];
+  const productPriceResolver = vi.fn(
+    (parent: { price: number }) => parent.price,
+  );
+  const schema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        productById(id: ID!): Product
+        productByName(name: String!): Product
+      }
+      type Product {
+        id: ID!
+        name: String!
+        price: Float!
+        review: Review
+      }
+      type Review {
+        id: ID!
+      }
+    `,
+    resolvers: {
+      Query: {
+        productById: (_, { id }) => data.find((product) => product.id === id),
+        productByName: (_, { name }) =>
+          data.find((product) => product.name === name),
+      },
+      Product: {
+        price: productPriceResolver,
+      },
+    },
+  });
+  return {
+    productPriceResolver,
+    subschemas: [
+      {
+        schema,
+        merge: {
+          Product: {
+            selectionSet: '{ id }',
+            fieldName: 'productById',
+            args: ({ id }) => ({ id }),
+          },
+        },
+      },
+      {
+        schema,
+        merge: {
+          Product: {
+            selectionSet: '{ name }',
+            fieldName: 'productByName',
+            args: ({ name }) => ({ name }),
+          },
+        },
+      },
+    ] satisfies SubschemaConfig[],
+  };
+}
+
+function createSubscriptionSchema(
+  subschemas: SubschemaConfig[],
+  events: Record<string, unknown>[],
+) {
+  return stitchSchemas({
+    subschemas,
+    typeDefs: /* GraphQL */ `
+      type Subscription {
+        newProduct: Product!
+      }
+    `,
+    resolvers: {
+      Subscription: {
+        newProduct: {
+          async *subscribe() {
+            for (const event of events) {
+              yield { newProduct: event };
+            }
+          },
+        },
+      },
+    },
+  });
+}
+
+describe('local subscription resolvers returning merged types', () => {
+  it('resolves fields from subschemas for subscription events', async () => {
+    const products = makeProducts();
+    const result = await subscribe({
+      schema: createSubscriptionSchema(products.subschemas, [
+        { id: '1' },
+        { name: 'Roomba Z' },
+      ]),
+      document: parse(/* GraphQL */ `
+        subscription {
+          newProduct {
+            name
+            ...ProductPrice
+          }
+        }
+        fragment ProductPrice on Product {
+          price
+        }
+      `),
+    });
+    assertAsyncIterable(result);
+    const iterator = result;
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        data: { newProduct: { name: 'Roomba X', price: 100 } },
+      },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        data: { newProduct: { name: 'Roomba Z', price: 300 } },
+      },
+      done: false,
+    });
+  });
+
+  it('resolves nested entities from subschemas for subscription events', async () => {
+    const products = makeProducts();
+    const reviews = makeReviews();
+    const result = await subscribe({
+      schema: createSubscriptionSchema(
+        [...products.subschemas, ...reviews.subschemas],
+        [{ id: '1' }, { name: 'Roomba Z' }],
+      ),
+      document: parse(/* GraphQL */ `
+        subscription {
+          newProduct {
+            name
+            review {
+              content
+            }
+          }
+        }
+      `),
+    });
+    assertAsyncIterable(result);
+    const iterator = result;
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        data: {
+          newProduct: {
+            name: 'Roomba X',
+            review: { content: 'Great vacuum!' },
+          },
+        },
+      },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        data: {
+          newProduct: {
+            name: 'Roomba Z',
+            review: { content: 'Worth every penny.' },
+          },
+        },
+      },
+      done: false,
+    });
+  });
+
+  it('delegates only fields missing from the subscription event', async () => {
+    const products = makeProducts();
+    const result = await subscribe({
+      schema: createSubscriptionSchema(products.subschemas, [
+        { id: '2', price: 999 },
+      ]),
+      document: parse(/* GraphQL */ `
+        subscription {
+          newProduct {
+            name
+            price
+          }
+        }
+      `),
+    });
+    assertAsyncIterable(result);
+    const iterator = result;
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        data: { newProduct: { name: 'Roomba Y', price: 999 } },
+      },
+      done: false,
+    });
+    expect(products.productPriceResolver).not.toHaveBeenCalled();
+  });
+});

--- a/packages/stitch/tests/resolveLocalFieldResult.test.ts
+++ b/packages/stitch/tests/resolveLocalFieldResult.test.ts
@@ -8,9 +8,12 @@ import {
   parse,
 } from 'graphql';
 import { describe, expect, it, vi } from 'vitest';
-import { resolveMergedTypeReference } from '../src/resolveMergedTypeReference.js';
-import { UNPATHED_ERRORS_SYMBOL } from '../src/symbols.js';
-import { MergedTypeResolver, StitchingInfo } from '../src/types.js';
+import {
+  MergedTypeResolver,
+  StitchingInfo,
+  UNPATHED_ERRORS_SYMBOL,
+} from '@graphql-tools/delegate';
+import { resolveLocalFieldResult } from '../src/resolveLocalFieldResult.js';
 
 const schema = makeExecutableSchema({
   typeDefs: /* GraphQL */ `
@@ -66,11 +69,11 @@ function stitchingInfoOf(
 const info = infoOf('query { person { name surname } }');
 const context = {};
 
-describe('resolveMergedTypeReference', () => {
+describe('resolveLocalFieldResult', () => {
   it('returns the value as-is when it already satisfies the requested selection', () => {
     const resolver = vi.fn();
     const value = { id: '1', name: 'Joe', surname: 'Doe' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       info,
@@ -88,7 +91,7 @@ describe('resolveMergedTypeReference', () => {
       surname: 'RemoteSurname',
     }));
     const value: { id: string; __typename?: string } = { id: '1' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       info,
@@ -121,7 +124,7 @@ describe('resolveMergedTypeReference', () => {
   it('delegates only the fields missing from the payload', () => {
     const resolver = vi.fn<MergedTypeResolver>(() => ({ surname: 'Remote' }));
     const value = { id: '1', name: 'Stale' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       info,
@@ -139,7 +142,7 @@ describe('resolveMergedTypeReference', () => {
   it('returns the value untouched when no merge key is satisfied', () => {
     const resolver = vi.fn();
     const value = { foo: 'bar' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       info,
@@ -151,7 +154,7 @@ describe('resolveMergedTypeReference', () => {
 
   it('returns the value untouched without stitching info', () => {
     const value = { id: '1' };
-    expect(resolveMergedTypeReference(value, context, info, null as any)).toBe(
+    expect(resolveLocalFieldResult(value, context, info, null as any)).toBe(
       value,
     );
   });
@@ -159,7 +162,7 @@ describe('resolveMergedTypeReference', () => {
   it('returns the value untouched when the return type is not merged', () => {
     const resolver = vi.fn();
     const value = { id: '1' };
-    const result = resolveMergedTypeReference(value, context, info, {
+    const result = resolveLocalFieldResult(value, context, info, {
       mergedTypes: {},
     } as unknown as StitchingInfo);
     expect(result).toBe(value);
@@ -169,7 +172,7 @@ describe('resolveMergedTypeReference', () => {
   it('returns already external objects untouched', () => {
     const resolver = vi.fn();
     const value = { id: '1', [UNPATHED_ERRORS_SYMBOL]: [] };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       info,
@@ -182,7 +185,7 @@ describe('resolveMergedTypeReference', () => {
   it('resolves each item of a list independently', () => {
     const resolver = vi.fn((value: any) => ({ ...value, name: 'Remote' }));
     const complete = { id: '2', name: 'Joe', surname: 'Doe' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       [{ id: '1' }, complete],
       context,
       info,
@@ -198,10 +201,10 @@ describe('resolveMergedTypeReference', () => {
     const stitchingInfo = stitchingInfoOf([
       { subschema: {}, keySelectionSet: '{ id }', resolver },
     ]);
-    expect(resolveMergedTypeReference(null, context, info, stitchingInfo)).toBe(
+    expect(resolveLocalFieldResult(null, context, info, stitchingInfo)).toBe(
       null,
     );
-    expect(resolveMergedTypeReference('x', context, info, stitchingInfo)).toBe(
+    expect(resolveLocalFieldResult('x', context, info, stitchingInfo)).toBe(
       'x',
     );
     expect(resolver).not.toHaveBeenCalled();
@@ -210,7 +213,7 @@ describe('resolveMergedTypeReference', () => {
   it('counts null leaf fields as satisfied', () => {
     const resolver = vi.fn();
     const value = { id: '1', name: null, surname: 'Doe' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       info,
@@ -223,7 +226,7 @@ describe('resolveMergedTypeReference', () => {
   it('counts null composites with a requested sub-selection as unsatisfied', () => {
     const resolver = vi.fn((value: any) => value);
     const value = { id: '1', friend: null };
-    resolveMergedTypeReference(
+    resolveLocalFieldResult(
       value,
       context,
       infoOf('query { person { friend { name } } }'),
@@ -240,7 +243,7 @@ describe('resolveMergedTypeReference', () => {
     const products = { name: 'products' };
     const inventoryResolver = vi.fn();
     const productsResolver = vi.fn((value: any) => value);
-    resolveMergedTypeReference(
+    resolveLocalFieldResult(
       { id: '1' },
       context,
       info,
@@ -268,7 +271,7 @@ describe('resolveMergedTypeReference', () => {
       surname: 'Doe',
       friend: { id: '2' },
     }));
-    const result = await resolveMergedTypeReference(
+    const result = await resolveLocalFieldResult(
       { id: '1' },
       context,
       infoOf('query { person { name surname friend { id } } }'),
@@ -291,7 +294,7 @@ describe('resolveMergedTypeReference', () => {
   it('treats providedFields as resolved locally when checking satisfaction', () => {
     const resolver = vi.fn();
     const value = { id: '1' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       infoOf('query { person { id name } }'),
@@ -307,7 +310,7 @@ describe('resolveMergedTypeReference', () => {
       ...value,
       surname: 'Remote',
     }));
-    resolveMergedTypeReference(
+    resolveLocalFieldResult(
       { id: '1' },
       context,
       info,
@@ -324,7 +327,7 @@ describe('resolveMergedTypeReference', () => {
   it('keeps payload fields that are outside the delegated selection', () => {
     const resolver = vi.fn(() => ({ name: 'Remote' }));
     const value = { id: '1', local: 'kept' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       infoOf('query { person { name } }'),
@@ -340,7 +343,7 @@ describe('resolveMergedTypeReference', () => {
   it('matches query aliases against the literal field names of the payload', () => {
     const resolver = vi.fn();
     const value = { id: '1', name: 'Local' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       infoOf('query { person { fullName: name } }'),
@@ -354,7 +357,7 @@ describe('resolveMergedTypeReference', () => {
     const resolver = vi.fn<MergedTypeResolver>(() => ({
       fullName: 'Remote',
     }));
-    resolveMergedTypeReference(
+    resolveLocalFieldResult(
       { id: '1' },
       context,
       infoOf('query { person { fullName: name } }'),
@@ -372,7 +375,7 @@ describe('resolveMergedTypeReference', () => {
       familyName: 'Remote',
     }));
     const value = { id: '1', name: 'Local' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       infoOf('query { person { fullName: name, familyName: surname } }'),
@@ -391,7 +394,7 @@ describe('resolveMergedTypeReference', () => {
 
   it('keeps only literal field names on nested payload objects', () => {
     const resolver = vi.fn(() => ({ friend: { surname: 'Remote' } }));
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       { id: '1', friend: { id: '2', name: 'LocalFriend' } },
       context,
       infoOf('query { person { friend { nick: name, surname } } }'),
@@ -407,7 +410,7 @@ describe('resolveMergedTypeReference', () => {
   it('sees through inline fragments in the requested selection', () => {
     const resolver = vi.fn();
     const value = { id: '1', name: 'Joe' };
-    const result = resolveMergedTypeReference(
+    const result = resolveLocalFieldResult(
       value,
       context,
       infoOf('query { person { ... on Person { name } } }'),

--- a/packages/stitch/tests/resolveLocalFieldResult.test.ts
+++ b/packages/stitch/tests/resolveLocalFieldResult.test.ts
@@ -1,3 +1,8 @@
+import {
+  MergedTypeResolver,
+  StitchingInfo,
+  UNPATHED_ERRORS_SYMBOL,
+} from '@graphql-tools/delegate';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { parseSelectionSet } from '@graphql-tools/utils';
 import {
@@ -8,11 +13,6 @@ import {
   parse,
 } from 'graphql';
 import { describe, expect, it, vi } from 'vitest';
-import {
-  MergedTypeResolver,
-  StitchingInfo,
-  UNPATHED_ERRORS_SYMBOL,
-} from '@graphql-tools/delegate';
 import { resolveLocalFieldResult } from '../src/resolveLocalFieldResult.js';
 
 const schema = makeExecutableSchema({

--- a/packages/transports/common/package.json
+++ b/packages/transports/common/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@graphql-mesh/cross-helpers": "^0.4.13",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "graphql": "^16.12.0",
     "pkgroll": "2.27.1"
   },

--- a/packages/transports/common/package.json
+++ b/packages/transports/common/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@graphql-mesh/cross-helpers": "^0.4.13",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "graphql": "^16.12.0",
     "pkgroll": "2.27.1"
   },

--- a/packages/transports/http-callback/package.json
+++ b/packages/transports/http-callback/package.json
@@ -47,7 +47,7 @@
     "@graphql-mesh/string-interpolation": "^0.5.16",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/executor-common": "workspace:^",
     "@graphql-tools/utils": "^11.0.0",
     "@repeaterjs/repeater": "^3.0.6",

--- a/packages/transports/http-callback/package.json
+++ b/packages/transports/http-callback/package.json
@@ -47,7 +47,7 @@
     "@graphql-mesh/string-interpolation": "^0.5.16",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/executor-common": "workspace:^",
     "@graphql-tools/utils": "^11.0.0",
     "@repeaterjs/repeater": "^3.0.6",

--- a/packages/transports/http/package.json
+++ b/packages/transports/http/package.json
@@ -46,7 +46,7 @@
     "@graphql-mesh/string-interpolation": "^0.5.16",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/executor-http": "workspace:^",
     "@graphql-tools/utils": "^11.0.0",
     "@whatwg-node/promise-helpers": "^1.3.2",

--- a/packages/transports/http/package.json
+++ b/packages/transports/http/package.json
@@ -46,7 +46,7 @@
     "@graphql-mesh/string-interpolation": "^0.5.16",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/executor-http": "workspace:^",
     "@graphql-tools/utils": "^11.0.0",
     "@whatwg-node/promise-helpers": "^1.3.2",

--- a/packages/transports/ws/package.json
+++ b/packages/transports/ws/package.json
@@ -46,7 +46,7 @@
     "@graphql-mesh/string-interpolation": "^0.5.16",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
+    "@graphql-mesh/utils": "^0.104.38",
     "@graphql-tools/executor-graphql-ws": "workspace:^",
     "@graphql-tools/utils": "^11.0.0",
     "graphql-ws": "^6.0.6",

--- a/packages/transports/ws/package.json
+++ b/packages/transports/ws/package.json
@@ -46,7 +46,7 @@
     "@graphql-mesh/string-interpolation": "^0.5.16",
     "@graphql-mesh/transport-common": "workspace:^",
     "@graphql-mesh/types": "^0.104.27",
-    "@graphql-mesh/utils": "^0.104.36",
+    "@graphql-mesh/utils": "0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183",
     "@graphql-tools/executor-graphql-ws": "workspace:^",
     "@graphql-tools/utils": "^11.0.0",
     "graphql-ws": "^6.0.6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -107,6 +107,9 @@
       "@graphql-hive/pubsub": ["./packages/pubsub/src/index.ts"],
       "@graphql-hive/pubsub/redis": ["./packages/pubsub/src/redis.ts"],
       "@graphql-hive/pubsub/nats": ["./packages/pubsub/src/nats.ts"],
+      "@graphql-hive/pubsub/nats-jetstream": [
+        "./packages/pubsub/src/nats-jetstream.ts"
+      ],
       "@graphql-hive/router-runtime": [
         "./packages/router-runtime/src/index.ts"
       ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -54,11 +54,9 @@ export default defineConfig({
                   '!**/e2e/edfs-subgraph-defs',
                   '!**/e2e/edfs-mesh-defs-with-entity-resolution',
                   '!**/e2e/edfs-additional-resolver-with-cursor',
+                  '!**/e2e/subscriptions-type-merging',
                   // TODO: windows has issues with the shutdown process (idk what exactly)
                   '!**/e2e/graceful-shutdown',
-                  // TODO: I am just lazy to set everything up in a containerised version although,
-                  // this test is ultimately a unit test so different envs make no difference
-                  '!**/e2e/subscriptions-type-merging',
                 ]
               : []),
             ...(usingHiveRouterRuntime()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -55,6 +55,9 @@ export default defineConfig({
                   '!**/e2e/edfs-mesh-defs-with-entity-resolution',
                   // TODO: windows has issues with the shutdown process (idk what exactly)
                   '!**/e2e/graceful-shutdown',
+                  // TODO: I am just lazy to set everything up in a containerised version although,
+                  // this test is ultimately a unit test so different envs make no difference
+                  '!**/e2e/subscriptions-type-merging',
                 ]
               : []),
             ...(usingHiveRouterRuntime()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
                   '!**/e2e/edfs-gateway-defs',
                   '!**/e2e/edfs-subgraph-defs',
                   '!**/e2e/edfs-mesh-defs-with-entity-resolution',
+                  '!**/e2e/edfs-additional-resolver-with-cursor',
                   // TODO: windows has issues with the shutdown process (idk what exactly)
                   '!**/e2e/graceful-shutdown',
                   // TODO: I am just lazy to set everything up in a containerised version although,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4525,7 +4525,7 @@ __metadata:
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/transport-rest": "npm:^0.9.38"
     "@graphql-mesh/types": "npm:^0.104.28"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/batch-delegate": "workspace:^"
     "@graphql-tools/delegate": "workspace:^"
     "@graphql-tools/executor-common": "workspace:^"
@@ -4617,7 +4617,7 @@ __metadata:
     "@graphql-mesh/transport-soap": "npm:^0.10.42"
     "@graphql-mesh/transport-ws": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.28"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/code-file-loader": "npm:^8.1.26"
     "@graphql-tools/executor": "npm:^1.4.13"
     "@graphql-tools/graphql-file-loader": "npm:^8.1.6"
@@ -4789,7 +4789,7 @@ __metadata:
   dependencies:
     "@graphql-hive/gateway-runtime": "workspace:*"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@whatwg-node/fetch": "npm:^0.10.13"
     "@whatwg-node/promise-helpers": "npm:^1.3.2"
@@ -4835,7 +4835,7 @@ __metadata:
     "@graphql-mesh/cross-helpers": "npm:^0.4.13"
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@opentelemetry/api": "npm:^1.9.1"
     "@opentelemetry/api-logs": "npm:^0.219.0"
@@ -4918,7 +4918,7 @@ __metadata:
     "@graphql-hive/router-query-planner": "npm:^0.0.38"
     "@graphql-mesh/fusion-runtime": "workspace:^"
     "@graphql-mesh/transport-common": "workspace:^"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/delegate": "workspace:^"
     "@graphql-tools/executor": "npm:^1.4.13"
     "@graphql-tools/executor-common": "workspace:^"
@@ -5057,18 +5057,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183":
-  version: 0.4.15-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183
-  resolution: "@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
-  dependencies:
-    "@graphql-tools/utils": "npm:^11.2.0"
-    path-browserify: "npm:1.0.1"
-  peerDependencies:
-    graphql: "*"
-  checksum: 10c0/5862743d8894315e9ef539b5f5b5615dd9a2d0477859a44485de43d24bfe3d08564edcbc3e96c0ed860c492e5ff588c6359a567aa824cf7741d8e509e4feafdf
-  languageName: node
-  linkType: hard
-
 "@graphql-mesh/cross-helpers@npm:^0.4.13, @graphql-mesh/cross-helpers@npm:^0.4.14":
   version: 0.4.14
   resolution: "@graphql-mesh/cross-helpers@npm:0.4.14"
@@ -5078,6 +5066,18 @@ __metadata:
   peerDependencies:
     graphql: "*"
   checksum: 10c0/7d0bc66503f7709500fa3b94d9d4d836fa97f872768781679a2122095a8e669b5cee0eb5b26094d94e27180de1ec63a4f513a5663088b68bd5ddc66e3d992fb8
+  languageName: node
+  linkType: hard
+
+"@graphql-mesh/cross-helpers@npm:^0.4.15":
+  version: 0.4.15
+  resolution: "@graphql-mesh/cross-helpers@npm:0.4.15"
+  dependencies:
+    "@graphql-tools/utils": "npm:^11.2.0"
+    path-browserify: "npm:1.0.1"
+  peerDependencies:
+    graphql: "*"
+  checksum: 10c0/2c49fef580878e7dfdaa4e0c2c502a9559489e8996a2e88c6b7fb20cbecb408e65ae8cceefd3dc0066dd7b2d3fe7678ec044e59777932a60402b25be30ec5439
   languageName: node
   linkType: hard
 
@@ -5113,7 +5113,7 @@ __metadata:
     "@graphql-mesh/cross-helpers": "npm:^0.4.13"
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.28"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/batch-execute": "workspace:^"
     "@graphql-tools/delegate": "workspace:^"
     "@graphql-tools/executor": "npm:^1.4.13"
@@ -5142,7 +5142,7 @@ __metadata:
     "@graphql-hive/gateway-runtime": "workspace:*"
     "@graphql-mesh/cross-helpers": "npm:^0.4.13"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/executor-common": "workspace:^"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@whatwg-node/promise-helpers": "npm:^1.3.2"
@@ -5232,7 +5232,7 @@ __metadata:
     "@envelop/core": "npm:^5.4.0"
     "@envelop/generic-auth": "npm:^11.0.0"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-yoga/plugin-jwt": "npm:^3.10.2"
     graphql: "npm:^16.12.0"
     graphql-yoga: "npm:^5.21.1"
@@ -5271,7 +5271,7 @@ __metadata:
     "@graphql-hive/logger": "workspace:^"
     "@graphql-mesh/cross-helpers": "npm:^0.4.13"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@graphql-yoga/plugin-prometheus": "npm:^6.11.3"
     graphql: "npm:^16.12.0"
@@ -5324,20 +5324,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183":
-  version: 0.5.18-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183
-  resolution: "@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
-  dependencies:
-    dayjs: "npm:^1.11.21"
-    json-pointer: "npm:^0.6.2"
-    lodash.get: "npm:^4.4.2"
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    graphql: "*"
-  checksum: 10c0/69b077cd82236cf2ed2ee9af010e3cc50b38ef4e1cf41e4880d022b59b17459c3e7a21bfd40ab421b82f27014d97bc9627a67a44e7ce2a60684da9801f569847
-  languageName: node
-  linkType: hard
-
 "@graphql-mesh/string-interpolation@npm:^0.5.16":
   version: 0.5.16
   resolution: "@graphql-mesh/string-interpolation@npm:0.5.16"
@@ -5366,6 +5352,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-mesh/string-interpolation@npm:^0.5.18":
+  version: 0.5.18
+  resolution: "@graphql-mesh/string-interpolation@npm:0.5.18"
+  dependencies:
+    dayjs: "npm:^1.11.21"
+    json-pointer: "npm:^0.6.2"
+    lodash.get: "npm:^4.4.2"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    graphql: "*"
+  checksum: 10c0/bcee348dbd5027005dc7e8ade44c07d3dd6b0ea20781cb1b6dcba15c36c94498d5dd09c96c98d4849ab8afc9e581718a22bbac838170a2bb5d6612a0f30c4e4e
+  languageName: node
+  linkType: hard
+
 "@graphql-mesh/transport-common@npm:^1.0.16, @graphql-mesh/transport-common@workspace:^, @graphql-mesh/transport-common@workspace:packages/transports/common":
   version: 0.0.0-use.local
   resolution: "@graphql-mesh/transport-common@workspace:packages/transports/common"
@@ -5376,7 +5376,7 @@ __metadata:
     "@graphql-hive/signal": "workspace:^"
     "@graphql-mesh/cross-helpers": "npm:^0.4.13"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/executor": "npm:^1.4.13"
     "@graphql-tools/executor-common": "workspace:^"
     "@graphql-tools/utils": "npm:^11.0.0"
@@ -5397,7 +5397,7 @@ __metadata:
     "@graphql-mesh/string-interpolation": "npm:^0.5.16"
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/executor-common": "workspace:^"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@repeaterjs/repeater": "npm:^3.0.6"
@@ -5419,7 +5419,7 @@ __metadata:
     "@graphql-mesh/string-interpolation": "npm:^0.5.16"
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/executor-http": "workspace:^"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@whatwg-node/promise-helpers": "npm:^1.3.2"
@@ -5482,7 +5482,7 @@ __metadata:
     "@graphql-mesh/string-interpolation": "npm:^0.5.16"
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/utils": "npm:^0.104.38"
     "@graphql-tools/executor-graphql-ws": "workspace:^"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@types/ws": "npm:^8"
@@ -5514,33 +5514,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/utils@npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183":
-  version: 0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183
-  resolution: "@graphql-mesh/utils@npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
-  dependencies:
-    "@envelop/instrumentation": "npm:^1.0.0"
-    "@graphql-mesh/cross-helpers": "npm:0.4.15-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
-    "@graphql-mesh/string-interpolation": "npm:0.5.18-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
-    "@graphql-mesh/types": "npm:0.104.30-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
-    "@graphql-tools/batch-delegate": "npm:^10.0.26"
-    "@graphql-tools/delegate": "npm:^12.0.19"
-    "@graphql-tools/utils": "npm:^11.2.0"
-    "@graphql-tools/wrap": "npm:^11.1.18"
-    "@whatwg-node/disposablestack": "npm:^0.0.6"
-    "@whatwg-node/fetch": "npm:^0.10.6"
-    "@whatwg-node/promise-helpers": "npm:^1.2.0"
-    dset: "npm:^3.1.2"
-    js-yaml: "npm:^4.3.0"
-    lodash.get: "npm:^4.4.2"
-    lodash.topath: "npm:^4.5.2"
-    tiny-lru: "npm:^13.0.0"
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    graphql: "*"
-  checksum: 10c0/dc62c31f3e73e396a027a42c514367f429be2ff9d22bf243d6e20c8840976a21ce5ae2872233e377646f3467960260fc7b88a19345d07d0b1098d5f60195784a
-  languageName: node
-  linkType: hard
-
 "@graphql-mesh/utils@npm:^0.104.36":
   version: 0.104.37
   resolution: "@graphql-mesh/utils@npm:0.104.37"
@@ -5565,6 +5538,33 @@ __metadata:
   peerDependencies:
     graphql: "*"
   checksum: 10c0/25f3cb2b298ffe9f07b1b3bcb62426bc8213b0dc494ac5842216207c4f1359bc7956ba2022c9fd9d35ba329612fb6f8180edadae2e17be2ba1997d504a54434c
+  languageName: node
+  linkType: hard
+
+"@graphql-mesh/utils@npm:^0.104.38":
+  version: 0.104.38
+  resolution: "@graphql-mesh/utils@npm:0.104.38"
+  dependencies:
+    "@envelop/instrumentation": "npm:^1.0.0"
+    "@graphql-mesh/cross-helpers": "npm:^0.4.15"
+    "@graphql-mesh/string-interpolation": "npm:^0.5.18"
+    "@graphql-mesh/types": "npm:^0.104.30"
+    "@graphql-tools/batch-delegate": "npm:^10.0.26"
+    "@graphql-tools/delegate": "npm:^12.0.19"
+    "@graphql-tools/utils": "npm:^11.2.0"
+    "@graphql-tools/wrap": "npm:^11.1.18"
+    "@whatwg-node/disposablestack": "npm:^0.0.6"
+    "@whatwg-node/fetch": "npm:^0.10.6"
+    "@whatwg-node/promise-helpers": "npm:^1.2.0"
+    dset: "npm:^3.1.2"
+    js-yaml: "npm:^4.3.0"
+    lodash.get: "npm:^4.4.2"
+    lodash.topath: "npm:^4.5.2"
+    tiny-lru: "npm:^13.0.0"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    graphql: "*"
+  checksum: 10c0/330af2feb0e9b90d56af152646333961021570982234d399b520d5022635d1861badefa61931689cd9d72fb23dc873c795bc9ef5dc7afe28397567340ff4f052
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5057,15 +5057,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1":
-  version: 0.4.15-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1
-  resolution: "@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
+"@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2":
+  version: 0.4.15-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2
+  resolution: "@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
   dependencies:
     "@graphql-tools/utils": "npm:^11.2.0"
     path-browserify: "npm:1.0.1"
   peerDependencies:
     graphql: "*"
-  checksum: 10c0/c3294c11df689521df1d5f7a69c20da636019c8da3476c5a5e0f682c494ce4170aebba9f2c2b9c623ac0f95961965734711c1ce4146b1fee248ce9c344669eb6
+  checksum: 10c0/43f120a1e577e18e164090f227f6b5b8350a02a9ca570d005b90903044deb41027a83a418ce54613da73e8e6a948e55f14b0507c9a7317c5b57d86f630ddf556
   languageName: node
   linkType: hard
 
@@ -5324,9 +5324,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1":
-  version: 0.5.18-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1
-  resolution: "@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
+"@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2":
+  version: 0.5.18-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2
+  resolution: "@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
   dependencies:
     dayjs: "npm:^1.11.21"
     json-pointer: "npm:^0.6.2"
@@ -5334,7 +5334,7 @@ __metadata:
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: "*"
-  checksum: 10c0/83394a3918bc9feafc84652d792b391af98ba83465d38c2ed09f730637419dcd9de90b682b2e25821dc564e454f59605b646ae3fef42caf5f46b58c0d2a83902
+  checksum: 10c0/1738bf3d395006a578b008f29ff2ae49c8e3f1e2d46f847d0a432e7fdaa3fcd8d0700398e413432748409ba5c66d1b18e98b59f7dff3f700e3a30cc3967de1ad
   languageName: node
   linkType: hard
 
@@ -5514,14 +5514,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/utils@npm:0.104.38-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1":
-  version: 0.104.38-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1
-  resolution: "@graphql-mesh/utils@npm:0.104.38-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
+"@graphql-mesh/utils@npm:0.104.38-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2":
+  version: 0.104.38-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2
+  resolution: "@graphql-mesh/utils@npm:0.104.38-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
   dependencies:
     "@envelop/instrumentation": "npm:^1.0.0"
-    "@graphql-mesh/cross-helpers": "npm:0.4.15-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
-    "@graphql-mesh/string-interpolation": "npm:0.5.18-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
-    "@graphql-mesh/types": "npm:0.104.30-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
+    "@graphql-mesh/cross-helpers": "npm:0.4.15-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
+    "@graphql-mesh/string-interpolation": "npm:0.5.18-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
+    "@graphql-mesh/types": "npm:0.104.30-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
     "@graphql-tools/batch-delegate": "npm:^10.0.26"
     "@graphql-tools/delegate": "npm:^12.0.19"
     "@graphql-tools/utils": "npm:^11.2.0"
@@ -5537,7 +5537,7 @@ __metadata:
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: "*"
-  checksum: 10c0/eb83ad3f609cfba58304e4ca015e0a0e31ff6ee45c7bf99effe38da7e35da4430343cd18c747893fe9339f8de4ee6c814c6deec4207203b7eda1174f5ea27524
+  checksum: 10c0/808a10e501f2737a32e11808b8a104068aac659b0dd1aed660cb89338dc30dac7a790db0746c07b95f2c02c2878df66b73828762c5ef08066809d31f5158e2d2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5047,6 +5047,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1":
+  version: 0.4.15-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1
+  resolution: "@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
+  dependencies:
+    "@graphql-tools/utils": "npm:^11.2.0"
+    path-browserify: "npm:1.0.1"
+  peerDependencies:
+    graphql: "*"
+  checksum: 10c0/c3294c11df689521df1d5f7a69c20da636019c8da3476c5a5e0f682c494ce4170aebba9f2c2b9c623ac0f95961965734711c1ce4146b1fee248ce9c344669eb6
+  languageName: node
+  linkType: hard
+
 "@graphql-mesh/cross-helpers@npm:^0.4.13, @graphql-mesh/cross-helpers@npm:^0.4.14":
   version: 0.4.14
   resolution: "@graphql-mesh/cross-helpers@npm:0.4.14"
@@ -5302,6 +5314,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1":
+  version: 0.5.18-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1
+  resolution: "@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
+  dependencies:
+    dayjs: "npm:^1.11.21"
+    json-pointer: "npm:^0.6.2"
+    lodash.get: "npm:^4.4.2"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    graphql: "*"
+  checksum: 10c0/83394a3918bc9feafc84652d792b391af98ba83465d38c2ed09f730637419dcd9de90b682b2e25821dc564e454f59605b646ae3fef42caf5f46b58c0d2a83902
+  languageName: node
+  linkType: hard
+
 "@graphql-mesh/string-interpolation@npm:^0.5.16":
   version: 0.5.16
   resolution: "@graphql-mesh/string-interpolation@npm:0.5.16"
@@ -5478,30 +5504,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/utils@npm:0.104.36":
-  version: 0.104.36
-  resolution: "@graphql-mesh/utils@npm:0.104.36"
+"@graphql-mesh/utils@npm:0.104.38-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1":
+  version: 0.104.38-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1
+  resolution: "@graphql-mesh/utils@npm:0.104.38-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
   dependencies:
     "@envelop/instrumentation": "npm:^1.0.0"
-    "@graphql-mesh/cross-helpers": "npm:^0.4.14"
-    "@graphql-mesh/string-interpolation": "npm:^0.5.16"
-    "@graphql-mesh/types": "npm:^0.104.28"
-    "@graphql-tools/batch-delegate": "npm:^10.0.20"
-    "@graphql-tools/delegate": "npm:^12.0.14"
-    "@graphql-tools/utils": "npm:^11.1.0"
-    "@graphql-tools/wrap": "npm:^11.1.14"
+    "@graphql-mesh/cross-helpers": "npm:0.4.15-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
+    "@graphql-mesh/string-interpolation": "npm:0.5.18-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
+    "@graphql-mesh/types": "npm:0.104.30-alpha-20260717173123-0fdc1800aa1083a1c703a39b10032d1e368dc7e1"
+    "@graphql-tools/batch-delegate": "npm:^10.0.26"
+    "@graphql-tools/delegate": "npm:^12.0.19"
+    "@graphql-tools/utils": "npm:^11.2.0"
+    "@graphql-tools/wrap": "npm:^11.1.18"
     "@whatwg-node/disposablestack": "npm:^0.0.6"
     "@whatwg-node/fetch": "npm:^0.10.6"
     "@whatwg-node/promise-helpers": "npm:^1.2.0"
     dset: "npm:^3.1.2"
-    js-yaml: "npm:^4.1.0"
+    js-yaml: "npm:^4.3.0"
     lodash.get: "npm:^4.4.2"
     lodash.topath: "npm:^4.5.2"
     tiny-lru: "npm:^13.0.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: "*"
-  checksum: 10c0/7661b10dc4ee26d8e9b86d6d3312c471a802aaad89f7647d595477d00c0848c18a5b3439788ee808df2d04b2ad347f82231a391892327b00b4e554772bc12f87
+  checksum: 10c0/eb83ad3f609cfba58304e4ca015e0a0e31ff6ee45c7bf99effe38da7e35da4430343cd18c747893fe9339f8de4ee6c814c6deec4207203b7eda1174f5ea27524
   languageName: node
   linkType: hard
 
@@ -5519,7 +5545,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/batch-delegate@npm:^10.0.20, @graphql-tools/batch-delegate@workspace:^, @graphql-tools/batch-delegate@workspace:packages/batch-delegate":
+"@graphql-tools/batch-delegate@npm:^10.0.20, @graphql-tools/batch-delegate@npm:^10.0.26, @graphql-tools/batch-delegate@workspace:^, @graphql-tools/batch-delegate@workspace:packages/batch-delegate":
   version: 0.0.0-use.local
   resolution: "@graphql-tools/batch-delegate@workspace:packages/batch-delegate"
   dependencies:
@@ -5977,6 +6003,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-tools/utils@npm:^11.2.0":
+  version: 11.2.1
+  resolution: "@graphql-tools/utils@npm:11.2.1"
+  dependencies:
+    "@graphql-typed-document-node/core": "npm:^3.1.1"
+    "@whatwg-node/promise-helpers": "npm:^1.0.0"
+    cross-inspect: "npm:1.0.1"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 10c0/cfd6661bd074a4f4385167378e8a5fe249cf6f5c89ccd8408f03d9c9f589bde135e35e4f07c8756663af0bbcad8f4c0d6a6ea65f8041c129ce9b9d211b8aa304
+  languageName: node
+  linkType: hard
+
 "@graphql-tools/utils@npm:^8.5.2":
   version: 8.13.1
   resolution: "@graphql-tools/utils@npm:8.13.1"
@@ -5988,7 +6028,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/wrap@npm:^11.1.1, @graphql-tools/wrap@npm:^11.1.14, @graphql-tools/wrap@workspace:^, @graphql-tools/wrap@workspace:packages/wrap":
+"@graphql-tools/wrap@npm:^11.1.1, @graphql-tools/wrap@npm:^11.1.14, @graphql-tools/wrap@npm:^11.1.18, @graphql-tools/wrap@workspace:^, @graphql-tools/wrap@workspace:packages/wrap":
   version: 0.0.0-use.local
   resolution: "@graphql-tools/wrap@workspace:packages/wrap"
   dependencies:
@@ -19407,6 +19447,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3437,7 +3437,7 @@ __metadata:
   dependencies:
     graphql: "npm:^16.14.0"
     graphql-sse: "npm:^2.5.4"
-    ioredis: "npm:^5.11.1"
+    ioredis: "npm:^5.8.2"
   languageName: unknown
   linkType: soft
 
@@ -18303,21 +18303,6 @@ __metadata:
     redis-parser: "npm:3.0.0"
     standard-as-callback: "npm:2.1.0"
   checksum: 10c0/6bba1eda256bafabf581089ec24c98bccc5af614b108f13fca6672ea707c36d67e7021c4f0965cbe0294e7a3964b6dbd897a95ed7f8fe82a175531219e91b84f
-  languageName: node
-  linkType: hard
-
-"ioredis@npm:^5.11.1":
-  version: 5.11.1
-  resolution: "ioredis@npm:5.11.1"
-  dependencies:
-    "@ioredis/commands": "npm:1.10.0"
-    cluster-key-slot: "npm:1.1.1"
-    debug: "npm:4.4.3"
-    denque: "npm:2.1.0"
-    redis-errors: "npm:1.2.0"
-    redis-parser: "npm:3.0.0"
-    standard-as-callback: "npm:2.1.0"
-  checksum: 10c0/a8b27043cf2c045dfc93f40a32ce24cf9f8b57799a37f4234c4b925c365ccf131629590f94a512f546fda2ba8ed034009c94c4933ecd44c50bc166636d929fd6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4525,7 +4525,7 @@ __metadata:
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/transport-rest": "npm:^0.9.38"
     "@graphql-mesh/types": "npm:^0.104.28"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/batch-delegate": "workspace:^"
     "@graphql-tools/delegate": "workspace:^"
     "@graphql-tools/executor-common": "workspace:^"
@@ -4617,7 +4617,7 @@ __metadata:
     "@graphql-mesh/transport-soap": "npm:^0.10.42"
     "@graphql-mesh/transport-ws": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.28"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/code-file-loader": "npm:^8.1.26"
     "@graphql-tools/executor": "npm:^1.4.13"
     "@graphql-tools/graphql-file-loader": "npm:^8.1.6"
@@ -4789,7 +4789,7 @@ __metadata:
   dependencies:
     "@graphql-hive/gateway-runtime": "workspace:*"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@whatwg-node/fetch": "npm:^0.10.13"
     "@whatwg-node/promise-helpers": "npm:^1.3.2"
@@ -4835,7 +4835,7 @@ __metadata:
     "@graphql-mesh/cross-helpers": "npm:^0.4.13"
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@opentelemetry/api": "npm:^1.9.1"
     "@opentelemetry/api-logs": "npm:^0.219.0"
@@ -4918,7 +4918,7 @@ __metadata:
     "@graphql-hive/router-query-planner": "npm:^0.0.38"
     "@graphql-mesh/fusion-runtime": "workspace:^"
     "@graphql-mesh/transport-common": "workspace:^"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/delegate": "workspace:^"
     "@graphql-tools/executor": "npm:^1.4.13"
     "@graphql-tools/executor-common": "workspace:^"
@@ -5113,7 +5113,7 @@ __metadata:
     "@graphql-mesh/cross-helpers": "npm:^0.4.13"
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.28"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/batch-execute": "workspace:^"
     "@graphql-tools/delegate": "workspace:^"
     "@graphql-tools/executor": "npm:^1.4.13"
@@ -5142,7 +5142,7 @@ __metadata:
     "@graphql-hive/gateway-runtime": "workspace:*"
     "@graphql-mesh/cross-helpers": "npm:^0.4.13"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/executor-common": "workspace:^"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@whatwg-node/promise-helpers": "npm:^1.3.2"
@@ -5232,7 +5232,7 @@ __metadata:
     "@envelop/core": "npm:^5.4.0"
     "@envelop/generic-auth": "npm:^11.0.0"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-yoga/plugin-jwt": "npm:^3.10.2"
     graphql: "npm:^16.12.0"
     graphql-yoga: "npm:^5.21.1"
@@ -5271,7 +5271,7 @@ __metadata:
     "@graphql-hive/logger": "workspace:^"
     "@graphql-mesh/cross-helpers": "npm:^0.4.13"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@graphql-yoga/plugin-prometheus": "npm:^6.11.3"
     graphql: "npm:^16.12.0"
@@ -5376,7 +5376,7 @@ __metadata:
     "@graphql-hive/signal": "workspace:^"
     "@graphql-mesh/cross-helpers": "npm:^0.4.13"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/executor": "npm:^1.4.13"
     "@graphql-tools/executor-common": "workspace:^"
     "@graphql-tools/utils": "npm:^11.0.0"
@@ -5397,7 +5397,7 @@ __metadata:
     "@graphql-mesh/string-interpolation": "npm:^0.5.16"
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/executor-common": "workspace:^"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@repeaterjs/repeater": "npm:^3.0.6"
@@ -5419,7 +5419,7 @@ __metadata:
     "@graphql-mesh/string-interpolation": "npm:^0.5.16"
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/executor-http": "workspace:^"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@whatwg-node/promise-helpers": "npm:^1.3.2"
@@ -5482,7 +5482,7 @@ __metadata:
     "@graphql-mesh/string-interpolation": "npm:^0.5.16"
     "@graphql-mesh/transport-common": "workspace:^"
     "@graphql-mesh/types": "npm:^0.104.27"
-    "@graphql-mesh/utils": "npm:^0.104.36"
+    "@graphql-mesh/utils": "npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/executor-graphql-ws": "workspace:^"
     "@graphql-tools/utils": "npm:^11.0.0"
     "@types/ws": "npm:^8"
@@ -5541,6 +5541,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-mesh/utils@npm:^0.104.36":
+  version: 0.104.37
+  resolution: "@graphql-mesh/utils@npm:0.104.37"
+  dependencies:
+    "@envelop/instrumentation": "npm:^1.0.0"
+    "@graphql-mesh/cross-helpers": "npm:^0.4.14"
+    "@graphql-mesh/string-interpolation": "npm:^0.5.17"
+    "@graphql-mesh/types": "npm:^0.104.29"
+    "@graphql-tools/batch-delegate": "npm:^10.0.22"
+    "@graphql-tools/delegate": "npm:^12.0.16"
+    "@graphql-tools/utils": "npm:^11.1.0"
+    "@graphql-tools/wrap": "npm:^11.1.15"
+    "@whatwg-node/disposablestack": "npm:^0.0.6"
+    "@whatwg-node/fetch": "npm:^0.10.6"
+    "@whatwg-node/promise-helpers": "npm:^1.2.0"
+    dset: "npm:^3.1.2"
+    js-yaml: "npm:^4.1.0"
+    lodash.get: "npm:^4.4.2"
+    lodash.topath: "npm:^4.5.2"
+    tiny-lru: "npm:^13.0.0"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    graphql: "*"
+  checksum: 10c0/25f3cb2b298ffe9f07b1b3bcb62426bc8213b0dc494ac5842216207c4f1359bc7956ba2022c9fd9d35ba329612fb6f8180edadae2e17be2ba1997d504a54434c
+  languageName: node
+  linkType: hard
+
 "@graphql-tools/apollo-engine-loader@npm:^8.0.28":
   version: 8.0.30
   resolution: "@graphql-tools/apollo-engine-loader@npm:8.0.30"
@@ -5555,7 +5582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/batch-delegate@npm:^10.0.20, @graphql-tools/batch-delegate@npm:^10.0.26, @graphql-tools/batch-delegate@workspace:^, @graphql-tools/batch-delegate@workspace:packages/batch-delegate":
+"@graphql-tools/batch-delegate@npm:^10.0.20, @graphql-tools/batch-delegate@npm:^10.0.22, @graphql-tools/batch-delegate@npm:^10.0.26, @graphql-tools/batch-delegate@workspace:^, @graphql-tools/batch-delegate@workspace:packages/batch-delegate":
   version: 0.0.0-use.local
   resolution: "@graphql-tools/batch-delegate@workspace:packages/batch-delegate"
   dependencies:
@@ -6038,7 +6065,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/wrap@npm:^11.1.1, @graphql-tools/wrap@npm:^11.1.14, @graphql-tools/wrap@npm:^11.1.18, @graphql-tools/wrap@workspace:^, @graphql-tools/wrap@workspace:packages/wrap":
+"@graphql-tools/wrap@npm:^11.1.1, @graphql-tools/wrap@npm:^11.1.14, @graphql-tools/wrap@npm:^11.1.15, @graphql-tools/wrap@npm:^11.1.18, @graphql-tools/wrap@workspace:^, @graphql-tools/wrap@workspace:packages/wrap":
   version: 0.0.0-use.local
   resolution: "@graphql-tools/wrap@workspace:packages/wrap"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3431,6 +3431,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/subscriptions-type-merging@workspace:e2e/subscriptions-type-merging":
+  version: 0.0.0-use.local
+  resolution: "@e2e/subscriptions-type-merging@workspace:e2e/subscriptions-type-merging"
+  dependencies:
+    graphql: "npm:^16.14.0"
+    graphql-sse: "npm:^2.5.4"
+    ioredis: "npm:^5.11.1"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/subscriptions-with-transforms@workspace:e2e/subscriptions-with-transforms":
   version: 0.0.0-use.local
   resolution: "@e2e/subscriptions-with-transforms@workspace:e2e/subscriptions-with-transforms"
@@ -17703,7 +17713,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-sse@npm:^2.6.0":
+"graphql-sse@npm:^2.5.4, graphql-sse@npm:^2.6.0":
   version: 2.6.0
   resolution: "graphql-sse@npm:2.6.0"
   peerDependencies:
@@ -18293,6 +18303,21 @@ __metadata:
     redis-parser: "npm:3.0.0"
     standard-as-callback: "npm:2.1.0"
   checksum: 10c0/6bba1eda256bafabf581089ec24c98bccc5af614b108f13fca6672ea707c36d67e7021c4f0965cbe0294e7a3964b6dbd897a95ed7f8fe82a175531219e91b84f
+  languageName: node
+  linkType: hard
+
+"ioredis@npm:^5.11.1":
+  version: 5.11.1
+  resolution: "ioredis@npm:5.11.1"
+  dependencies:
+    "@ioredis/commands": "npm:1.10.0"
+    cluster-key-slot: "npm:1.1.1"
+    debug: "npm:4.4.3"
+    denque: "npm:2.1.0"
+    redis-errors: "npm:1.2.0"
+    redis-parser: "npm:3.0.0"
+    standard-as-callback: "npm:2.1.0"
+  checksum: 10c0/a8b27043cf2c045dfc93f40a32ce24cf9f8b57799a37f4234c4b925c365ccf131629590f94a512f546fda2ba8ed034009c94c4933ecd44c50bc166636d929fd6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5057,15 +5057,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2":
-  version: 0.4.15-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2
-  resolution: "@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
+"@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183":
+  version: 0.4.15-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183
+  resolution: "@graphql-mesh/cross-helpers@npm:0.4.15-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
   dependencies:
     "@graphql-tools/utils": "npm:^11.2.0"
     path-browserify: "npm:1.0.1"
   peerDependencies:
     graphql: "*"
-  checksum: 10c0/43f120a1e577e18e164090f227f6b5b8350a02a9ca570d005b90903044deb41027a83a418ce54613da73e8e6a948e55f14b0507c9a7317c5b57d86f630ddf556
+  checksum: 10c0/5862743d8894315e9ef539b5f5b5615dd9a2d0477859a44485de43d24bfe3d08564edcbc3e96c0ed860c492e5ff588c6359a567aa824cf7741d8e509e4feafdf
   languageName: node
   linkType: hard
 
@@ -5324,9 +5324,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2":
-  version: 0.5.18-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2
-  resolution: "@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
+"@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183":
+  version: 0.5.18-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183
+  resolution: "@graphql-mesh/string-interpolation@npm:0.5.18-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
   dependencies:
     dayjs: "npm:^1.11.21"
     json-pointer: "npm:^0.6.2"
@@ -5334,7 +5334,7 @@ __metadata:
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: "*"
-  checksum: 10c0/1738bf3d395006a578b008f29ff2ae49c8e3f1e2d46f847d0a432e7fdaa3fcd8d0700398e413432748409ba5c66d1b18e98b59f7dff3f700e3a30cc3967de1ad
+  checksum: 10c0/69b077cd82236cf2ed2ee9af010e3cc50b38ef4e1cf41e4880d022b59b17459c3e7a21bfd40ab421b82f27014d97bc9627a67a44e7ce2a60684da9801f569847
   languageName: node
   linkType: hard
 
@@ -5514,14 +5514,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-mesh/utils@npm:0.104.38-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2":
-  version: 0.104.38-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2
-  resolution: "@graphql-mesh/utils@npm:0.104.38-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
+"@graphql-mesh/utils@npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183":
+  version: 0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183
+  resolution: "@graphql-mesh/utils@npm:0.104.38-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
   dependencies:
     "@envelop/instrumentation": "npm:^1.0.0"
-    "@graphql-mesh/cross-helpers": "npm:0.4.15-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
-    "@graphql-mesh/string-interpolation": "npm:0.5.18-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
-    "@graphql-mesh/types": "npm:0.104.30-alpha-20260717191133-97ee063bdca630f2b2a02b71b8455ae717fa36a2"
+    "@graphql-mesh/cross-helpers": "npm:0.4.15-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/string-interpolation": "npm:0.5.18-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
+    "@graphql-mesh/types": "npm:0.104.30-alpha-20260720145753-a9bbec477ec07ad5e973ae3f68460fab8d0cd183"
     "@graphql-tools/batch-delegate": "npm:^10.0.26"
     "@graphql-tools/delegate": "npm:^12.0.19"
     "@graphql-tools/utils": "npm:^11.2.0"
@@ -5537,7 +5537,7 @@ __metadata:
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: "*"
-  checksum: 10c0/808a10e501f2737a32e11808b8a104068aac659b0dd1aed660cb89338dc30dac7a790db0746c07b95f2c02c2878df66b73828762c5ef08066809d31f5158e2d2
+  checksum: 10c0/dc62c31f3e73e396a027a42c514367f429be2ff9d22bf243d6e20c8840976a21ce5ae2872233e377646f3467960260fc7b88a19345d07d0b1098d5f60195784a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,6 +2802,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/edfs-additional-resolver-with-cursor@workspace:e2e/edfs-additional-resolver-with-cursor":
+  version: 0.0.0-use.local
+  resolution: "@e2e/edfs-additional-resolver-with-cursor@workspace:e2e/edfs-additional-resolver-with-cursor"
+  dependencies:
+    "@nats-io/jetstream": "npm:^3.4.0"
+    "@nats-io/transport-node": "npm:^3.2.0"
+    "@whatwg-node/promise-helpers": "npm:^1.3.2"
+    graphql: "npm:^16.12.0"
+    graphql-sse: "npm:^2.6.0"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/edfs-gateway-defs@workspace:e2e/edfs-gateway-defs":
   version: 0.0.0-use.local
   resolution: "@e2e/edfs-gateway-defs@workspace:e2e/edfs-gateway-defs"
@@ -4848,6 +4860,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphql-hive/pubsub@workspace:packages/pubsub"
   dependencies:
+    "@nats-io/jetstream": "npm:^3.4.0"
     "@nats-io/nats-core": "npm:^3.2.0"
     "@nats-io/transport-node": "npm:^3.2.0"
     "@repeaterjs/repeater": "npm:^3.0.6"
@@ -4856,9 +4869,12 @@ __metadata:
     ioredis: "npm:^5.8.2"
     pkgroll: "npm:2.27.1"
   peerDependencies:
+    "@nats-io/jetstream": ^3
     "@nats-io/nats-core": ^3
     ioredis: ^5
   peerDependenciesMeta:
+    "@nats-io/jetstream":
+      optional: true
     "@nats-io/nats-core":
       optional: true
     ioredis:
@@ -7423,6 +7439,15 @@ __metadata:
     "@emnapi/core": ^1.7.1
     "@emnapi/runtime": ^1.7.1
   checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
+  languageName: node
+  linkType: hard
+
+"@nats-io/jetstream@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "@nats-io/jetstream@npm:3.4.0"
+  dependencies:
+    "@nats-io/nats-core": "npm:3.4.0"
+  checksum: 10c0/50d6d3abbad35167c253bf555a0ba80cd74654d76d12bdcd91ef5ba37f2dc630865c9bef9f0c7e6e73d8eafd1057495d9bf4eeebabca82f32e81661c5f4627bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Local and gateway resolvers can return partial objects for merged types, usually containing only key fields. Stitching then loads only the missing requested fields from the appropriate subschemas. Fields already present on the object are kept as-is and are not re-fetched.

This enables event payloads and additional schema fields that wrap a federated or merged type alongside local data, such as a cursor, without manually wiring a merge or making an extra subgraph call.

This PR also adds NATS JetStream as a pubsub transport.

### Resolve partial merged types from local data

Stitching now automatically wraps local fields introduced through additional `typeDefs` or `resolvers` when they return merged types. If a resolver returns a plain partial object with a usable merge key, stitching performs an initial delegation for only the missing requested fields.

Type merging remains enabled for that delegation, so the existing stitching planner continues to handle nested entities, computed fields, `@requires` dependencies, batching, and fields owned by other subschemas. Objects that already satisfy the request, do not match a merge key, or are already external are returned untouched.

Returning a key is enough:

```graphql
type Query {
  personCreated: PersonCreated
}

type PersonCreated {
  person: Person # merged type owned by a subschema
  cursor: String
}
```

```ts
const resolvers = {
  Query: {
    personCreated: () => ({ person: { id: '1' }, cursor: 'c1' }),
  },
};
```

The following query loads `name` through normal stitching while keeping `cursor` and any local `Person` fields local:

```graphql
{
  personCreated {
    person {
      name
    }
    cursor
  }
}
```

This also applies to subscription and event payloads. Pubsub-backed additional resolvers wrap emitted values using the graphql-js subscription root-field shape, while stitching automatically hydrates partial merged values.

### Aliased fields on mixed local and external objects

`defaultMergedResolver` previously looked up only the response key, which is the alias when one is present. Plain resolver data is stored under the field name, so a selection such as `fullName: name` could resolve to `null` even when `name` was present.

It now falls back to the literal field name when the aliased response key is absent, matching plain graphql-js behavior. A response-key value already supplied by a subschema still takes precedence.

### NATS JetStream pubsub

This PR adds a JetStream-backed pubsub implementation for durable and stream-oriented messaging, including tests and end-to-end coverage for additional-resolver subscription payloads containing local data such as cursors.

### TODO

- [x] release stable after https://github.com/ardatan/graphql-mesh/pull/9568