### PR TITLE
feat(runtime): retry subscriptions on schema reload

### DIFF
--- a/.changeset/retry-subscriptions-on-schema-reload.md
+++ b/.changeset/retry-subscriptions-on-schema-reload.md
@@ -1,0 +1,11 @@
+---
+'@graphql-hive/gateway-runtime': minor
+---
+
+Retry subscriptions on schema reload instead of surfacing an internal error frame
+
+When the supergraph reloaded, in-flight subscriptions received one final result carrying the runtime's internal abort (`extensions.code: 'SCHEMA_RELOAD'`, http 503) before the stream completed. Queries never see this error because `useRetryOnSchemaReload` retries them, but for subscriptions it leaked to clients, which have no way to tell an internal abort apart from a real subscription failure. Some client caches also carry the error forward onto healthy events that follow a transport-level resubscribe, so one reload could poison an operation permanently.
+
+`useRetryOnSchemaReload` now gives subscriptions the same contract queries have: when the runtime aborts the stream with a schema reload notice, the operation is re-executed against the new schema and the new stream is spliced in, invisibly to the client. If the operation no longer validates against the new schema, that failure is delivered and the stream ends. If re-execution is not possible, the stream completes without the error frame, the same shape clients receive when a gateway instance shuts down.
+
+Only results whose errors are all `SCHEMA_RELOAD` and which carry no non-null data are treated as reload notices. Results with real data or any other error are delivered untouched. Mutations are still never retried, and shutdown (`SHUTTING_DOWN`) is unchanged.

--- a/packages/runtime/src/plugins/useRetryOnSchemaReload.ts
+++ b/packages/runtime/src/plugins/useRetryOnSchemaReload.ts
@@ -10,15 +10,36 @@ import type { GatewayConfigContext, GatewayPlugin } from '../types';
 
 type ExecHandler = () => MaybePromise<MaybeAsyncIterable<ExecutionResult>>;
 
+/**
+ * A schema-reload notice is the runtime aborting the operation because the
+ * supergraph reloaded: a result whose errors all carry
+ * `extensions.code: 'SCHEMA_RELOAD'` and whose data holds no non-null root
+ * field. Results carrying real data or any other error are never treated as
+ * a notice.
+ */
+function isSchemaReloadNotice(result: ExecutionResult): boolean {
+  const { errors, data } = result;
+  if (!errors || errors.length === 0) {
+    return false;
+  }
+  if (!errors.every((e) => e.extensions?.['code'] === 'SCHEMA_RELOAD')) {
+    return false;
+  }
+  return data == null || Object.values(data).every((value) => value == null);
+}
+
 export function useRetryOnSchemaReload<
   TContext extends Record<string, any>,
 >(): GatewayPlugin<TContext> {
   const execHandlerByContext = new WeakMap<{}, ExecHandler>();
+  const subscriptionContexts = new WeakSet<{}>();
   function handleOnExecute(args: ExecutionArgs) {
     if (args.contextValue) {
       const operation = getOperationAST(args.document, args.operationName);
-      // Only queries will be retried
-      if (operation?.operation !== 'query') {
+      if (operation?.operation === 'subscription') {
+        subscriptionContexts.add(args.contextValue);
+      } else if (operation?.operation !== 'query') {
+        // Mutations are never retried
         execHandlerByContext.delete(args.contextValue);
       }
     }
@@ -49,6 +70,43 @@ export function useRetryOnSchemaReload<
       }
     }
   }
