### PR TITLE
feat(runtime): graceful reload for subscriptions (pin + gradual retirement)

### DIFF
--- a/.changeset/graceful-subscription-reload.md
+++ b/.changeset/graceful-subscription-reload.md
@@ -1,0 +1,10 @@
+---
+'@graphql-hive/gateway-runtime': minor
+---
+
+Graceful reload for subscriptions: two new opt-in options on `gracefulSchemaReload`.
+
+- `pinSubscriptions` pins subscriptions to the schema generation that admitted them, the way queries and mutations already are, so a reload no longer ends every subscription on the instance at once. The superseded generation keeps serving them until each stream ends or `drainTimeout` force-disposes it.
+- `subscriptionRetirementSpread` (requires `pinSubscriptions`) retires the superseded generation's subscriptions gradually: each is ended with a plain stream completion at an evenly spaced, randomly assigned moment inside the window, so clients resubscribe against the new schema as a steady trickle instead of a burst. Until its moment a subscription keeps receiving events from the old generation.
+
+Both default off; existing behavior is unchanged.

--- a/packages/runtime/src/createGatewayRuntime.ts
+++ b/packages/runtime/src/createGatewayRuntime.ts
@@ -2,11 +2,12 @@ import {
   getInstrumented,
   OnExecuteEventPayload,
   OnSubscribeEventPayload,
+  OnSubscribeResultEventPayload,
 } from '@envelop/core';
 import { useDisableIntrospection } from '@envelop/disable-introspection';
 import { useGenericAuth } from '@envelop/generic-auth';
 import { createCDNArtifactFetcher, joinUrl } from '@graphql-hive/core';
-import { LegacyLogger } from '@graphql-hive/logger';
+import { LegacyLogger, type Logger } from '@graphql-hive/logger';
 import type {
   OnDelegationPlanHook,
   OnDelegationStageExecuteHook,
@@ -249,6 +250,18 @@ export function createGatewayRuntime<
   let retainGenerationFor:
     | ((schema: GraphQLSchema) => SchemaGenerationLease | undefined)
     | undefined;
+  // gracefulSchemaReload.pinSubscriptions / .subscriptionRetirementSpread, only
+  // meaningful once retainGenerationFor is set.
+  let pinSubscriptions = false;
+  let subscriptionRetirementSpread = 0;
+  // Gradual retirement of a superseded generation's pinned subscriptions
+  // (gracefulSchemaReload.subscriptionRetirementSpread). Driven from the
+  // unified graph manager's swap callback below, which runs synchronously
+  // with the generation change.
+  const retirement = createSubscriptionRetirement({
+    getSpread: () => subscriptionRetirementSpread,
+    log: configContext.log,
+  });
   let replaceSchema: (schema: GraphQLSchema) => void = (newSchema) => {
     unifiedGraph = newSchema;
   };
@@ -680,6 +693,21 @@ export function createGatewayRuntime<
           'gracefulSchemaReload.maxConcurrentGenerations must be a finite number that is at least 1',
         );
       }
