### PR TITLE
Delegated argument variable type compatibility

### DIFF
--- a/.changeset/chatty-pears-drive.md
+++ b/.changeset/chatty-pears-drive.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+Fix delegated argument variable type compatibility
+
+Avoid reusing variables whose types are incompatible with target schema argument types, and create correctly typed variables instead.

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -16,12 +16,14 @@ import {
   isInputObjectType,
   isListType,
   isNonNullType,
+  isTypeSubTypeOf,
   Kind,
   NameNode,
   OperationDefinitionNode,
   OperationTypeNode,
   SelectionNode,
   SelectionSetNode,
+  typeFromAST,
 } from 'graphql';
 import { ICreateRequest } from './types.js';
 
@@ -103,12 +105,26 @@ export function createRequest({
         (argNode) => argNode.name.value === argName,
       );
       // Check if we can re-use the variable from the original request for this argument
-      if (existingArgNode?.value.kind === Kind.VARIABLE) {
+      if (existingArgNode?.value.kind === Kind.VARIABLE && argInstance) {
         const varName = existingArgNode.value.name.value;
         const varValue = newVariables[varName];
-        // If the variable value is the same as the argument value,
-        // we can re-use the variable and its definition
-        if (varValue === argValue) {
+        const variableDefinition = variableDefinitions.find(
+          (definition) => definition.variable.name.value === varName,
+        );
+        const variableType =
+          variableDefinition && targetSchema
+            ? typeFromAST(info?.schema ?? targetSchema, variableDefinition.type)
+            : undefined;
+        // If the variable value and type are compatible, we can re-use them
+        if (
+          varValue === argValue &&
+          variableType &&
+          isTypeSubTypeOf(
+            info?.schema ?? targetSchema!,
+            variableType,
+            argInstance.type,
+          )
+        ) {
           argNodes.push(existingArgNode);
           continue;
         }
@@ -130,6 +146,17 @@ export function createRequest({
           let i = 0;
           while (varExists(varName)) {
             varName = `_${i++}_${rootFieldName}_${argName}`;
+          }
+        }
+        if (existingArgNode?.value.kind === Kind.VARIABLE) {
+          const existingVarName = existingArgNode.value.name.value;
+          const existingVarIndex = variableDefinitions.findIndex(
+            (definition) =>
+              definition.variable.name.value === existingVarName,
+          );
+          if (existingVarIndex !== -1) {
+            variableDefinitions.splice(existingVarIndex, 1);
+            delete newVariables[existingVarName];
           }
         }
         variableDefinitions.push({

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -151,8 +151,7 @@ export function createRequest({
         if (existingArgNode?.value.kind === Kind.VARIABLE) {
           const existingVarName = existingArgNode.value.name.value;
           const existingVarIndex = variableDefinitions.findIndex(
-            (definition) =>
-              definition.variable.name.value === existingVarName,
+            (definition) => definition.variable.name.value === existingVarName,
           );
           if (existingVarIndex !== -1) {
             variableDefinitions.splice(existingVarIndex, 1);

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -1,6 +1,13 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { createGraphQLError } from '@graphql-tools/utils';
-import { graphql, Kind, OperationTypeNode } from 'graphql';
+import {
+  buildSchema,
+  graphql,
+  Kind,
+  OperationTypeNode,
+  parse,
+  validate,
+} from 'graphql';
 import { describe, expect, test } from 'vitest';
 import { createRequest } from '../src/createRequest.js';
 import { delegateRequest } from '../src/delegateToSchema.js';
@@ -274,4 +281,47 @@ describe('bare requests', () => {
       ],
     });
   });
+});
+
+test('creates a target-compatible variable when reusing an argument value', () => {
+  const targetSchema = buildSchema(/* GraphQL */ `
+    type Identity {
+      id: ID!
+    }
+    type Query {
+      identity(id: ID!): Identity!
+    }
+  `);
+  const document = parse(/* GraphQL */ `
+    query GetIdentity($identityId: ID) {
+      identity(id: $identityId) {
+        id
+      }
+    }
+  `);
+  const operation = document.definitions[0];
+
+  if (operation?.kind !== Kind.OPERATION_DEFINITION) {
+    throw new Error('Expected an operation definition');
+  }
+  const fieldNode = operation.selectionSet.selections[0];
+  if (fieldNode?.kind !== Kind.FIELD) {
+    throw new Error('Expected a field');
+  }
+
+  const request = createRequest({
+    subgraphName: 'identity',
+    targetOperation: OperationTypeNode.QUERY,
+    targetFieldName: 'identity',
+    targetSchema,
+    fieldNodes: [fieldNode],
+    // @ts-expect-error we are testing the creation of a request with a variable
+    info: {
+      operation,
+      variableValues: { identityId: 'identity-abc-123' },
+    },
+    args: { id: 'identity-abc-123' },
+  });
+
+  expect(validate(targetSchema, request.document)).toEqual([]);
 });


### PR DESCRIPTION
Ref GW-613

Fixes delegated requests reusing variables whose types are incompatible with the target schema argument types.

Previously, `createRequest` reused an original variable when its value matched the delegated argument value, without checking type compatibility. This could reuse a nullable variable such as `ID` for a target argument requiring `ID!`, causing downstream validation to fail.

The request now reuses a variable only when its type is compatible with the target argument type. Otherwise, it removes the unused original variable and creates a new variable using the target schema's argument type.
