### PR TITLE
Enum argument serialization for filtered delegated fields

### DIFF
--- a/.changeset/honest-penguins-rest.md
+++ b/.changeset/honest-penguins-rest.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+Fix enum argument serialization when delegating to a field removed from the transformed schema.
+
+When a delegated query field is filtered from the transformed schema, its arguments now use the original subschema for type lookup. This ensures enum values are sent as typed variables instead of invalid quoted enum literals while preserving input field transforms for fields that remain exposed.

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -88,7 +88,11 @@ export function delegateToSchema<
   const request = createRequest({
     subgraphName: (schema as SubschemaConfig).name,
     fragments,
-    targetSchema,
+    targetSchema:
+      targetSchema.getQueryType()?.getFields()[fieldName] == null &&
+      isSubschemaConfig(schema)
+        ? schema.schema
+        : targetSchema,
     rootValue: rootValue,
     targetOperationName: operationName,
     targetOperation: operation,

--- a/packages/delegate/tests/delegateToSchema.test.ts
+++ b/packages/delegate/tests/delegateToSchema.test.ts
@@ -7,12 +7,12 @@ import {
   isAsyncIterable,
   mergeDeep,
 } from '@graphql-tools/utils';
-import { wrapSchema } from '@graphql-tools/wrap';
+import { FilterRootFields, wrapSchema } from '@graphql-tools/wrap';
 import { graphql, OperationTypeNode, parse } from 'graphql';
 import _ from 'lodash';
 import { describe, expect, test } from 'vitest';
 import { delegateToSchema } from '../src/delegateToSchema.js';
-import { DelegationContext } from '../src/index.js';
+import { DelegationContext, Subschema } from '../src/index.js';
 
 function assertSome<T>(
   input: T,
@@ -69,6 +69,79 @@ describe('delegateToSchema', () => {
 
     assertSome(result.data);
     expect(result.data['delegateToSchema']).toEqual('test');
+  });
+
+  test('should serialize enum arguments when the delegated field is filtered from the transformed schema', async () => {
+    const innerSchema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        enum CustodianEnum {
+          so
+        }
+        input CustodianAccountID {
+          id: ID!
+          custodian: CustodianEnum!
+        }
+        type CustodianAccount {
+          id: ID!
+          custodian: CustodianEnum!
+        }
+        type Query {
+          custodianAccounts(ids: [CustodianAccountID!]!): [CustodianAccount!]!
+        }
+      `,
+      resolvers: {
+        Query: {
+          custodianAccounts: (_root, { ids }) => ids,
+        },
+      },
+    });
+    const subschema = new Subschema({
+      schema: innerSchema,
+      transforms: [
+        new FilterRootFields(
+          (_operation, fieldName) => fieldName !== 'custodianAccounts',
+        ),
+      ],
+    });
+    const outerSchema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        enum CustodianEnum {
+          so
+        }
+        type CustodianAccount {
+          id: ID!
+          custodian: CustodianEnum!
+        }
+        type Query {
+          account: CustodianAccount
+        }
+      `,
+      resolvers: {
+        Query: {
+          account: async (_root, _args, context, info) => {
+            const accounts = await delegateToSchema({
+              schema: subschema,
+              operation: OperationTypeNode.QUERY,
+              fieldName: 'custodianAccounts',
+              args: { ids: [{ id: '123', custodian: 'so' }] },
+              context,
+              info,
+              validateRequest: true,
+            });
+            return accounts[0];
+          },
+        },
+      },
+    });
+
+    const result = await graphql({
+      schema: outerSchema,
+      source: '{ account { id custodian } }',
+    });
+
+    expect(result).toEqual({
+      data: { account: { id: '123', custodian: 'so' } },
+    });
   });
 
   test('should work even where there are default fields', async () => {


### PR DESCRIPTION
Ref GW-614

Fixes delegation to fields that are removed from a subschema's transformed schema, such as private fields used for type merging.

When the delegated query field is absent from the transformed schema, argument types are now looked up from the original subschema. This preserves typed variable serialization for nested enum values instead of inlining them as quoted strings, which downstream GraphQL servers reject.

The transformed schema remains the source for fields that are present, preserving transforms such as renamed input object fields.