+      if (gracefulSchemaReload.subscriptionRetirementSpread != null) {
+        if (
+          !Number.isFinite(gracefulSchemaReload.subscriptionRetirementSpread) ||
+          gracefulSchemaReload.subscriptionRetirementSpread <= 0
+        ) {
+          throw new Error(
+            'gracefulSchemaReload.subscriptionRetirementSpread must be a finite positive number of milliseconds',
+          );
+        }
+        if (!gracefulSchemaReload.pinSubscriptions) {
+          throw new Error(
+            'gracefulSchemaReload.subscriptionRetirementSpread requires gracefulSchemaReload.pinSubscriptions',
+          );
+        }
+      }
     }
     const unifiedGraphManager = new UnifiedGraphManager<GatewayContext>({
       handleUnifiedGraph: config.unifiedGraphHandler,
@@ -687,6 +715,7 @@ export function createGatewayRuntime<
       onUnifiedGraphChange(newUnifiedGraph: GraphQLSchema) {
         unifiedGraph = newUnifiedGraph;
         replaceSchema(newUnifiedGraph);
+        retirement.onSchemaChange();
       },
       transports: config.transports,
       transportEntryAdditions: config.transportEntries,
@@ -743,6 +772,9 @@ export function createGatewayRuntime<
       // warning) entirely.
       retainGenerationFor = (schema) =>
         unifiedGraphManager.retainGenerationFor(schema);
+      pinSubscriptions = gracefulSchemaReload.pinSubscriptions === true;
+      subscriptionRetirementSpread =
+        gracefulSchemaReload.subscriptionRetirementSpread ?? 0;
     }
     unifiedGraphPlugin = {
       onDispose() {
@@ -867,22 +899,56 @@ export function createGatewayRuntime<
       );
     };
     const onSubscribe = ({
+      args,
       setSubscribeFn,
-    }: OnSubscribeEventPayload<GatewayContext>) =>
-      // Subscriptions are intentionally NOT pinned to a generation (no
-      // retainGenerationFor here): they are long-lived, so rather than keeping
-      // the old generation alive indefinitely they end — when that generation
-      // is disposed (immediately on reload when idle, otherwise once it
-      // finishes draining) — and the client reconnects against the new schema.
-      handleMaybePromise(
-        () => getExecutor?.(),
+    }: OnSubscribeEventPayload<GatewayContext>) => {
+      // Subscriptions are NOT pinned to a generation by default: they are
+      // long-lived, so rather than keeping the old generation alive
+      // indefinitely they end — when that generation is disposed (immediately
+      // on reload when idle, otherwise once it finishes draining) — and the
+      // client reconnects against the new schema. With pinSubscriptions they
+      // are pinned exactly like queries in onExecute: the superseded generation
+      // keeps serving them until each stream ends (or drainTimeout), and the
+      // retirement spread ends them gradually before that.
+      const lease = pinSubscriptions
+        ? retainGenerationFor?.(args.schema)
+        : undefined;
+      const admittedGeneration = retirement.currentGeneration();
+      return handleMaybePromise(
+        () => (lease ? lease.executor : getExecutor?.()),
         (executor) => {
           if (executor) {
             const subscribeFn = getExecuteFnFromExecutor(executor);
             setSubscribeFn(subscribeFn);
           }
+          if (!lease) {
+            return undefined;
+          }
+          return {
+            onSubscribeResult({
+              result,
+              setResult,
+            }: OnSubscribeResultEventPayload<GatewayContext>) {
+              if (!isAsyncIterable(result)) {
+                lease.release();
+                return undefined;
+              }
+              if (subscriptionRetirementSpread > 0) {
+                setResult(retirement.track(result, admittedGeneration));
+              }
+              return { onEnd: lease.release };
+            },
+            onSubscribeError() {
+              lease.release();
+            },
+          };
+        },
+        (error) => {
+          lease?.release();
+          throw error;
         },
       );
+    };
     defaultGatewayPlugin.onExecute = onExecute;
     defaultGatewayPlugin.onSubscribe = onSubscribe;
   }
@@ -1342,3 +1408,178 @@ function isDynamicUnifiedGraphSchema(
   // anything else is dynamic
   return true;
 }
