### PR TITLE
fix(stitch): do not mutate the caller's resolvers in stitchSchemas

### DIFF
--- a/.changeset/stitch-do-not-mutate-resolvers.md
+++ b/.changeset/stitch-do-not-mutate-resolvers.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/stitch': patch
+---
+
+`stitchSchemas` no longer mutates the resolver objects passed in `resolvers`.
+
+The wrapper it adds around resolvers of fields that return a merged type (so the merged type's fields get resolved) used to be written back into the caller's field config (`existing.resolve = wrappedResolve`). A resolver map reused across `stitchSchemas` calls — a gateway's additional resolvers on every supergraph reload — therefore gained one wrapper per call, and every wrapper kept its call's `stitchingInfo`, and with it the entire superseded schema, subschemas and executors, reachable: a heap leak of one schema generation per reload. The merged resolver map is now cloned before the wrappers are added.

--- a/.changeset/stitch-do-not-mutate-resolvers.md
+++ b/.changeset/stitch-do-not-mutate-resolvers.md
@@ -4,4 +4,8 @@
 
 `stitchSchemas` no longer mutates the resolver objects passed in `resolvers`.
 
-The wrapper it adds around resolvers of fields that return a merged type (so the merged type's fields get resolved) used to be written back into the caller's field config (`existing.resolve = wrappedResolve`). A resolver map reused across `stitchSchemas` calls — a gateway's additional resolvers on every supergraph reload — therefore gained one wrapper per call, and every wrapper kept its call's `stitchingInfo`, and with it the entire superseded schema, subschemas and executors, reachable: a heap leak of one schema generation per reload. The merged resolver map is now cloned before the wrappers are added.
+The wrapper it adds around resolvers of fields that return a merged type (so the merged type's fields get resolved) used to be written back into the caller's field config (`existing.resolve = wrappedResolve`). A resolver map reused across `stitchSchemas` calls — a gateway's additional resolvers on every supergraph reload — therefore gained one wrapper per call, and every wrapper kept its call's `stitchingInfo`, and with it the entire superseded schema, subschemas and executors, reachable: a heap leak of one schema generation per reload.
+
+Nesting also changed behaviour, because `wrappedResolve` closes over its own call's `stitchingInfo` and the innermost (oldest) wrapper runs first: such a field hydrated through a superseded call's stitching plan and executors, and once that hydration satisfied the selection the newest wrapper found nothing left to resolve.
+
+The merged resolver map is now cloned before the wrappers are added. Enum value maps, scalars, union and input type resolvers and plain resolver functions are still passed through by reference, so their identities are unchanged.

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -103,7 +103,16 @@ export function stitchSchemas<
     } as any);
   }
 
-  const resolverMap: IResolvers = mergeResolvers(resolvers);
+  // addLocalFieldResolvers writes the wrappers it builds back into this map, so
+  // clone it two levels first and leave the caller's resolver objects untouched.
+  // A resolver map reused across stitchSchemas calls (a gateway's additional
+  // resolvers on every schema reload) would otherwise gain one wrapper per call,
+  // each closing over that call's stitchingInfo and keeping the whole superseded
+  // schema alive.
+  const resolverMap: IResolvers = cloneResolverMap(
+    mergeResolvers(resolvers),
+    schema,
+  );
 
   const finalResolvers = inheritResolversFromInterfaces
     ? extendResolversFromInterfaces(schema, resolverMap)
@@ -189,6 +198,47 @@ function stripCustomDirectiveUsages(types: GraphQLNamedType[]): void {
       }
     }
   }
