### PR TITLE
Flush deferred merged fields without blocking the initial payload

### DIFF
--- a/.changeset/shy-mails-share.md
+++ b/.changeset/shy-mails-share.md
@@ -1,0 +1,9 @@
+---
+'@graphql-tools/federation': patch
+'@graphql-tools/delegate': patch
+'@graphql-tools/stitch': patch
+---
+
+Flush deferred merged fields without blocking the initial payload
+
+Deferred fields on merged entity types are now delegated when their deferred resolvers run instead of being included in the initial delegation plan. This allows the initial payload to be delivered before slower merged subgraph fields resolve.

--- a/packages/delegate/src/defaultMergedResolver.ts
+++ b/packages/delegate/src/defaultMergedResolver.ts
@@ -24,6 +24,7 @@ import {
   getUnpathedErrors,
   handleResolverResult,
   isExternalObject,
+  mergeFields,
 } from './mergeFields.js';
 import { resolveExternalValue } from './resolveExternalValue.js';
 import { Subschema } from './Subschema.js';
@@ -113,6 +114,37 @@ export function defaultMergedResolver(
     // way graphql-js default resolution would on a plain object
     if (Object.prototype.hasOwnProperty.call(parent, info.fieldName)) {
       return defaultFieldResolver(parent, args, context, info);
+    }
+    const stitchingInfo = info.schema?.extensions?.[
+      'stitchingInfo'
+    ] as StitchingInfo;
+    const parentTypeName = parent.__typename || info.parentType?.name;
+    const mergedTypeInfo = parentTypeName
+      ? stitchingInfo?.mergedTypes[parentTypeName]
+      : undefined;
+    const sourceSubschema = parent[OBJECT_SUBSCHEMA_SYMBOL] as Subschema;
+    if (mergedTypeInfo && sourceSubschema) {
+      const fieldNode: FieldNode = {
+        kind: Kind.FIELD,
+        name: info.fieldNodes[0]?.name ?? {
+          kind: Kind.NAME,
+          value: info.fieldName,
+        },
+        selectionSet: {
+          kind: Kind.SELECTION_SET,
+          selections: info.fieldNodes,
+        },
+      };
+      return handleMaybePromise(
+        () =>
+          mergeFields(mergedTypeInfo, parent, sourceSubschema, context, info, [
+            fieldNode,
+          ]),
+        () =>
+          Object.prototype.hasOwnProperty.call(parent, responseKey)
+            ? handleResult(parent, responseKey, context, info)
+            : undefined,
+      );
     }
     return undefined;
   }

--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -70,7 +70,6 @@ export function getUnpathedErrors(object: ExternalObject): Array<GraphQLError> {
   return object[UNPATHED_ERRORS_SYMBOL];
 }
 