+
+interface RetirableSubscription {
+  generation: number;
+  /** Ends the client-facing stream with a plain completion and releases the source. */
+  end(): void;
+}
+
+/**
+ * Gradual retirement of a superseded generation's pinned subscriptions.
+ *
+ * Generation identity is a counter bumped on every schema change (the runtime
+ * fires it synchronously with the swap), captured when a subscription is
+ * admitted. On a change, every live subscription of an older generation is
+ * assigned an evenly spaced, randomly ordered moment inside the spread window
+ * and ended there with a plain completion — the same thing a client sees when
+ * a gateway instance shuts down — so clients resubscribe as a trickle. Until
+ * its moment a subscription keeps streaming from the generation it is pinned
+ * to. drainTimeout stays the hard bound: whatever is still open when it fires
+ * ends with SCHEMA_RELOAD as before.
+ */
+function createSubscriptionRetirement({
+  getSpread,
+  log,
+}: {
+  getSpread: () => number;
+  log: Logger;
+}) {
+  const live = new Set<RetirableSubscription>();
+  let generation = 0;
+
+  function retire(retiring: RetirableSubscription[], fromGeneration: number) {
+    // Fisher–Yates: a random sample per moment rather than "oldest first",
+    // which would correlate by client.
+    for (let i = retiring.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [retiring[i], retiring[j]] = [retiring[j]!, retiring[i]!];
+    }
+    const spread = getSpread();
+    const step = spread / retiring.length;
+    log.debug(
+      { subscriptions: retiring.length, fromGeneration, spread },
+      "Retiring the superseded schema generation's subscriptions gradually",
+    );
+    let index = 0;
+    const startedAt = Date.now();
+    const tick = () => {
+      // Every subscription whose moment has come (also catches up after a late
+      // timer), skipping the ones the client has already ended.
+      const elapsed = Date.now() - startedAt;
+      while (index < retiring.length && index * step <= elapsed) {
+        const subscription = retiring[index++]!;
+        if (live.has(subscription)) {
+          subscription.end();
+        }
+      }
+      if (index < retiring.length) {
+        const timer = setTimeout(
+          tick,
+          Math.max(0, Math.ceil(index * step - (Date.now() - startedAt))),
+        );
+        (timer as { unref?: () => void }).unref?.();
+      }
+    };
+    tick();
+  }
+
+  return {
+    currentGeneration: () => generation,
+    onSchemaChange() {
+      const previous = generation;
+      generation += 1;
+      const retiring = [...live].filter((s) => s.generation < generation);
+      if (retiring.length > 0 && getSpread() > 0) {
+        retire(retiring, previous);
+      }
+    },
+    /**
+     * Wraps a subscription stream so it can be ended from the outside. A single
+     * wake slot suffices because a consumer awaits at most one next() at a time,
+     * so nothing accumulates on a long-lived stream.
+     */
+    track<T>(
+      source: AsyncIterable<T>,
+      admittedGeneration: number,
+    ): AsyncIterableIterator<T> {
+      const iterator = source[Symbol.asyncIterator]();
+      let ended = false;
+      let finished = false;
+      let wake: ((outcome: Outcome<T>) => void) | null = null;
+      const entry: RetirableSubscription = {
+        generation: admittedGeneration,
+        end() {
+          if (ended) return;
+          ended = true;
+          wake?.({ kind: 'end' });
+        },
+      };
+      live.add(entry);
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        live.delete(entry);
+      };
+      // A consumer that receives done never calls return(), so release the
+      // source here. Not awaited: the client's completion must not wait on the
+      // upstream teardown.
+      const closeSource = () => {
+        if (typeof iterator.return !== 'function') return;
+        Promise.resolve()
+          .then(() => iterator.return?.())
+          .catch((error: unknown) => {
+            log.error(
+              { err: error },
+              "Failed to release a retired subscription's source",
+            );
+          });
+      };
+      const DONE: IteratorReturnResult<undefined> = {
+        value: undefined,
+        done: true,
+      };
+      return {
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+        async next(): Promise<IteratorResult<T>> {
+          if (ended) {
+            finish();
+            closeSource();
+            return DONE;
+          }
+          const outcome = await new Promise<Outcome<T>>((resolve) => {
+            wake = resolve;
+            iterator.next().then(
+              (result) => resolve({ kind: 'result', result }),
+              (error: unknown) => resolve({ kind: 'error', error }),
+            );
+          });
+          wake = null;
+          if (outcome.kind === 'end') {
+            finish();
+            closeSource();
+            return DONE;
+          }
+          if (outcome.kind === 'error') {
+            finish();
+            throw outcome.error;
+          }
+          if (outcome.result.done) finish();
+          return outcome.result;
+        },
+        async return(value?: unknown): Promise<IteratorResult<T>> {
+          ended = true;
+          finish();
+          if (typeof iterator.return === 'function') {
+            return iterator.return(value);
+          }
+          return DONE;
+        },
+        async throw(error?: unknown): Promise<IteratorResult<T>> {
+          finish();
+          if (typeof iterator.throw === 'function') {
+            return iterator.throw(error);
+          }
+          throw error;
+        },
+      };
+    },
+  };
+}
+
+type Outcome<T> =
+  | { kind: 'result'; result: IteratorResult<T> }
+  | { kind: 'error'; error: unknown }
+  | { kind: 'end' };

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -529,11 +529,14 @@ export interface GatewayHivePersistedDocumentsOptions {
  * Incremental-delivery operations (`@defer` / `@stream`) are kept alive until
  * their stream ends.
  *
- * Subscriptions are NOT pinned: they are long-lived, so a subscription on a
- * superseded generation ends with `SCHEMA_RELOAD` when that generation is
- * disposed — immediately on reload when it has no in-flight operations,
- * otherwise once it finishes draining (at the latest after
+ * Subscriptions are NOT pinned by default: they are long-lived, so a
+ * subscription on a superseded generation ends with `SCHEMA_RELOAD` when that
+ * generation is disposed — immediately on reload when it has no in-flight
+ * operations, otherwise once it finishes draining (at the latest after
  * {@link drainTimeout}) — and the client reconnects against the new schema.
+ * {@link pinSubscriptions} opts them into the overlap as well, and
+ * {@link subscriptionRetirementSpread} then retires them gradually instead of
+ * all at once.
  *
  * Schema-replacing plugins must preserve the schema object supplied by the
  * gateway. If a plugin replaces or rebuilds it, the gateway cannot associate
@@ -558,6 +561,30 @@ export interface GracefulSchemaReloadConfig {
    * @default 10
    */
   maxConcurrentGenerations?: number;
+  /**
+   * Pin subscriptions to the schema generation that admitted them, the way
+   * queries and mutations are pinned. A reload then no longer ends every
+   * subscription on the instance at once: the superseded generation keeps
+   * serving its subscriptions until each stream ends, or until
+   * {@link drainTimeout} force-disposes it (ending whatever is left with
+   * `SCHEMA_RELOAD`). Combine with {@link subscriptionRetirementSpread} to
+   * retire them gradually before the timeout.
+   *
+   * @default false
+   */
+  pinSubscriptions?: boolean;
+  /**
+   * Time window, in milliseconds, over which the subscriptions of a superseded
+   * generation are retired after a reload. Each pinned subscription is ended
+   * (a plain stream completion, no error) at an evenly spaced, randomly
+   * assigned moment inside the window, so their clients resubscribe against
+   * the new schema as a steady trickle instead of a burst. Until its moment a
+   * subscription keeps receiving events from the superseded generation.
+   *
+   * Requires {@link pinSubscriptions}. Should be shorter than
+   * {@link drainTimeout}, which remains the hard bound.
+   */
+  subscriptionRetirementSpread?: number;
 }
 
 export interface GatewayConfigBase<TContext extends Record<string, any>> {

--- a/packages/runtime/tests/graceful-schema-reload.test.ts
+++ b/packages/runtime/tests/graceful-schema-reload.test.ts
@@ -12,9 +12,13 @@ import {
   composeLocalSchemasWithApollo,
   createDisposableServer,
 } from '@internal/testing';
-import { DisposableSymbols } from '@whatwg-node/disposablestack';
+import {
+  AsyncDisposableStack,
+  DisposableSymbols,
+} from '@whatwg-node/disposablestack';
 import { lexicographicSortSchema, parse, type GraphQLSchema } from 'graphql';
-import { createYoga } from 'graphql-yoga';
+import { createClient as createSSEClient } from 'graphql-sse';
+import { createYoga, Repeater } from 'graphql-yoga';
 import { beforeAll, describe, expect, it } from 'vitest';
 
 /**
@@ -1066,5 +1070,210 @@ describe('Graceful schema reload — config validation', () => {
         logging: false,
       }),
     ).toThrow(/gracefulSchemaReload/);
+  });
+});
+
+describe('Graceful schema reload for subscriptions', () => {
+  const SUB_TYPE_DEFS = /* GraphQL */ `
+    type Query {
+      ping: String
+    }
+    type Subscription {
+      tick: String
+    }
+  `;
+
+  /** A subgraph whose subscription emits its generation label every 30ms. */
+  function tickingSubgraph(gen: string) {
+    return buildSubgraphSchema({
+      typeDefs: parse(SUB_TYPE_DEFS),
+      resolvers: {
+        Query: { ping: () => gen },
+        Subscription: {
+          tick: {
+            subscribe: () =>
+              new Repeater<string>(async (push, stop) => {
+                const timer = setInterval(() => push(gen), 30);
+                await stop;
+                clearInterval(timer);
+              }),
+            resolve: (value: string) => value,
+          },
+        },
+      },
+    });
+  }
+
+  type SubState = {
+    values: { value: string; at: number }[];
+    last: unknown;
+    endedAt: number | null;
+    done: Promise<void>;
+    dispose(): void;
+  };
+
+  /** Subscribes over SSE the way a client would; records every event with a timestamp. */
+  function subscribeTicks(gw: GatewayRuntime): SubState {
+    const client = createSSEClient({
+      url: GW_URL,
+      fetchFn: gw.fetch,
+      retryAttempts: 0,
+    });
+    const state: SubState = {
+      values: [],
+      last: null,
+      endedAt: null,
+      done: Promise.resolve(),
+      dispose: () => client.dispose(),
+    };
+    state.done = (async () => {
+      for await (const msg of client.iterate({
+        query: /* GraphQL */ `
+          subscription {
+            tick
+          }
+        `,
+      })) {
+        state.last = msg;
+        const value = (msg as { data?: { tick?: string } }).data?.tick;
+        if (typeof value === 'string') {
+          state.values.push({ value, at: Date.now() });
+        }
+      }
+      state.endedAt = Date.now();
+    })();
+    return state;
+  }
+
+  async function until(
+    predicate: () => boolean,
+    what: string,
+    timeoutMs = 5_000,
+  ) {
+    const deadline = Date.now() + timeoutMs;
+    while (!predicate()) {
+      if (Date.now() > deadline)
+        throw new Error(`timed out waiting for ${what}`);
+      await delay(15);
+    }
+  }
+
+  async function setup(gracefulSchemaReload: {
+    drainTimeout: number;
+    pinSubscriptions?: boolean;
+    subscriptionRetirementSpread?: number;
+  }) {
+    const stack = new AsyncDisposableStack();
+    const schemaA = tickingSubgraph('genA');
+    const schemaB = tickingSubgraph('genB');
+    const yogaA = stack.use(createYoga({ schema: schemaA, logging: false }));
+    const serverA = stack.use(await createDisposableServer(yogaA));
+    const yogaB = stack.use(createYoga({ schema: schemaB, logging: false }));
+    const serverB = stack.use(await createDisposableServer(yogaB));
+    const sdlA = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaA, url: `${serverA.url}/graphql` },
+    ]);
+    const sdlB = await composeLocalSchemasWithApollo([
+      { name: 'upstream', schema: schemaB, url: `${serverB.url}/graphql` },
+    ]);
+    const state = { useSecond: false };
+    const gw = stack.use(
+      createGatewayRuntime({
+        supergraph: () => (state.useSecond ? sdlB : sdlA),
+        pollingInterval: 100,
+        gracefulSchemaReload,
+        logging: false,
+      }),
+    );
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genA');
+    return { gw, state, stack };
+  }
+
+  it('keeps a pinned subscription streaming on the superseded generation until the drain timeout', async () => {
+    const { gw, state, stack } = await setup({
+      drainTimeout: 1_500,
+      pinSubscriptions: true,
+    });
+    await using _ = stack;
+
+    const old = subscribeTicks(gw);
+    await until(() => old.values.length >= 2, 'first ticks from genA');
+
+    state.useSecond = true;
+    await waitForGeneration(gw, 'genB');
+    const swappedAt = Date.now();
+
+    // The old subscription is still served by generation A after the swap...
+    await until(
+      () => old.values.filter((v) => v.at > swappedAt).length >= 3,
+      'ticks after the swap',
+    );
+    expect(old.endedAt).toBeNull();
+    expect(new Set(old.values.map((v) => v.value))).toEqual(new Set(['genA']));
+
+    // ...while a new subscription lands on generation B.
+    const fresh = subscribeTicks(gw);
+    await until(() => fresh.values.length >= 1, 'first tick from genB');
+    expect(fresh.values[0]!.value).toBe('genB');
+
+    // drainTimeout is still the hard bound: it force-disposes generation A and
+    // the pinned subscription ends the way it always did.
+    await old.done;
+    expect(old.endedAt! - swappedAt).toBeGreaterThanOrEqual(1_000);
+    expect(JSON.stringify(old.last)).toContain('SCHEMA_RELOAD');
+    expect(fresh.endedAt).toBeNull();
+    fresh.dispose();
+  });
+
+  it("retires the superseded generation's subscriptions spread over subscriptionRetirementSpread", async () => {
+    const spread = 900;
+    const { gw, state, stack } = await setup({
+      drainTimeout: 10_000,
+      pinSubscriptions: true,
+      subscriptionRetirementSpread: spread,
+    });
+    await using _ = stack;
+
+    const subs = [subscribeTicks(gw), subscribeTicks(gw), subscribeTicks(gw)];
+    await until(
+      () => subs.every((s) => s.values.length >= 1),
+      'every subscription ticking',
+    );
+
+    state.useSecond = true;
+    await waitForGeneration(gw, 'genB');
+    const swappedAt = Date.now();
+
+    await Promise.all(subs.map((s) => s.done));
+    const endedAt = subs.map((s) => s.endedAt!).sort((a, b) => a - b);
+
+    // Not a burst: three subscriptions spaced spread/3 apart (0, 300, 600ms).
+    expect(endedAt[2]! - endedAt[0]!).toBeGreaterThanOrEqual(400);
+    expect(endedAt[2]! - swappedAt).toBeLessThan(spread + 1_000);
+    // A plain completion, no SCHEMA_RELOAD notice: the last message is a tick.
+    for (const s of subs) {
+      expect(s.last).toMatchObject({ data: { tick: 'genA' } });
+    }
+    // The last one retired was still receiving genA events after the first
+    // one ended — no gap while waiting its turn.
+    const lastRetired = subs.find((s) => s.endedAt === endedAt[2])!;
+    expect(
+      lastRetired.values.some((v) => v.at > endedAt[0]! && v.value === 'genA'),
+    ).toBe(true);
+    // Generation A is gone once its last subscription ended; B serves.
+    expect((await runOperation(gw, `{ ping }`)).data?.['ping']).toBe('genB');
+  });
+
+  it('rejects subscriptionRetirementSpread without pinSubscriptions', () => {
+    expect(() =>
+      createGatewayRuntime({
+        supergraph: () => `type Query { ping: String }`,
+        gracefulSchemaReload: {
+          drainTimeout: 1_000,
+          subscriptionRetirementSpread: 500,
+        },
+        logging: false,
+      }),
+    ).toThrow(/requires gracefulSchemaReload.pinSubscriptions/);
   });
 });