+}
+
+function isResolverRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Copies the resolver map one level, and the field configs of object and
+ * interface types one level more, so addLocalFieldResolvers can write its
+ * wrappers into the copy. Every other entry (enum value maps, scalar
+ * instances or configs, union and input type resolvers, functions) is passed
+ * through by reference: it is never mutated, and enum internal values in
+ * particular must keep their identity.
+ */
+function cloneResolverMap(
+  resolverMap: IResolvers,
+  schema: GraphQLSchema,
+): IResolvers {
+  const cloned: IResolvers = {};
+  for (const typeName in resolverMap) {
+    const typeResolvers = resolverMap[typeName];
+    if (typeResolvers === undefined) {
+      continue;
+    }
+    const type = schema.getType(typeName);
+    if (
+      !isResolverRecord(typeResolvers) ||
+      (!isObjectType(type) && !isInterfaceType(type))
+    ) {
+      cloned[typeName] = typeResolvers;
+      continue;
+    }
+    const fieldConfigs: Record<string, unknown> = typeResolvers;
+    const clonedType: Record<string, unknown> = {};
+    for (const fieldName in fieldConfigs) {
+      const field = fieldConfigs[fieldName];
+      clonedType[fieldName] = isResolverRecord(field) ? { ...field } : field;
+    }
+    cloned[typeName] = clonedType as IResolvers[string];
+  }
+  return cloned;
 }
 
 /**

--- a/packages/stitch/tests/resolverMapNotMutated.test.ts
+++ b/packages/stitch/tests/resolverMapNotMutated.test.ts
@@ -150,4 +150,86 @@ describe('stitchSchemas does not mutate the resolvers it is given', () => {
       });
     }
   });
+
+  // The mutation is not only a leak: `wrappedResolve` closes over its own
+  // call's `stitchingInfo`, and when the wrappers nest the innermost (oldest)
+  // one runs first. So a field reusing the caller's config hydrates through a
+  // superseded call's stitching plan and executors, and once that hydration
+  // fills the selection the newest wrapper finds nothing missing to resolve.
+  it('resolves through the current subschemas after the resolvers are reused', async () => {
+    const subschemaForGeneration = (generation: string) => ({
+      schema: makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+          type Person {
+            id: ID!
+            name: String
+          }
+          type Account {
+            id: ID!
+            ownerId: ID!
+          }
+          type Query {
+            personById(id: ID!): Person
+            account(id: ID!): Account
+          }
+        `,
+        resolvers: {
+          Query: {
+            // the generation is baked into this subschema's data, so the answer
+            // names whichever generation actually served the delegation
+            personById: (_: unknown, { id }: { id: string }) => ({
+              id,
+              name: `person-${id}-from-${generation}`,
+            }),
+            account: (_: unknown, { id }: { id: string }) => ({
+              id,
+              ownerId: '7',
+            }),
+          },
+        },
+      }),
+      merge: { Person: personMerge },
+    });
+
+    // the long-lived object: built once, handed to every call
+    const additionalResolvers = {
+      Account: {
+        owner: {
+          selectionSet: '{ ownerId }',
+          // returns only the merge key, so `name` must be delegated
+          resolve: (account: { ownerId: string }) => ({ id: account.ownerId }),
+        },
+      },
+    };
+
+    const ownerName = async (generation: string) => {
+      const schema = stitchSchemas({
+        subschemas: [subschemaForGeneration(generation)],
+        typeDefs: /* GraphQL */ `
+          extend type Account {
+            owner: Person
+          }
+        `,
+        resolvers: [additionalResolvers],
+      });
+      const result = await graphql({
+        schema,
+        source: /* GraphQL */ `
+          {
+            account(id: "1") {
+              owner {
+                name
+              }
+            }
+          }
+        `,
+      });
+      expect(result.errors).toBeUndefined();
+      return (result.data as any).account.owner.name;
+    };
+
+    expect(await ownerName('generation-1')).toBe('person-7-from-generation-1');
+    expect(await ownerName('generation-2')).toBe('person-7-from-generation-2');
+    expect(await ownerName('generation-3')).toBe('person-7-from-generation-3');
+  });
 });

