### PR TITLE
feat(gateway): support the `HOST` env variable for the `--host` option

### DIFF
--- a/.changeset/host-env-variable.md
+++ b/.changeset/host-env-variable.md
@@ -1,0 +1,11 @@
+---
+'@graphql-hive/gateway': minor
+---
+
+Support the `HOST` environment variable for the `--host` CLI option
+
+The `--host` option can now be configured through the `HOST` environment variable, matching the existing behaviour of `--port` / `PORT` and the other global CLI options.
+
+```sh
+HOST=127.0.0.1 PORT=4000 hive-gateway supergraph
+```

--- a/packages/gateway/src/cli.ts
+++ b/packages/gateway/src/cli.ts
@@ -330,7 +330,7 @@ let cli = new Command()
     new Option(
       '-h, --host <hostname>',
       `host to use for serving (default: ${defaultOptions.host})`,
-    ),
+    ).env('HOST'),
   )
   .addOption(
     new Option(


### PR DESCRIPTION
Closes #2547

### What

Binds the `-h, --host <hostname>` CLI option to the `HOST` environment variable, so it behaves like every other global option of the gateway CLI (`FORK`, `CONFIG_PATH`, `PORT`, `POLLING`, `RENDER_LEGACY_GRAPHIQL`).

```diff
   .addOption(
     new Option(
       '-h, --host <hostname>',
       `host to use for serving (default: ${defaultOptions.host})`,
-    ),
+    ).env('HOST'),
   )
```

### Why

`--port` has read `PORT` since the initial import from `graphql-mesh`, but `--host` never got an env binding, so the bind address could only be set through a CLI flag. That is inconvenient for container/PaaS deployments with a fixed entrypoint, especially since the default host is platform-dependent (`0.0.0.0`, `127.0.0.1` on Windows/WSL).

### Notes

- Precedence is unchanged and matches `--port`: CLI flag > `HOST` env var > config file > `defaultOptions.host`. commander's `.env()` only applies the value when the variable is set, and `Option.default()` is deliberately not used here (see the comment above `defaultOptions`).
- No runtime wiring needed — the parsed `host` already reaches `servers/nodeHttp.ts` (`server.listen(port, host, …)`) and `servers/bun.ts` (`hostname`).
- Changeset included (`minor` on `@graphql-hive/gateway`).
- The env-variable list on graphql-hive.com lives in a separate repo — happy to open a docs PR alongside this one if you'd like.

### Verification

`yarn check:types`, `yarn check:lint` and `yarn check:format` are clean, and `yarn changeset status` reports the expected `minor` bump for `@graphql-hive/gateway`.

Behaviour with commander 14 (same option shape as in `cli.ts`):

```
no env, no flag        -> {}                       (falls through to defaultOptions.host)
HOST=127.0.0.1         -> { host: '127.0.0.1' }
HOST=127.0.0.1 + flag  -> { host: '0.0.0.0' }      (CLI flag still wins)
```

and `--help` now documents it:

```
-h, --host <hostname>  host to use for serving (default: 0.0.0.0) (env: HOST)
```