-export const EMPTY_ARRAY: any[] = [];
 export const EMPTY_OBJECT = Object.create(null);
 
 export const getActualFieldNodes = memoize1(function (fieldNode: FieldNode) {
@@ -83,6 +82,7 @@ export function mergeFields<TContext>(
   sourceSubschema: Subschema<any, any, any, TContext>,
   context: any,
   info: GraphQLResolveInfo,
+  fieldNodes = info.fieldNodes as FieldNode[],
 ): MaybePromise<any> {
   const variableValues = getCoercedVariableValues(info.variableValues);
   const delegationMaps = mergedTypeInfo.delegationPlanBuilder(
@@ -94,11 +94,9 @@ export function mergeFields<TContext>(
     info.fragments != null && Object.keys(info.fragments).length > 0
       ? info.fragments
       : EMPTY_OBJECT,
-    info.fieldNodes?.length
-      ? info.fieldNodes.length === 1 && info.fieldNodes[0]
-        ? getActualFieldNodes(info.fieldNodes[0])
-        : (info.fieldNodes as FieldNode[])
-      : EMPTY_ARRAY,
+    fieldNodes.length === 1 && fieldNodes[0]
+      ? getActualFieldNodes(fieldNodes[0])
+      : fieldNodes,
     context,
     info,
   );

--- a/packages/federation/tests/__snapshots__/defer-stream.test.ts.snap
+++ b/packages/federation/tests/__snapshots__/defer-stream.test.ts.snap
@@ -53,6 +53,11 @@ exports[`Defer/Stream defers the nested fields: defer-nested-fields 1`] = `
         },
         "path": [],
       },
+    ],
+  },
+  {
+    "hasNext": true,
+    "incremental": [
       {
         "data": {
           "name": "Ada Lovelace",
@@ -113,7 +118,7 @@ exports[`Defer/Stream defers the nested fields: defer-nested-fields 1`] = `
     ],
   },
   {
-    "hasNext": false,
+    "hasNext": true,
     "incremental": [
       {
         "data": {
@@ -137,6 +142,11 @@ exports[`Defer/Stream defers the nested fields: defer-nested-fields 1`] = `
           0,
         ],
       },
+    ],
+  },
+  {
+    "hasNext": false,
+    "incremental": [
       {
         "data": {
           "name": "Ada Lovelace",

--- a/packages/federation/tests/defer-stream.test.ts
+++ b/packages/federation/tests/defer-stream.test.ts
@@ -431,6 +431,134 @@ describe('Defer/Stream', () => {
   });
 });
 
+describe('Defer/Stream - entity-level defer on merged types', () => {
+  const slowSubgraphDelayMs = 1000;
+  const menuItems = [
+    { id: '1', name: 'Item 1', prepSequenceMultiLocationId: 'p1' },
+    { id: '2', name: 'Item 2', prepSequenceMultiLocationId: 'p2' },
+  ];
+  const menusSubgraph = buildSubgraphSchema({
+    typeDefs: parse(/* GraphQL */ `
+      type Query {
+        menuItems: [MenuItem]
+      }
+
+      type MenuItem @key(fields: "id") {
+        id: ID!
+        name: String!
+        prepSequenceMultiLocationId: ID
+      }
+    `),
+    resolvers: {
+      Query: {
+        menuItems: () => menuItems,
+      },
+    },
+  });
+  const kitchenSubgraph = buildSubgraphSchema({
+    typeDefs: parse(/* GraphQL */ `
+      type PrepSequence {
+        id: ID!
+      }
+
+      type MenuItem @key(fields: "id") {
+        id: ID!
+        prepSequenceMultiLocationId: ID @external
+        prepSequence: PrepSequence
+          @requires(fields: "prepSequenceMultiLocationId")
+      }
+    `),
+    resolvers: {
+      MenuItem: {
+        __resolveReference: (ref: { id: string }) => ref,
+        prepSequence: async (ref: { prepSequenceMultiLocationId: string }) => {
+          await setTimeout(slowSubgraphDelayMs);
+          return { id: `seq-${ref.prepSequenceMultiLocationId}` };
+        },
+      },
+    },
+  });
+  const menusServer = createYoga({
+    schema: menusSubgraph,
+    plugins: [useDeferStream()],
+  });
+  const kitchenServer = createYoga({
+    schema: kitchenSubgraph,
+    plugins: [useDeferStream()],
+  });
+  let schema: GraphQLSchema;
+  beforeAll(async () => {
+    const supergraphSdl = await composeLocalSchemasWithApollo([
+      { name: 'menus', schema: menusSubgraph },
+      { name: 'kitchen', schema: kitchenSubgraph },
+    ]);
+    schema = getStitchedSchemaFromSupergraphSdl({
+      supergraphSdl,
+      onSubschemaConfig(subschemaConfig) {
+        const server =
+          subschemaConfig.name.toLowerCase() === 'kitchen'
+            ? kitchenServer
+            : menusServer;
+        const origExecutor = buildHTTPExecutor({
+          endpoint: 'http://localhost:4003/graphql',
+          fetch: server.fetch,
+        });
+        subschemaConfig.executor = origExecutor;
+      },
+    });
+  });
+  it('flushes the initial payload before deferred merged fields resolve', async () => {
+    const start = Date.now();
+    const result = await normalizedExecutor({
+      schema,
+      document: parse(/* GraphQL */ `
+        query {
+          menuItems {
+            ... on MenuItem {
+              id
+              name
+            }
+            ... on MenuItem @defer {
+              prepSequence {
+                id
+              }
+            }
+          }
+        }
+      `),
+    });
+    assertAsyncIterable(result);
+    const values: ExecutionResult[] = [];
+    let initialPayload: ExecutionResult | undefined;
+    for await (const value of result) {
+      if (!initialPayload) {
+        initialPayload = value;
+        // the initial payload must not wait for the deferred merged fields
+        expect(Date.now() - start).toBeLessThan(slowSubgraphDelayMs);
+      }
+      values.push(value);
+    }
+    expect(initialPayload).toEqual({
+      data: {
+        menuItems: [
+          { id: '1', name: 'Item 1' },
+          { id: '2', name: 'Item 2' },
+        ],
+      },
+      hasNext: true,
+    });
+    const mergedResult = mergeIncrementalResults(values);
+    expect(mergedResult).toEqual({
+      data: {
+        menuItems: [
+          { id: '1', name: 'Item 1', prepSequence: { id: 'seq-p1' } },
+          { id: '2', name: 'Item 2', prepSequence: { id: 'seq-p2' } },
+        ],
+      },
+    });
+  });
+});
+
 describe('Defer/Stream - scalar streaming via HTTP', () => {
   const letters = ['a', 'b', 'c', 'd', 'e'];
 

--- a/packages/stitch/src/getFieldsNotInSubschema.ts
+++ b/packages/stitch/src/getFieldsNotInSubschema.ts
@@ -36,7 +36,7 @@ export function getFieldsNotInSubschema(
   info: GraphQLResolveInfo | undefined,
 ): Array<FieldNode> {
   const sourceSchema = subschema.transformedSchema;
-  let { fields: subFieldNodesByResponseKey, patches } = collectSubFields(
+  let { fields: subFieldNodesByResponseKey } = collectSubFields(
     schema,
     fragments,
     variableValues,
@@ -47,24 +47,7 @@ export function getFieldsNotInSubschema(
   let mapChanged = false;
 
   // Collect deferred fields
-  if (patches.length) {
-    subFieldNodesByResponseKey = new Map(subFieldNodesByResponseKey);
-    for (const patch of patches) {
-      for (const [responseKey, fields] of patch.fields) {
-        if (!mapChanged) {
-          subFieldNodesByResponseKey = new Map(subFieldNodesByResponseKey);
-          mapChanged = true;
-        }
-        const existingSubFieldNodes =
-          subFieldNodesByResponseKey.get(responseKey);
-        if (existingSubFieldNodes) {
-          existingSubFieldNodes.push(...fields);
-        } else {
-          subFieldNodesByResponseKey.set(responseKey, fields);
-        }
-      }
-    }
-  }
+  // delegate them when their resolver runs so the parent can be released
 
   const fieldsNotInSchema = new Set<FieldNode>();
   if (isAbstractType(gatewayType)) {
@@ -76,29 +59,13 @@ export function getFieldsNotInSubschema(
       },
     });
     for (const possibleType of schema.getPossibleTypes(gatewayType)) {
-      const { fields: subFieldNodesOfPossibleType, patches } = collectSubFields(
+      const { fields: subFieldNodesOfPossibleType } = collectSubFields(
         schema,
         fragments,
         variableValues,
         possibleType,
         fieldNodes,
       );
-
-      for (const patch of patches) {
-        for (const [responseKey, fields] of patch.fields) {
-          if (!mapChanged) {
-            subFieldNodesByResponseKey = new Map(subFieldNodesByResponseKey);
-            mapChanged = true;
-          }
-          const existingSubFieldNodes =
-            subFieldNodesByResponseKey.get(responseKey);
-          if (existingSubFieldNodes) {
-            existingSubFieldNodes.push(...fields);
-          } else {
-            subFieldNodesByResponseKey.set(responseKey, fields);
-          }
-        }
-      }
 
       for (const [responseKey, subFieldNodes] of subFieldNodesOfPossibleType) {
         if (!mapChanged) {


### PR DESCRIPTION
Deferred fields on merged entity types are now delegated when their deferred resolvers run instead of being included in the initial delegation plan. This allows the initial payload to be delivered before slower merged subgraph fields resolve.