--- a/packages/stitch/tests/resolverMapNotMutated.test.ts
+++ b/packages/stitch/tests/resolverMapNotMutated.test.ts
@@ -1,0 +1,153 @@
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { graphql, GraphQLEnumType } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import { stitchSchemas } from '../src/stitchSchemas.js';
+
+// stitchSchemas wraps every user resolver whose field returns a merged type so
+// the merged type's fields get resolved (addLocalFieldResolvers). That wrapper
+// must land on the schema, not on the caller's resolver objects: a gateway that
+// reuses one `resolvers` object across schema reloads would otherwise wrap the
+// previous wrapper on every call, and every wrapper keeps its call's
+// stitchingInfo — the entire superseded schema — reachable.
+describe('stitchSchemas does not mutate the resolvers it is given', () => {
+  const personMerge = {
+    fieldName: 'personById',
+    args: (originalResult: any) => ({ id: originalResult.id }),
+    selectionSet: '{ id }',
+  };
+  // Enum internal value as an object: enum maps must pass through by
+  // reference, or the value loses its identity in the stitched schema.
+  const paidTier = { code: 'paid' };
+  const subschemas = () => [
+    {
+      schema: makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+          type Person {
+            id: ID!
+            name: String
+          }
+          type Query {
+            personById(id: ID!): Person
+          }
+        `,
+        resolvers: {
+          Query: {
+            personById: (_: unknown, { id }: { id: string }) => ({
+              id,
+              name: `person-${id}`,
+            }),
+          },
+        },
+      }),
+      merge: { Person: personMerge },
+    },
+    {
+      schema: makeExecutableSchema({
+        typeDefs: /* GraphQL */ `
+          type Person {
+            id: ID!
+            email: String
+          }
+          type Account {
+            id: ID!
+            ownerId: ID!
+            tier: Tier
+          }
+          enum Tier {
+            FREE
+            PAID
+          }
+          type Query {
+            personById(id: ID!): Person
+            account(id: ID!): Account
+          }
+        `,
+        resolvers: {
+          Query: {
+            personById: (_: unknown, { id }: { id: string }) => ({
+              id,
+              email: `${id}@example.com`,
+            }),
+            account: (_: unknown, { id }: { id: string }) => ({
+              id,
+              ownerId: '7',
+              tier: paidTier,
+            }),
+          },
+          Tier: { FREE: { code: 'free' }, PAID: paidTier },
+        },
+      }),
+      merge: { Person: personMerge },
+    },
+  ];
+
+  it('keeps the caller resolve functions and configs identical across repeated calls', async () => {
+    const resolveOwner = (account: { ownerId: string }) => ({
+      id: account.ownerId,
+    });
+    // Field config object returning the merged type Person — exactly what
+    // addLocalFieldResolvers wraps — next to an enum value map that must not
+    // be copied.
+    const additionalResolvers = {
+      Account: {
+        owner: { selectionSet: '{ ownerId }', resolve: resolveOwner },
+      },
+      Tier: { FREE: { code: 'free' }, PAID: paidTier },
+    };
+    const stitch = () =>
+      stitchSchemas({
+        subschemas: subschemas(),
+        typeDefs: /* GraphQL */ `
+          extend type Account {
+            owner: Person
+            label: String
+          }
+        `,
+        // Two maps for the same type: mergeResolvers deep-merges them into a
+        // new `Account` object, but still reuses the `owner` field config by
+        // reference, so this is the case where the wrapper reached the caller.
+        resolvers: [additionalResolvers, { Account: { label: () => 'acct' } }],
+      });
+
+    const first = stitch();
+    expect(additionalResolvers.Account.owner.resolve).toBe(resolveOwner);
+
+    const second = stitch();
+    expect(additionalResolvers.Account.owner.resolve).toBe(resolveOwner);
+    expect(additionalResolvers.Account.owner.selectionSet).toBe('{ ownerId }');
+    expect(additionalResolvers.Tier.PAID).toBe(paidTier);
+    expect(
+      (second.getType('Tier') as GraphQLEnumType).getValue('PAID')?.value,
+    ).toBe(paidTier);
+
+    // The wrapper is on the schema, and the stitched field still resolves the
+    // merged type through it on both builds.
+    for (const schema of [first, second]) {
+      const result = await graphql({
+        schema,
+        source: /* GraphQL */ `
+          {
+            account(id: "a1") {
+              owner {
+                id
+                name
+                email
+              }
+              label
+              tier
+            }
+          }
+        `,
+      });
+      expect(result).toEqual({
+        data: {
+          account: {
+            owner: { id: '7', name: 'person-7', email: '7@example.com' },
+            label: 'acct',
+            tier: 'PAID',
+          },
+        },
+      });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #2592.

## Problem

`stitchSchemas` wraps every user resolver whose field returns a merged type so the merged type's fields get resolved (`addLocalFieldResolvers`). The wrapper is written back into the caller's own field config:

```ts
if (existing != null && typeof existing === 'object') {
  existing.resolve = wrappedResolve;
}
```

`wrappedResolve` closes over `baseResolve` (the previous `existing.resolve`) and this call's `stitchingInfo`. When the same `resolvers` object is passed to `stitchSchemas` again — which is what `@graphql-mesh/fusion-runtime` does with `additionalResolvers` on every supergraph reload — the second call wraps the first call's wrapper, the third wraps the second, and so on. Every wrapper in the chain keeps its call's `stitchingInfo` reachable: the subschema map, every subschema's `GraphQLSchema`, executors and transports of a schema generation that has otherwise been disposed.

We hit this in production on a Hive Gateway (`@graphql-hive/gateway` 2.11.2, stitch 10.2.2) that reloads its supergraph without restarting: heap grew by ~135 MB per reload, linear in the number of reloads, until Node aborted at the V8 heap limit after ~6 reloads. Heap-snapshot retainer paths for every stale `GraphQLSchema` went through `additionalResolvers.<Type>.<field>.resolve → wrappedResolve → wrappedResolve → …`. With this change the heap is flat across reloads (216 → 219 MB over four reloads in the same setup).

## It is also a behaviour bug, not only a leak

`wrappedResolve` closes over *its own* call's `stitchingInfo`, and when the wrappers nest the innermost — oldest — one runs first. So a field whose config is reused hydrates through a superseded call's stitching plan and executors, and once that hydration satisfies the requested selection the newest wrapper finds nothing missing and returns it unchanged.

A test that gives each generation its own subschema data shows it directly. On `main`:

```
call 1: "person-7-from-generation-1"   OK
call 2: "person-7-from-generation-1"   expected "person-7-from-generation-2"
call 3: "person-7-from-generation-1"   expected "person-7-from-generation-3"
```

Every later call keeps answering from generation 1. In a reloading gateway the executors of the superseded generation still point at the same subgraph URLs, so requests do go out and the data looks plausible — the stale part is the plan, which is why this can run for a long time without being noticed.

## Fix

Clone the merged resolver map two levels (type maps and field config objects; functions and custom scalar instances pass through by reference) before `addLocalFieldResolvers` runs, so the wrapper lands on the copy that `addResolversToSchema` consumes and the caller's objects stay untouched.

The clone is limited to object and interface types, the only ones `addLocalFieldResolvers` writes into; enum value maps, scalar instances or configs, union and input type resolvers and functions pass through by reference, so enum internal values keep their identity. It deliberately does not test for plain objects: `mergeResolvers` deep-merges a type that appears in more than one map into an object whose prototype is not `Object.prototype`, while still reusing the field config objects by reference — exactly the case that leaked for us (a type with both user resolvers and `@resolveTo`-generated ones).

## Test

`packages/stitch/tests/resolverMapNotMutated.test.ts` stitches twice with the same `resolvers` (passed as two maps for one type) and asserts the caller's `resolve` function and `selectionSet` are unchanged, an enum value map keeps its object identity, and the stitched field still resolves the merged type on both schemas. It fails on `main` with `expected [Function wrappedResolve] to be [Function resolveOwner]`.

A second case in the same file covers the behaviour above: it stitches three times with one long-lived resolver map, each call over a subschema whose data names its generation, and asserts the delegated field answers from the current one. It fails on `main` with `expected 'person-7-from-generation-1' to be 'person-7-from-generation-2'`.

The full unit project passes with both (`1726 passed | 21 skipped | 2 todo`), as do `check:types`, `check:lint` and `prettier --check`.

Changeset included (`@graphql-tools/stitch`: patch).