### PR DESCRIPTION
Follow-up to #2551, the second half of the comment there. Opening as a draft on purpose: this is a working, tested implementation so the proposal is concrete rather than hand-wavy, but treat it as a demonstration of the shape. If you'd rather have it split, renamed, reduced to the pin alone, or done differently, I'm glad to rework it or drop it.

Two opt-in options on `gracefulSchemaReload`, both default off:

- **`pinSubscriptions`**: `onSubscribe` pins a subscription to the schema generation that admitted it, the same bookkeeping `onExecute` already does for queries and mutations, released when the stream ends. A reload then no longer ends every subscription on the instance at once: the superseded generation keeps serving them until each stream ends, or until `drainTimeout` force-disposes it (ending whatever is left with `SCHEMA_RELOAD`, as today). The overlap is bounded by `drainTimeout`, which addresses the "alive indefinitely" concern that kept subscriptions out of #2449.
- **`subscriptionRetirementSpread`** (requires `pinSubscriptions`): after a reload, the superseded generation's subscriptions are ended one by one at evenly spaced, randomly ordered moments inside the window, each as a plain stream completion (what a client sees on shutdown, so every client already handles it by resubscribing). Until its moment a subscription keeps receiving events from the old generation, so there is no gap; clients resubscribe against the new schema as a trickle instead of a burst.

Implementation notes:

- The pin mirrors `onExecute` exactly (`retainGenerationFor(args.schema)`, release on `onEnd` / `onSubscribeError` / rejected executor lookup).
- Retirement is driven from the manager's `onUnifiedGraphChange` callback, which runs synchronously with the generation swap, so a subscription admitted in the same tick is attributed to the schema it validated against. Streams are wrapped only when a spread is configured; the wrapper has a single wake slot, so nothing accumulates on a long-lived stream.
- `drainTimeout` stays the hard bound and should be longer than the spread.

Tests (black-box, in `graceful-schema-reload.test.ts`): a pinned subscription keeps streaming from the superseded generation after the swap while a new one lands on the new generation, then ends at `drainTimeout` as before; three subscriptions retired over a 900ms spread end roughly 300ms apart with no error frame, the last one still receiving old-generation events after the first ended, and the old generation is gone afterwards; the spread without the pin is rejected at config time.

Relation to #2552: independent. If both land, the retry there could re-execute at the retirement moment instead of completing, so clients see nothing at all; happy to do that as a follow-up.
