### PR TITLE
Proper enum serialization and variables/arguments discovery

### DIFF
--- a/.changeset/healthy-drinks-eat.md
+++ b/.changeset/healthy-drinks-eat.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+Fix delegated argument serialization when fields are filtered or renamed
+
+Inline enum values now remain enum literals, and original variable definitions are preserved while still referenced by fragments, selections, directives, or other arguments.

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -244,21 +244,23 @@ export function createRequest({
     definitions,
   };
 
-  const usedVariableNames = new Set<string>();
-  visit(document, {
-    VariableDefinition: () => false,
-    Variable: (variableNode) => {
-      usedVariableNames.add(variableNode.name.value);
-    },
-  });
-  for (const variableName of replacedVariableNames) {
-    if (!usedVariableNames.has(variableName)) {
-      const variableIndex = variableDefinitions.findIndex(
-        (definition) => definition.variable.name.value === variableName,
-      );
-      if (variableIndex !== -1) {
-        variableDefinitions.splice(variableIndex, 1);
-        delete newVariables[variableName];
+  if (replacedVariableNames.size > 0) {
+    const usedVariableNames = new Set<string>();
+    visit(document, {
+      VariableDefinition: () => false,
+      Variable: (variableNode) => {
+        usedVariableNames.add(variableNode.name.value);
+      },
+    });
+    for (const variableName of replacedVariableNames) {
+      if (!usedVariableNames.has(variableName)) {
+        const variableIndex = variableDefinitions.findIndex(
+          (definition) => definition.variable.name.value === variableName,
+        );
+        if (variableIndex !== -1) {
+          variableDefinitions.splice(variableIndex, 1);
+          delete newVariables[variableName];
+        }
       }
     }
   }

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -107,11 +107,11 @@ export function createRequest({
         (argNode) => argNode.name.value === argName,
       );
       // Check if we can re-use the variable from the original request for this argument
+      if (existingArgNode && !argInstance) {
+        argNodes.push(existingArgNode);
+        continue;
+      }
       if (existingArgNode?.value.kind === Kind.VARIABLE) {
-        if (!argInstance) {
-          argNodes.push(existingArgNode);
-          continue;
-        }
         const varName = existingArgNode.value.name.value;
         const varValue = newVariables[varName];
         const variableDefinition = variableDefinitions.find(

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -106,7 +106,7 @@ export function createRequest({
       const existingArgNode = fieldNode?.arguments?.find(
         (argNode) => argNode.name.value === argName,
       );
-      // Check if we can re-use the variable from the original request for this argument
+      // If we can't resolve the argument type from the target schema, preserve the original argument AST (variable or literal) to avoid losing enum literal kinds.
       if (existingArgNode && !argInstance) {
         argNodes.push(existingArgNode);
         continue;

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -125,6 +125,7 @@ export function createRequest({
         if (
           varValue === argValue &&
           variableType &&
+          argInstance &&
           isTypeSubTypeOf(
             info?.schema ?? targetSchema!,
             variableType,

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -91,18 +91,7 @@ export function createRequest({
     ? [...info.operation.variableDefinitions]
     : [];
   const argNodes: ArgumentNode[] = [];
-  const variablesUsedOutsideRootArguments = new Set<string>();
-  for (const node of [
-    ...(newSelectionSet ? [newSelectionSet] : []),
-    ...(fieldNode?.directives ?? []),
-    ...(fragments ?? []),
-  ]) {
-    visit(node, {
-      Variable: (variableNode) => {
-        variablesUsedOutsideRootArguments.add(variableNode.name.value);
-      },
-    });
-  }
+  const replacedVariableNames = new Set<string>();
 
   if (args != null) {
     const rootType =
@@ -166,17 +155,7 @@ export function createRequest({
           }
         }
         if (existingArgNode?.value.kind === Kind.VARIABLE) {
-          const existingVarName = existingArgNode.value.name.value;
-          const existingVarIndex = variableDefinitions.findIndex(
-            (definition) => definition.variable.name.value === existingVarName,
-          );
-          if (
-            existingVarIndex !== -1 &&
-            !variablesUsedOutsideRootArguments.has(existingVarName)
-          ) {
-            variableDefinitions.splice(existingVarIndex, 1);
-            delete newVariables[existingVarName];
-          }
+          replacedVariableNames.add(existingArgNode.value.name.value);
         }
         variableDefinitions.push({
           kind: Kind.VARIABLE_DEFINITION,
@@ -263,6 +242,25 @@ export function createRequest({
     kind: Kind.DOCUMENT,
     definitions,
   };
+
+  const usedVariableNames = new Set<string>();
+  visit(document, {
+    VariableDefinition: () => false,
+    Variable: (variableNode) => {
+      usedVariableNames.add(variableNode.name.value);
+    },
+  });
+  for (const variableName of replacedVariableNames) {
+    if (!usedVariableNames.has(variableName)) {
+      const variableIndex = variableDefinitions.findIndex(
+        (definition) => definition.variable.name.value === variableName,
+      );
+      if (variableIndex !== -1) {
+        variableDefinitions.splice(variableIndex, 1);
+        delete newVariables[variableName];
+      }
+    }
+  }
 
   return {
     subgraphName,

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -24,6 +24,7 @@ import {
   SelectionNode,
   SelectionSetNode,
   typeFromAST,
+  visit,
 } from 'graphql';
 import { ICreateRequest } from './types.js';
 
@@ -90,6 +91,18 @@ export function createRequest({
     ? [...info.operation.variableDefinitions]
     : [];
   const argNodes: ArgumentNode[] = [];
+  const variablesUsedOutsideRootArguments = new Set<string>();
+  for (const node of [
+    ...(newSelectionSet ? [newSelectionSet] : []),
+    ...(fieldNode?.directives ?? []),
+    ...(fragments ?? []),
+  ]) {
+    visit(node, {
+      Variable: (variableNode) => {
+        variablesUsedOutsideRootArguments.add(variableNode.name.value);
+      },
+    });
+  }
 
   if (args != null) {
     const rootType =
@@ -105,7 +118,11 @@ export function createRequest({
         (argNode) => argNode.name.value === argName,
       );
       // Check if we can re-use the variable from the original request for this argument
-      if (existingArgNode?.value.kind === Kind.VARIABLE && argInstance) {
+      if (existingArgNode?.value.kind === Kind.VARIABLE) {
+        if (!argInstance) {
+          argNodes.push(existingArgNode);
+          continue;
+        }
         const varName = existingArgNode.value.name.value;
         const varValue = newVariables[varName];
         const variableDefinition = variableDefinitions.find(
@@ -153,7 +170,10 @@ export function createRequest({
           const existingVarIndex = variableDefinitions.findIndex(
             (definition) => definition.variable.name.value === existingVarName,
           );
-          if (existingVarIndex !== -1) {
+          if (
+            existingVarIndex !== -1 &&
+            !variablesUsedOutsideRootArguments.has(existingVarName)
+          ) {
             variableDefinitions.splice(existingVarIndex, 1);
             delete newVariables[existingVarName];
           }

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -84,12 +84,18 @@ export function delegateToSchema<
   }
 
   const fragments = info ? getFragmentDefinitions(info) : undefined;
+  const targetRootType =
+    operation === OperationTypeNode.MUTATION
+      ? targetSchema.getMutationType()
+      : operation === OperationTypeNode.SUBSCRIPTION
+        ? targetSchema.getSubscriptionType()
+        : targetSchema.getQueryType();
 
   const request = createRequest({
     subgraphName: (schema as SubschemaConfig).name,
     fragments,
     targetSchema:
-      getDefinedRootType(targetSchema, operation).getFields()[fieldName] == null &&
+      targetRootType?.getFields()[fieldName] == null &&
       isSubschemaConfig(schema)
         ? schema.schema
         : targetSchema,

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -89,7 +89,7 @@ export function delegateToSchema<
     subgraphName: (schema as SubschemaConfig).name,
     fragments,
     targetSchema:
-      targetSchema.getQueryType()?.getFields()[fieldName] == null &&
+      getDefinedRootType(targetSchema, operation).getFields()[fieldName] == null &&
       isSubschemaConfig(schema)
         ? schema.schema
         : targetSchema,

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -2,6 +2,7 @@ import { makeExecutableSchema } from '@graphql-tools/schema';
 import { createGraphQLError } from '@graphql-tools/utils';
 import {
   buildSchema,
+  DocumentNode,
   graphql,
   Kind,
   OperationTypeNode,
@@ -345,6 +346,7 @@ test('does not inline enum arguments as quoted strings when the delegated field 
       createThing(input: CreateThingInput!): Thing
     }
   `);
+
   // the delegated field has been filtered out of the target schema
   // (@inaccessible, FilterRootFields, ...), so its arg types cannot be looked up
   const targetSchema = buildSchema(/* GraphQL */ `
@@ -364,66 +366,78 @@ test('does not inline enum arguments as quoted strings when the delegated field 
       other: Boolean
     }
   `);
-  // the subgraph the delegated document is actually sent to still has the field
-  const subgraphSchema = buildSchema(/* GraphQL */ `
-    enum Color {
-      RED
-      GREEN
-      BLUE
+
+  function buildRequest(
+    document: DocumentNode,
+    variableValues: Record<string, unknown>,
+  ) {
+    const operation = document.definitions[0];
+    if (operation?.kind !== Kind.OPERATION_DEFINITION) {
+      throw new Error('Expected an operation definition');
     }
-    input CreateThingInput {
-      name: String!
-      color: Color!
+    const fieldNode = operation.selectionSet.selections[0];
+    if (fieldNode?.kind !== Kind.FIELD) {
+      throw new Error('Expected a field');
     }
-    type Thing {
-      id: ID!
-    }
-    type Query {
-      _: Boolean
-    }
-    type Mutation {
-      createThing(input: CreateThingInput!): Thing
-    }
-  `);
-  const document = parse(/* GraphQL */ `
-    mutation CreateThing($input: CreateThingInput!) {
+    // const variableValues = { input: { name: 'x', color: 'RED' } };
+
+    return createRequest({
+      subgraphName: 'inner',
+      targetOperation: OperationTypeNode.MUTATION,
+      targetFieldName: 'createThing',
+      targetSchema,
+      fieldNodes: [fieldNode],
+      // @ts-expect-error only the fields read by createRequest are needed here
+      info: {
+        schema: gatewaySchema,
+        operation,
+        variableValues,
+      },
+      args: variableValues,
+    });
+  }
+
+  // vars
+  const variableValues = {
+    input: { name: 'x', color: 'RED' },
+  };
+  const requestVars = buildRequest(
+    parse(/* GraphQL */ `
+      mutation CreateThingVars($input: CreateThingInput!) {
+        createThing(input: $input) {
+          id
+        }
+      }
+    `),
+    variableValues,
+  );
+  expect(print(requestVars.document)).toMatchInlineSnapshot(`
+    "mutation ($input: CreateThingInput!) {
       createThing(input: $input) {
         id
       }
-    }
+    }"
   `);
-  const operation = document.definitions[0];
-  if (operation?.kind !== Kind.OPERATION_DEFINITION) {
-    throw new Error('Expected an operation definition');
-  }
-  const fieldNode = operation.selectionSet.selections[0];
-  if (fieldNode?.kind !== Kind.FIELD) {
-    throw new Error('Expected a field');
-  }
-  const variableValues = { input: { name: 'x', color: 'RED' } };
+  expect(requestVars.variables).toMatchObject(variableValues);
 
-  const request = createRequest({
-    subgraphName: 'inner',
-    targetOperation: OperationTypeNode.MUTATION,
-    targetFieldName: 'createThing',
-    targetSchema,
-    fieldNodes: [fieldNode],
-    // @ts-expect-error only the fields read by createRequest are needed here
-    info: {
-      schema: gatewaySchema,
-      operation,
-      variableValues,
-    },
-    args: { input: variableValues.input },
-  });
-
-  // either forwarding `$input` or inlining a proper EnumValue is acceptable,
-  // a quoted `color: "RED"` is not
-  expect(validate(subgraphSchema, request.document)).toEqual([]);
-  const serialized =
-    print(request.document) + JSON.stringify(request.variables);
-  expect(serialized).not.toContain('color: "RED"');
-  expect(serialized).toContain('RED');
+  // inline
+  const requestInl = buildRequest(
+    parse(/* GraphQL */ `
+      mutation CreateThingVars {
+        createThing(input: { name: "x", color: RED }) {
+          id
+        }
+      }
+    `),
+    variableValues,
+  );
+  expect(print(requestInl.document)).toMatchInlineSnapshot(`
+    "mutation {
+      createThing(input: {name: "x", color: RED}) {
+        id
+      }
+    }"
+  `);
 });
 
 test('keeps the original variable definition when it is still used inside a fragment', () => {
@@ -444,6 +458,7 @@ test('keeps the original variable definition when it is still used inside a frag
       grouping(filter: Filter!): Group
     }
   `);
+
   const document = parse(/* GraphQL */ `
     query Board($filter: Filter) {
       grouping(filter: $filter) {
@@ -491,7 +506,21 @@ test('keeps the original variable definition when it is still used inside a frag
     args: { filter: variableValues.filter },
   });
 
-  expect(validate(targetSchema, request.document)).toEqual([]);
+  expect(print(request.document)).toMatchInlineSnapshot(`
+    "query ($filter: Filter, $_grouping_filter: Filter!) {
+      grouping(filter: $_grouping_filter) {
+        ...GroupFields
+      }
+    }
+
+    fragment GroupFields on Group {
+      visible {
+        values(filter: $filter) {
+          id
+        }
+      }
+    }"
+  `);
   expect(request.variables).toMatchObject(variableValues);
 });
 
@@ -513,6 +542,7 @@ test('keeps the original variable definition when it is still used by a sibling 
       grouping(filter: Filter!): Group
     }
   `);
+
   const document = parse(/* GraphQL */ `
     query Board($filter: Filter) {
       grouping(filter: $filter) {
@@ -551,7 +581,17 @@ test('keeps the original variable definition when it is still used by a sibling 
     args: { filter: variableValues.filter },
   });
 
-  expect(validate(targetSchema, request.document)).toEqual([]);
+  expect(print(request.document)).toMatchInlineSnapshot(`
+    "query ($filter: Filter, $_grouping_filter: Filter!) {
+      grouping(filter: $_grouping_filter) {
+        visible {
+          values(filter: $filter) {
+            id
+          }
+        }
+      }
+    }"
+  `);
   expect(request.variables).toMatchObject(variableValues);
 });
 
@@ -561,6 +601,7 @@ test('keeps the original variable definition when it is still used by a root fie
       check(flag: Boolean!): Boolean
     }
   `);
+
   const document = parse(/* GraphQL */ `
     query Check($flag: Boolean = true) {
       check(flag: $flag) @include(if: $flag)
@@ -590,7 +631,11 @@ test('keeps the original variable definition when it is still used by a root fie
     args: { flag: true },
   });
 
-  expect(validate(targetSchema, request.document)).toEqual([]);
+  expect(print(request.document)).toMatchInlineSnapshot(`
+    "query ($flag: Boolean = true, $_check_flag: Boolean!) {
+      check(flag: $_check_flag) @include(if: $flag)
+    }"
+  `);
   expect(request.variables).toMatchObject({ flag: true });
 });
 
@@ -605,6 +650,7 @@ test('keeps a variable forwarded by another root argument', () => {
       field(a: String!): String
     }
   `);
+
   const document = parse(/* GraphQL */ `
     query SharedArgument($value: String) {
       field(a: $value, b: $value)
@@ -634,6 +680,10 @@ test('keeps a variable forwarded by another root argument', () => {
     args: { a: 'x', b: 'x' },
   });
 
-  expect(validate(gatewaySchema, request.document)).toEqual([]);
+  expect(print(request.document)).toMatchInlineSnapshot(`
+    "query ($value: String, $a: String!) {
+      field(a: $a, b: $value)
+    }"
+  `);
   expect(request.variables).toMatchObject({ value: 'x' });
 });

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -554,3 +554,86 @@ test('keeps the original variable definition when it is still used by a sibling 
   expect(validate(targetSchema, request.document)).toEqual([]);
   expect(request.variables).toMatchObject(variableValues);
 });
+
+test('keeps the original variable definition when it is still used by a root field directive', () => {
+  const targetSchema = buildSchema(/* GraphQL */ `
+    type Query {
+      check(flag: Boolean!): Boolean
+    }
+  `);
+  const document = parse(/* GraphQL */ `
+    query Check($flag: Boolean = true) {
+      check(flag: $flag) @include(if: $flag)
+    }
+  `);
+  const operation = document.definitions[0];
+  if (operation?.kind !== Kind.OPERATION_DEFINITION) {
+    throw new Error('Expected an operation definition');
+  }
+  const fieldNode = operation.selectionSet.selections[0];
+  if (fieldNode?.kind !== Kind.FIELD) {
+    throw new Error('Expected a field');
+  }
+
+  const request = createRequest({
+    subgraphName: 'inner',
+    targetOperation: OperationTypeNode.QUERY,
+    targetFieldName: 'check',
+    targetSchema,
+    fieldNodes: [fieldNode],
+    // @ts-expect-error only the fields read by createRequest are needed here
+    info: {
+      schema: targetSchema,
+      operation,
+      variableValues: { flag: true },
+    },
+    args: { flag: true },
+  });
+
+  expect(validate(targetSchema, request.document)).toEqual([]);
+  expect(request.variables).toMatchObject({ flag: true });
+});
+
+test('keeps a variable forwarded by another root argument', () => {
+  const gatewaySchema = buildSchema(/* GraphQL */ `
+    type Query {
+      field(a: String!, b: String): String
+    }
+  `);
+  const targetSchema = buildSchema(/* GraphQL */ `
+    type Query {
+      field(a: String!): String
+    }
+  `);
+  const document = parse(/* GraphQL */ `
+    query SharedArgument($value: String) {
+      field(a: $value, b: $value)
+    }
+  `);
+  const operation = document.definitions[0];
+  if (operation?.kind !== Kind.OPERATION_DEFINITION) {
+    throw new Error('Expected an operation definition');
+  }
+  const fieldNode = operation.selectionSet.selections[0];
+  if (fieldNode?.kind !== Kind.FIELD) {
+    throw new Error('Expected a field');
+  }
+
+  const request = createRequest({
+    subgraphName: 'inner',
+    targetOperation: OperationTypeNode.QUERY,
+    targetFieldName: 'field',
+    targetSchema,
+    fieldNodes: [fieldNode],
+    // @ts-expect-error only the fields read by createRequest are needed here
+    info: {
+      schema: gatewaySchema,
+      operation,
+      variableValues: { value: 'x' },
+    },
+    args: { a: 'x', b: 'x' },
+  });
+
+  expect(validate(gatewaySchema, request.document)).toEqual([]);
+  expect(request.variables).toMatchObject({ value: 'x' });
+});

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -6,6 +6,7 @@ import {
   Kind,
   OperationTypeNode,
   parse,
+  print,
   validate,
 } from 'graphql';
 import { describe, expect, test } from 'vitest';
@@ -324,4 +325,78 @@ test('creates a target-compatible variable when reusing an argument value', () =
   });
 
   expect(validate(targetSchema, request.document)).toEqual([]);
+});
+
+test('forwards enum arguments as variables when the delegated field is missing from the target schema', () => {
+  const gatewaySchema = buildSchema(/* GraphQL */ `
+    enum Color {
+      RED
+      GREEN
+      BLUE
+    }
+    input CreateThingInput {
+      name: String!
+      color: Color!
+    }
+    type Thing {
+      id: ID!
+    }
+    type Mutation {
+      createThing(input: CreateThingInput!): Thing
+    }
+  `);
+  // the delegated field has been filtered out of the target schema
+  // (@inaccessible, FilterRootFields, ...), so its arg types cannot be looked up
+  const targetSchema = buildSchema(/* GraphQL */ `
+    enum Color {
+      RED
+      GREEN
+      BLUE
+    }
+    input CreateThingInput {
+      name: String!
+      color: Color!
+    }
+    type Thing {
+      id: ID!
+    }
+    type Mutation {
+      other: Boolean
+    }
+  `);
+  const document = parse(/* GraphQL */ `
+    mutation CreateThing($input: CreateThingInput!) {
+      createThing(input: $input) {
+        id
+      }
+    }
+  `);
+  const operation = document.definitions[0];
+  if (operation?.kind !== Kind.OPERATION_DEFINITION) {
+    throw new Error('Expected an operation definition');
+  }
+  const fieldNode = operation.selectionSet.selections[0];
+  if (fieldNode?.kind !== Kind.FIELD) {
+    throw new Error('Expected a field');
+  }
+  const variableValues = { input: { name: 'x', color: 'RED' } };
+
+  const request = createRequest({
+    subgraphName: 'inner',
+    targetOperation: OperationTypeNode.MUTATION,
+    targetFieldName: 'createThing',
+    targetSchema,
+    fieldNodes: [fieldNode],
+    // @ts-expect-error only the fields read by createRequest are needed here
+    info: {
+      schema: gatewaySchema,
+      operation,
+      variableValues,
+    },
+    args: { input: variableValues.input },
+  });
+
+  // the enum must not be inlined as a quoted string, it has to stay a variable
+  expect(print(request.document)).toContain('createThing(input: $input)');
+  expect(request.variables).toEqual(variableValues);
 });

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -378,6 +378,9 @@ test('does not inline enum arguments as quoted strings when the delegated field 
     type Thing {
       id: ID!
     }
+    type Query {
+      _: Boolean
+    }
     type Mutation {
       createThing(input: CreateThingInput!): Thing
     }

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -327,7 +327,7 @@ test('creates a target-compatible variable when reusing an argument value', () =
   expect(validate(targetSchema, request.document)).toEqual([]);
 });
 
-test('forwards enum arguments as variables when the delegated field is missing from the target schema', () => {
+test('does not inline enum arguments as quoted strings when the delegated field is missing from the target schema', () => {
   const gatewaySchema = buildSchema(/* GraphQL */ `
     enum Color {
       RED
@@ -364,6 +364,24 @@ test('forwards enum arguments as variables when the delegated field is missing f
       other: Boolean
     }
   `);
+  // the subgraph the delegated document is actually sent to still has the field
+  const subgraphSchema = buildSchema(/* GraphQL */ `
+    enum Color {
+      RED
+      GREEN
+      BLUE
+    }
+    input CreateThingInput {
+      name: String!
+      color: Color!
+    }
+    type Thing {
+      id: ID!
+    }
+    type Mutation {
+      createThing(input: CreateThingInput!): Thing
+    }
+  `);
   const document = parse(/* GraphQL */ `
     mutation CreateThing($input: CreateThingInput!) {
       createThing(input: $input) {
@@ -396,9 +414,13 @@ test('forwards enum arguments as variables when the delegated field is missing f
     args: { input: variableValues.input },
   });
 
-  // the enum must not be inlined as a quoted string, it has to stay a variable
-  expect(print(request.document)).toContain('createThing(input: $input)');
-  expect(request.variables).toEqual(variableValues);
+  // either forwarding `$input` or inlining a proper EnumValue is acceptable,
+  // a quoted `color: "RED"` is not
+  expect(validate(subgraphSchema, request.document)).toEqual([]);
+  const serialized =
+    print(request.document) + JSON.stringify(request.variables);
+  expect(serialized).not.toContain('color: "RED"');
+  expect(serialized).toContain('RED');
 });
 
 test('keeps the original variable definition when it is still used inside a fragment', () => {
@@ -457,6 +479,66 @@ test('keeps the original variable definition when it is still used inside a frag
     targetSchema,
     fieldNodes: [fieldNode],
     fragments: [fragment],
+    // @ts-expect-error only the fields read by createRequest are needed here
+    info: {
+      schema: targetSchema,
+      operation,
+      variableValues,
+    },
+    args: { filter: variableValues.filter },
+  });
+
+  expect(validate(targetSchema, request.document)).toEqual([]);
+  expect(request.variables).toMatchObject(variableValues);
+});
+
+test('keeps the original variable definition when it is still used by a sibling selection', () => {
+  const targetSchema = buildSchema(/* GraphQL */ `
+    input Filter {
+      visible: Boolean
+    }
+    type Value {
+      id: ID!
+    }
+    type Section {
+      values(filter: Filter): [Value!]!
+    }
+    type Group {
+      visible: Section
+    }
+    type Query {
+      grouping(filter: Filter!): Group
+    }
+  `);
+  const document = parse(/* GraphQL */ `
+    query Board($filter: Filter) {
+      grouping(filter: $filter) {
+        visible {
+          values(filter: $filter) {
+            id
+          }
+        }
+      }
+    }
+  `);
+  const operation = document.definitions[0];
+  if (operation?.kind !== Kind.OPERATION_DEFINITION) {
+    throw new Error('Expected an operation definition');
+  }
+  const fieldNode = operation.selectionSet.selections[0];
+  if (fieldNode?.kind !== Kind.FIELD) {
+    throw new Error('Expected a field');
+  }
+  const variableValues = { filter: { visible: true } };
+
+  // same as above but with no fragment involved, so a usage scan that only
+  // walks fragments would still miss this one
+  const request = createRequest({
+    subgraphName: 'inner',
+    targetOperation: OperationTypeNode.QUERY,
+    targetFieldName: 'grouping',
+    targetSchema,
+    fieldNodes: [fieldNode],
     // @ts-expect-error only the fields read by createRequest are needed here
     info: {
       schema: targetSchema,

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -400,3 +400,72 @@ test('forwards enum arguments as variables when the delegated field is missing f
   expect(print(request.document)).toContain('createThing(input: $input)');
   expect(request.variables).toEqual(variableValues);
 });
+
+test('keeps the original variable definition when it is still used inside a fragment', () => {
+  const targetSchema = buildSchema(/* GraphQL */ `
+    input Filter {
+      visible: Boolean
+    }
+    type Value {
+      id: ID!
+    }
+    type Section {
+      values(filter: Filter): [Value!]!
+    }
+    type Group {
+      visible: Section
+    }
+    type Query {
+      grouping(filter: Filter!): Group
+    }
+  `);
+  const document = parse(/* GraphQL */ `
+    query Board($filter: Filter) {
+      grouping(filter: $filter) {
+        ...GroupFields
+      }
+    }
+
+    fragment GroupFields on Group {
+      visible {
+        values(filter: $filter) {
+          id
+        }
+      }
+    }
+  `);
+  const operation = document.definitions[0];
+  if (operation?.kind !== Kind.OPERATION_DEFINITION) {
+    throw new Error('Expected an operation definition');
+  }
+  const fragment = document.definitions[1];
+  if (fragment?.kind !== Kind.FRAGMENT_DEFINITION) {
+    throw new Error('Expected a fragment definition');
+  }
+  const fieldNode = operation.selectionSet.selections[0];
+  if (fieldNode?.kind !== Kind.FIELD) {
+    throw new Error('Expected a field');
+  }
+  const variableValues = { filter: { visible: true } };
+
+  // the nullable $filter is not assignable to the non-null arg, so the root arg
+  // gets its own variable, but $filter is still referenced from the fragment
+  const request = createRequest({
+    subgraphName: 'inner',
+    targetOperation: OperationTypeNode.QUERY,
+    targetFieldName: 'grouping',
+    targetSchema,
+    fieldNodes: [fieldNode],
+    fragments: [fragment],
+    // @ts-expect-error only the fields read by createRequest are needed here
+    info: {
+      schema: targetSchema,
+      operation,
+      variableValues,
+    },
+    args: { filter: variableValues.filter },
+  });
+
+  expect(validate(targetSchema, request.document)).toEqual([]);
+  expect(request.variables).toMatchObject(variableValues);
+});

--- a/packages/delegate/tests/delegateToSchema.test.ts
+++ b/packages/delegate/tests/delegateToSchema.test.ts
@@ -285,8 +285,8 @@ describe('delegateToSchema', () => {
         }
       `,
     });
-    // the delegation target only exists under its encapsulated name, so neither
-    // the transformed schema nor the original subschema can resolve its arg types
+    // the gateway delegates using the encapsulated field name; only the transformed
+    // schema contains that name (the original subschema schema does not)
     const subschema = new Subschema({
       schema: innerSchema,
       transforms: [

--- a/packages/delegate/tests/delegateToSchema.test.ts
+++ b/packages/delegate/tests/delegateToSchema.test.ts
@@ -12,7 +12,13 @@ import {
   RenameRootFields,
   wrapSchema,
 } from '@graphql-tools/wrap';
-import { graphql, OperationTypeNode, parse, print } from 'graphql';
+import {
+  graphql,
+  OperationTypeNode,
+  parse,
+  print,
+  validate,
+} from 'graphql';
 import _ from 'lodash';
 import { describe, expect, test } from 'vitest';
 import { delegateToSchema } from '../src/delegateToSchema.js';
@@ -235,8 +241,11 @@ describe('delegateToSchema', () => {
     });
 
     expect(result).toEqual({ data: { createThing: { id: '1' } } });
-    // the enum must not be inlined as a quoted string
-    expect(delegatedDocuments[0]).not.toContain('color: "RED"');
+    // the document must be valid against the subgraph it is sent to, a quoted
+    // `color: "RED"` fails with 'Enum "Color" cannot represent non-enum value'
+    const delegated = delegatedDocuments[0];
+    expect(delegated).toBeDefined();
+    expect(validate(innerSchema, parse(delegated!))).toEqual([]);
   });
 
   test('should work even where there are default fields', async () => {

--- a/packages/delegate/tests/delegateToSchema.test.ts
+++ b/packages/delegate/tests/delegateToSchema.test.ts
@@ -154,6 +154,119 @@ describe('delegateToSchema', () => {
     });
   });
 
+  test.each([
+    {
+      name: 'the transformed mutation root is absent',
+      queryFields: 'status: Boolean',
+      mutationFields: '',
+    },
+    {
+      name: 'the query root has a field with the same name',
+      queryFields: 'createThing: Boolean',
+      mutationFields: 'keepMutationRoot: Boolean',
+    },
+  ])(
+    'should recover argument types when $name',
+    async ({ queryFields, mutationFields }) => {
+      const innerSchema = makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+          enum Color {
+            RED
+            GREEN
+          }
+          input CreateThingInput {
+            color: Color!
+          }
+          type Thing {
+            id: ID!
+          }
+          type Query {
+            ${queryFields}
+          }
+          type Mutation {
+            createThing(input: CreateThingInput!): Thing
+            ${mutationFields}
+          }
+        `,
+        resolvers: {
+          Mutation: {
+            createThing: () => ({ id: '1' }),
+          },
+        },
+      });
+      const subschema = new Subschema({
+        schema: innerSchema,
+        transforms: [
+          new FilterRootFields(
+            (operation, fieldName) =>
+              `${operation}.${fieldName}` !== 'Mutation.createThing',
+          ),
+        ],
+      });
+      const outerSchema = makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+          enum Color {
+            RED
+            GREEN
+          }
+          input CreateThingInput {
+            color: Color!
+          }
+          type Thing {
+            id: ID!
+          }
+          type Query {
+            _: Boolean
+          }
+          type Mutation {
+            createThing(input: CreateThingInput!): Thing
+          }
+        `,
+        resolvers: {
+          Mutation: {
+            createThing: (_root, args, context, info) =>
+              delegateToSchema({
+                schema: subschema,
+                operation: OperationTypeNode.MUTATION,
+                fieldName: 'createThing',
+                args,
+                context,
+                info,
+                validateRequest: true,
+              }),
+          },
+        },
+      });
+
+      const result = await graphql({
+        schema: outerSchema,
+        source: /* GraphQL */ `
+          mutation ($input: CreateThingInput!) {
+            createThing(input: $input) {
+              id
+            }
+          }
+        `,
+        variableValues: { input: { color: 'RED' } },
+      });
+
+      expect(result).toEqual({ data: { createThing: { id: '1' } } });
+
+      const inlineResult = await graphql({
+        schema: outerSchema,
+        source: /* GraphQL */ `
+          mutation {
+            createThing(input: { color: RED }) {
+              id
+            }
+          }
+        `,
+      });
+
+      expect(inlineResult).toEqual({ data: { createThing: { id: '1' } } });
+    },
+  );
+
   test('should serialize enum arguments when delegating to a renamed mutation field', async () => {
     const delegatedDocuments: string[] = [];
     const innerSchema = makeExecutableSchema({
@@ -241,11 +354,25 @@ describe('delegateToSchema', () => {
     });
 
     expect(result).toEqual({ data: { createThing: { id: '1' } } });
-    // the document must be valid against the subgraph it is sent to, a quoted
+
+    const inlineResult = await graphql({
+      schema: outerSchema,
+      source: /* GraphQL */ `
+        mutation {
+          createThing(input: { name: "x", color: RED }) {
+            id
+          }
+        }
+      `,
+    });
+
+    expect(inlineResult).toEqual({ data: { createThing: { id: '1' } } });
+    // the documents must be valid against the subgraph they are sent to, a quoted
     // `color: "RED"` fails with 'Enum "Color" cannot represent non-enum value'
-    const delegated = delegatedDocuments[0];
-    expect(delegated).toBeDefined();
-    expect(validate(innerSchema, parse(delegated!))).toEqual([]);
+    expect(delegatedDocuments).toHaveLength(2);
+    for (const delegated of delegatedDocuments) {
+      expect(validate(innerSchema, parse(delegated))).toEqual([]);
+    }
   });
 
   test('should work even where there are default fields', async () => {

--- a/packages/delegate/tests/delegateToSchema.test.ts
+++ b/packages/delegate/tests/delegateToSchema.test.ts
@@ -12,13 +12,7 @@ import {
   RenameRootFields,
   wrapSchema,
 } from '@graphql-tools/wrap';
-import {
-  graphql,
-  OperationTypeNode,
-  parse,
-  print,
-  validate,
-} from 'graphql';
+import { graphql, OperationTypeNode, parse, print, validate } from 'graphql';
 import _ from 'lodash';
 import { describe, expect, test } from 'vitest';
 import { delegateToSchema } from '../src/delegateToSchema.js';

--- a/packages/delegate/tests/delegateToSchema.test.ts
+++ b/packages/delegate/tests/delegateToSchema.test.ts
@@ -294,6 +294,7 @@ describe('delegateToSchema', () => {
           fieldName === 'createThing' ? '_encapsulated_createThing' : fieldName,
         ),
       ],
+      // @ts-expect-error typescript scares me sometimes
       executor: (request) => {
         delegatedDocuments.push(print(request.document));
         return { data: { _encapsulated_createThing: { id: '1' } } };

--- a/packages/delegate/tests/delegateToSchema.test.ts
+++ b/packages/delegate/tests/delegateToSchema.test.ts
@@ -7,8 +7,12 @@ import {
   isAsyncIterable,
   mergeDeep,
 } from '@graphql-tools/utils';
-import { FilterRootFields, wrapSchema } from '@graphql-tools/wrap';
-import { graphql, OperationTypeNode, parse } from 'graphql';
+import {
+  FilterRootFields,
+  RenameRootFields,
+  wrapSchema,
+} from '@graphql-tools/wrap';
+import { graphql, OperationTypeNode, parse, print } from 'graphql';
 import _ from 'lodash';
 import { describe, expect, test } from 'vitest';
 import { delegateToSchema } from '../src/delegateToSchema.js';
@@ -142,6 +146,97 @@ describe('delegateToSchema', () => {
     expect(result).toEqual({
       data: { account: { id: '123', custodian: 'so' } },
     });
+  });
+
+  test('should serialize enum arguments when delegating to a renamed mutation field', async () => {
+    const delegatedDocuments: string[] = [];
+    const innerSchema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        enum Color {
+          RED
+          GREEN
+          BLUE
+        }
+        input CreateThingInput {
+          name: String!
+          color: Color!
+        }
+        type Thing {
+          id: ID!
+        }
+        type Query {
+          thing: Thing
+        }
+        type Mutation {
+          createThing(input: CreateThingInput!): Thing
+        }
+      `,
+    });
+    // the delegation target only exists under its encapsulated name, so neither
+    // the transformed schema nor the original subschema can resolve its arg types
+    const subschema = new Subschema({
+      schema: innerSchema,
+      transforms: [
+        new RenameRootFields((_operation, fieldName) =>
+          fieldName === 'createThing' ? '_encapsulated_createThing' : fieldName,
+        ),
+      ],
+      executor: (request) => {
+        delegatedDocuments.push(print(request.document));
+        return { data: { _encapsulated_createThing: { id: '1' } } };
+      },
+    });
+    const outerSchema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        enum Color {
+          RED
+          GREEN
+          BLUE
+        }
+        input CreateThingInput {
+          name: String!
+          color: Color!
+        }
+        type Thing {
+          id: ID!
+        }
+        type Query {
+          _: Boolean
+        }
+        type Mutation {
+          createThing(input: CreateThingInput!): Thing
+        }
+      `,
+      resolvers: {
+        Mutation: {
+          createThing: (_root, args, context, info) =>
+            delegateToSchema({
+              schema: subschema,
+              operation: OperationTypeNode.MUTATION,
+              fieldName: '_encapsulated_createThing',
+              args,
+              context,
+              info,
+            }),
+        },
+      },
+    });
+
+    const result = await graphql({
+      schema: outerSchema,
+      source: /* GraphQL */ `
+        mutation ($input: CreateThingInput!) {
+          createThing(input: $input) {
+            id
+          }
+        }
+      `,
+      variableValues: { input: { name: 'x', color: 'RED' } },
+    });
+
+    expect(result).toEqual({ data: { createThing: { id: '1' } } });
+    // the enum must not be inlined as a quoted string
+    expect(delegatedDocuments[0]).not.toContain('color: "RED"');
   });
 
   test('should work even where there are default fields', async () => {


### PR DESCRIPTION
Closes #2488

Fixes two regressions in `@graphql-tools/delegate` argument handling introduced by #2474 and #2475.

When a delegated field was missing from the transformed target schema, `createRequest` lost its argument type information and fell back to `astFromValueUntyped`. This serialized enum values as strings, producing invalid documents such as:

```graphql
createThing(input: { color: "RED" })
```

The correct enum literal is now preserved:

```graphql
createThing(input: { color: RED })
```

The variable compatibility handling could also remove an original variable definition even when that variable was still referenced elsewhere in the delegated document. This produced `Variable "$filter" is not defined` errors for references in fragments, sibling selections, directives, and other root arguments.