### PR TITLE
Reduce peak memory consumption for stitchSchemas

### DIFF
--- a/.changeset/late-tigers-sin.md
+++ b/.changeset/late-tigers-sin.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/stitch': patch
+---
+
+Reduce peak memory consumption for stitchSchemas function

--- a/.changeset/late-tigers-sin.md
+++ b/.changeset/late-tigers-sin.md
@@ -2,4 +2,4 @@
 '@graphql-tools/stitch': patch
 ---
 
-Reduce peak memory consumption for stitchSchemas function
+Reduce peak memory consumption for `stitchSchemas` function

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -61,6 +61,7 @@ export function stitchSchemas<
     ...rest
   } = options;
   let {
+    typeCandidates,
     newTypeMap,
     newDirectives,
     rootTypeNameMap,
@@ -433,6 +434,7 @@ function prepareStitchingData<TContext extends Record<string, any>>(
   // Everything else falls out of scope and gets Garbage Collected.
   // This is critical to optimize memory usage since schemas can be very big.
   return {
+    typeCandidates,
     newTypeMap,
     newDirectives,
     rootTypeNameMap,

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -18,6 +18,7 @@ import {
 import { inspect, IResolvers } from '@graphql-tools/utils';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import {
+  concatAST,
   extendSchema,
   getNamedType,
   GraphQLDirective,
@@ -50,99 +51,57 @@ import {
 
 export function stitchSchemas<
   TContext extends Record<string, any> = Record<string, any>,
->({
-  subschemas = [],
-  types = [],
-  typeDefs = [],
-  onTypeConflict,
-  mergeTypes = true,
-  typeMergingOptions,
-  subschemaConfigTransforms = [],
-  resolvers = {},
-  inheritResolversFromInterfaces = false,
-  resolverValidationOptions = {},
-  updateResolversInPlace = true,
-  schemaExtensions,
-  ...rest
-}: IStitchSchemasOptions<TContext>): GraphQLSchema {
-  const mergeDirectives = rest.mergeDirectives ?? true;
-  const transformedSubschemas: Array<Subschema<any, any, any, TContext>> = [];
-  const subschemaMap: Map<
-    GraphQLSchema | SubschemaConfig<any, any, any, TContext>,
-    Subschema<any, any, any, TContext>
-  > = new Map();
-  const originalSubschemaMap: Map<
-    Subschema<any, any, any, TContext>,
-    GraphQLSchema | SubschemaConfig<any, any, any, TContext>
-  > = new Map();
-
-  for (const subschema of subschemas) {
-    for (const transformedSubschemaConfig of applySubschemaConfigTransforms(
-      subschemaConfigTransforms,
-      subschema,
-      subschemaMap,
-      originalSubschemaMap,
-    )) {
-      transformedSubschemas.push(transformedSubschemaConfig);
-    }
-  }
-
-  const directiveMap: Record<string, GraphQLDirective> = Object.create(null);
-  for (const directive of specifiedDirectives) {
-    directiveMap[directive.name] = directive;
-  }
-  const schemaDefs = Object.create(null);
-
-  const [typeCandidates, rootTypeNameMap, extensions] = buildTypeCandidates({
-    subschemas: transformedSubschemas,
-    originalSubschemaMap,
-    types,
-    typeDefs: typeDefs || [],
-    parseOptions: rest,
-    directiveMap,
-    schemaDefs,
-    mergeDirectives,
-  });
-
-  let stitchingInfo = createStitchingInfo(
-    subschemaMap,
-    typeCandidates,
-    mergeTypes,
-  );
-
-  const { typeMap: newTypeMap, directives: newDirectives } = buildTypes({
-    typeCandidates,
-    directives: Object.values(directiveMap),
+>(options: IStitchSchemasOptions<TContext>): GraphQLSchema {
+  const {
+    resolvers = {},
+    inheritResolversFromInterfaces = false,
+    resolverValidationOptions = {},
+    updateResolversInPlace = true,
+    schemaExtensions,
+    ...rest
+  } = options;
+  let {
+    newTypeMap,
+    newDirectives,
+    rootTypeNameMap,
     stitchingInfo,
-    rootTypeNames: Object.values(rootTypeNameMap),
-    onTypeConflict,
-    mergeTypes,
-    typeMergingOptions,
-  });
+    schemaDefs,
+    extensions,
+    mergeDirectives,
+  } = prepareStitchingData(options);
 
-  if (!mergeDirectives) {
-    stripCustomDirectiveUsages(Object.values(newTypeMap));
+  let schema: GraphQLSchema;
+  {
+    // try to optimize memory...
+    // allocate inside scope to allow freeing after.
+    const finalTypes = Object.values(newTypeMap);
+
+    if (!mergeDirectives) {
+      stripCustomDirectiveUsages(finalTypes);
+    }
+
+    schema = new GraphQLSchema({
+      query: newTypeMap[rootTypeNameMap.query] as GraphQLObjectType,
+      mutation: newTypeMap[rootTypeNameMap.mutation] as GraphQLObjectType,
+      subscription: newTypeMap[
+        rootTypeNameMap.subscription
+      ] as GraphQLObjectType,
+      types: finalTypes,
+      directives: newDirectives,
+      astNode: schemaDefs.schemaDef,
+      extensionASTNodes: schemaDefs.schemaExtensions,
+      extensions: null,
+      assumeValid: rest.assumeValid,
+    });
   }
 
-  let schema = new GraphQLSchema({
-    query: newTypeMap[rootTypeNameMap.query] as GraphQLObjectType,
-    mutation: newTypeMap[rootTypeNameMap.mutation] as GraphQLObjectType,
-    subscription: newTypeMap[rootTypeNameMap.subscription] as GraphQLObjectType,
-    types: Object.values(newTypeMap),
-    directives: newDirectives,
-    astNode: schemaDefs.schemaDef,
-    extensionASTNodes: schemaDefs.schemaExtensions,
-    extensions: null,
-    assumeValid: rest.assumeValid,
-  });
-
-  for (const extension of extensions) {
-    schema = extendSchema(schema, extension, {
+  if (extensions.length > 0) {
+    const mergedExtensions = concatAST(extensions);
+    schema = extendSchema(schema, mergedExtensions, {
       commentDescriptions: true,
     } as any);
   }
 
-  // We allow passing in an array of resolver maps, in which case we merge them
   const resolverMap: IResolvers = mergeResolvers(resolvers);
 
   const finalResolvers = inheritResolversFromInterfaces
@@ -176,10 +135,11 @@ export function stitchSchemas<
   addStitchingInfo(schema, stitchingInfo);
 
   if (schemaExtensions) {
-    if (Array.isArray(schemaExtensions)) {
-      schemaExtensions = mergeExtensions(schemaExtensions);
-    }
-    applyExtensions(schema, schemaExtensions);
+    const mergedSchemaExtensions = Array.isArray(schemaExtensions)
+      ? mergeExtensions(schemaExtensions)
+      : schemaExtensions;
+
+    applyExtensions(schema, mergedSchemaExtensions);
   }
 
   return schema;
@@ -401,4 +361,84 @@ function applySubschemaConfigTransforms<TContext = Record<string, any>>(
   }
 
   return transformedSubschemas;
+}
+
+function prepareStitchingData<TContext extends Record<string, any>>(
+  options: IStitchSchemasOptions<TContext>,
+) {
+  const {
+    subschemas = [],
+    types = [],
+    typeDefs = [],
+    onTypeConflict,
+    mergeTypes = true,
+    typeMergingOptions,
+    subschemaConfigTransforms = [],
+    ...rest
+  } = options;
+
+  const mergeDirectives = rest.mergeDirectives ?? true;
+  const transformedSubschemas: Array<Subschema<any, any, any, TContext>> = [];
+
+  // These maps take up a lot of memory during large stitches...
+  const subschemaMap = new Map();
+  const originalSubschemaMap = new Map();
+
+  for (const subschema of subschemas) {
+    for (const transformedSubschemaConfig of applySubschemaConfigTransforms(
+      subschemaConfigTransforms,
+      subschema,
+      subschemaMap,
+      originalSubschemaMap,
+    )) {
+      transformedSubschemas.push(transformedSubschemaConfig);
+    }
+  }
+
+  const directiveMap: Record<string, GraphQLDirective> = Object.create(null);
+  for (const directive of specifiedDirectives) {
+    directiveMap[directive.name] = directive;
+  }
+  const schemaDefs = Object.create(null);
+
+  // note that typeCandidates is usually a massive object in large schemas
+  const [typeCandidates, rootTypeNameMap, extensions] = buildTypeCandidates({
+    subschemas: transformedSubschemas,
+    originalSubschemaMap,
+    types,
+    typeDefs: typeDefs || [],
+    parseOptions: rest,
+    directiveMap,
+    schemaDefs,
+    mergeDirectives,
+  });
+
+  const stitchingInfo = createStitchingInfo(
+    subschemaMap,
+    typeCandidates,
+    mergeTypes,
+  );
+
+  const { typeMap: newTypeMap, directives: newDirectives } = buildTypes({
+    typeCandidates,
+    directives: Object.values(directiveMap),
+    stitchingInfo,
+    rootTypeNames: Object.values(rootTypeNameMap),
+    onTypeConflict,
+    mergeTypes,
+    typeMergingOptions,
+  });
+
+  // We only return the specific references the main function actually needs.
+  // Everything else falls out of scope and gets Garbage Collected.
+  // This is critical to optimize memory usage since schemas can be very big.
+  return {
+    newTypeMap,
+    newDirectives,
+    rootTypeNameMap,
+    stitchingInfo,
+    schemaDefs,
+    extensions,
+    mergeDirectives,
+  };
 }


### PR DESCRIPTION
A minor improvement to memory usage. This places several of the larger objects inside utility functions and/or blocks to inform the runtime that it can free these objects in memory earlier.

For these high memory consumption functions, this is the difference between running out of memory and being able to process a larger schema.

A further improvement would be if we could gradually append new schemas onto a stitched schema, so that the older GraphQLSchema object could be freed. But this would require much more refactoring.