+  /**
+   * A stream cannot be retried by swapping the result, so when the runtime
+   * ends a subscription with a schema reload notice the operation is
+   * re-executed against the new schema and the new stream is spliced in,
+   * mirroring the retry queries get above. Without an exec handler the
+   * stream just completes; a failed re-execution (e.g. the operation no
+   * longer validates against the new schema) is delivered before the end.
+   */
+  function wrapStreamForRetry(
+    source: AsyncIterable<ExecutionResult>,
+    context: { log: Logger },
+  ): AsyncIterable<ExecutionResult> {
+    return (async function* () {
+      for await (const result of source) {
+        if (!isSchemaReloadNotice(result)) {
+          yield result;
+          continue;
+        }
+        const execHandler = execHandlerByContext.get(context);
+        if (!execHandler) {
+          return;
+        }
+        context.log.info(
+          '[useRetryOnSchemaReload] The subscription has been aborted after the supergraph schema reloaded, re-subscribing...',
+        );
+        const next = await execHandler();
+        if (!isAsyncIterable(next)) {
+          yield next;
+          return;
+        }
+        // The re-executed stream went through the request pipeline again, so
+        // it is already wrapped for the next reload.
+        yield* next;
+        return;
+      }
+    })();
+  }
   return {
     onParams({ request, params, context, paramsHandler }) {
       execHandlerByContext.set(context, () =>
@@ -67,6 +125,9 @@ export function useRetryOnSchemaReload<
     },
     onExecutionResult({ request, context, result, setResult }) {
       if (isAsyncIterable(result)) {
+        if (subscriptionContexts.has(context)) {
+          setResult(wrapStreamForRetry(result, context));
+        }
         return;
       }
       return handleExecutionResult({ context, result, setResult, request });

--- a/packages/runtime/tests/subscriptions.test.ts
+++ b/packages/runtime/tests/subscriptions.test.ts
@@ -149,13 +149,13 @@ describe('Subscriptions', () => {
       msgs.push(msg);
     }
 
+    // The re-subscribe attempt fails validation (the new schema has no
+    // Subscription type) and its result ends the stream.
     expect(msgs[msgs.length - 1]).toMatchObject({
       errors: [
         {
-          extensions: {
-            code: 'SCHEMA_RELOAD',
-          },
-          message: 'operation has been aborted due to a schema reload',
+          message:
+            'Schema is not configured to execute subscription operation.',
         },
       ],
     });
@@ -229,13 +229,13 @@ describe('Subscriptions', () => {
       msgs.push(msg);
     }
 
+    // The re-subscribe attempt fails validation (the new schema has no
+    // Subscription type) and its result ends the stream.
     expect(msgs[msgs.length - 1]).toMatchObject({
       errors: [
         {
-          extensions: {
-            code: 'SCHEMA_RELOAD',
-          },
-          message: 'operation has been aborted due to a schema reload',
+          message:
+            'Schema is not configured to execute subscription operation.',
         },
       ],
     });
@@ -294,11 +294,13 @@ describe('Subscriptions', () => {
     }, 1000);
     await consumed;
 
+    // The re-subscribe attempt fails validation (the new schema has no
+    // Subscription type) and its result ends the stream.
     expect(msgs[msgs.length - 1]).toMatchObject({
       errors: [
         {
-          extensions: { code: 'SCHEMA_RELOAD' },
-          message: 'operation has been aborted due to a schema reload',
+          message:
+            'Schema is not configured to execute subscription operation.',
         },
       ],
     });
@@ -433,13 +435,13 @@ describe('Subscriptions', () => {
     }, 1000);
     await consumed;
 
+    // The re-subscribe attempt fails validation (the new schema has no
+    // Subscription type) and its result ends the stream.
     expect(msgs[msgs.length - 1]).toMatchObject({
       errors: [
         {
-          extensions: {
-            code: 'SCHEMA_RELOAD',
-          },
-          message: 'operation has been aborted due to a schema reload',
+          message:
+            'Schema is not configured to execute subscription operation.',
         },
       ],
     });
@@ -582,15 +584,95 @@ describe('Subscriptions', () => {
     }
     await consumed;
 
+    // The re-subscribe attempt fails validation (the new schema has no
+    // Subscription type) and its result ends the stream.
     expect(msgs[msgs.length - 1]).toMatchObject({
       errors: [
         {
-          extensions: {
-            code: 'SCHEMA_RELOAD',
-          },
-          message: 'operation has been aborted due to a schema reload',
+          message:
+            'Schema is not configured to execute subscription operation.',
         },
       ],
     });
+  }, 20_000);
+  it('re-subscribes transparently when the operation is still valid after a schema update', async () => {
+    let changeSchema = false;
+    const versionSchema = (version: string) =>
+      createSchema({
+        typeDefs: /* GraphQL */ `
+          type Query {
+            foo: String!
+            ${version === 'v1' ? '' : 'addedByReload: String!'}
+          }
+
+          type Subscription {
+            version: String!
+          }
+        `,
+        resolvers: {
+          Query: {
+            foo: () => 'bar',
+          },
+          Subscription: {
+            version: {
+              subscribe: () =>
+                new Repeater<string>((push, stop) => {
+                  void push(version);
+                  leftovers.push(stop);
+                }),
+              resolve: (value: string) => value,
+            },
+          },
+        },
+      });
+
+    await using serve = createGatewayTester({
+      pollingInterval: 500,
+      subgraphs: () => {
+        if (changeSchema) {
+          return [{ name: 'upstream', schema: versionSchema('v2') }];
+        }
+        changeSchema = true;
+        return [{ name: 'upstream', schema: versionSchema('v1') }];
+      },
+    });
+
+    const sse = createSSEClient({
+      url: 'http://mesh/graphql',
+      fetchFn: serve.fetch,
+    });
+
+    const sub = sse.iterate({
+      query: /* GraphQL */ `
+        subscription {
+          version
+        }
+      `,
+    });
+
+    const msgs: unknown[] = [];
+    globalThis.setTimeout(() => {
+      // Drives the poll that picks up the changed schema and reloads.
+      void serve.execute({
+        query: /* GraphQL */ `
+          query {
+            foo
+          }
+        `,
+      });
+    }, 1000);
+    for await (const msg of sub) {
+      msgs.push(msg);
+      if (msgs.length === 2) {
+        break;
+      }
+    }
+
+    // First event from the original stream, second from the re-subscribed
+    // one, no error frame in between.
+    expect(msgs).toMatchObject([
+      { data: { version: 'v1' } },
+      { data: { version: 'v2' } },
+    ]);
   }, 20_000);
 });


### PR DESCRIPTION
Closes #2551.

When the supergraph reloads, in-flight subscriptions receive one final result carrying the runtime's internal abort (`extensions.code: 'SCHEMA_RELOAD'`, http 503) before the stream completes. Queries never see this error because `useRetryOnSchemaReload` retries them. Subscriptions were the only operation type where it leaked to clients, which cannot tell an internal abort apart from a real subscription failure. See the linked issue for the client-side damage.

This gives subscriptions the same contract queries already have. `useRetryOnSchemaReload` keeps the exec handler it already captures in `onParams` and wraps subscription streams:

- On a reload notice, the operation is re-executed against the new schema and the new stream is spliced in. The client sees an uninterrupted subscription. The re-executed request goes through the full pipeline again, so validation and auth run against the new schema and the new stream is wrapped for the next reload.
- If the operation no longer validates against the new schema, that failure is delivered and the stream ends, which is what the client's own resubscribe would have produced.
- If re-execution is not possible, the stream completes without the error frame, the same shape clients receive when a gateway instance shuts down.

The wrapper is an inline async generator rather than `mapAsyncIterator` because the mapping is not one-to-one: it has to skip the notice frame and splice in a replacement stream.

A reload notice is a result whose errors are all `SCHEMA_RELOAD` with no non-null data. Results carrying real data or any other error pass through untouched. Mutations are still never retried, and shutdown (`SHUTTING_DOWN`) is unchanged, both covered by existing tests.

### Why re-executing a subscription is safe

- The spec requires the resolution of all fields other than top-level mutation fields to be side effect-free and idempotent (Execution section), so re-running validation, source-stream creation, and per-event resolution repeats only reads. Mutations stay excluded, as they are for the existing query retry.
- Clients already resubscribe on every deploy, socket drop, and network blip. A subgraph whose subscribe is not safe to repeat is already broken by ordinary reconnects; this changes who initiates, not what runs.
- The replay goes through `paramsHandler`, the full request pipeline. Parsing, validation, auth, and every plugin hook fire again exactly as they would for a client-initiated resubscribe. Nothing is bypassed. This is the same mechanism the plugin has always used to retry queries.
- Client intent is preserved: re-execution only happens while the client keeps the operation open, and tearing the operation down tears everything down.
- No retry loop is possible. One notice triggers one re-execution, and producing another notice requires another reload, which the polling interval and the generation cap bound. A reload that lands during the re-subscribe is handled by the re-executed stream being wrapped again by the pipeline.

### Tests

The five terminal-shape assertions in `subscriptions.test.ts` change to the honest re-execution result (those tests drop the `Subscription` type in the new schema, so the re-subscribe fails validation). A new test covers a still-valid operation surviving a reload with no error frame: the client receives the first event from the original stream and the next from the re-subscribed one.

Known trade-offs, happy to adjust:

- Sources that emit an initial snapshot on subscribe will re-emit it after the splice. Clients see the same thing on their own resubscribe today, but here they do not know a resubscribe happened.
- Events published between the abort and the re-subscribe are not replayed. This window exists with client-side resubscribe too.
- All in-flight subscriptions on an instance re-execute at the moment of the reload. Large deployments trade the client-side resubscribe burst for a synchronized in-process one (minus the connection churn). If that's a concern, the re-execution could take an optional spread/jitter.
- If you would rather keep the current behavior available, this can go behind a runtime option.

