### PR TITLE
Fix prototype pollution in Rust QP when projecting a field aliased to `__proto__`

### DIFF
--- a/.changeset/sour-olives-share.md
+++ b/.changeset/sour-olives-share.md
@@ -1,0 +1,19 @@
+---
+'@graphql-hive/router-runtime': patch
+---
+
+Fix prototype pollution when projecting a field aliased to `__proto__`
+
+Response keys come from client-controlled GraphQL aliases. Projecting a selection set into a plain object made `result['__proto__']` resolve to `Object.prototype`, and the merge branch then assigned attacker-controlled fields onto it - polluting the global prototype for the lifetime of the gateway process.
+
+```graphql
+{
+  field1 {
+    __proto__: field2 {
+      poc: echo(input: "pwned")
+    }
+  }
+}
+```
+
+Projected objects are now created with a `null` prototype, so `__proto__` is treated as an ordinary response key.

--- a/.changeset/sour-olives-share.md
+++ b/.changeset/sour-olives-share.md
@@ -6,14 +6,4 @@ Fix prototype pollution when projecting a field aliased to `__proto__`
 
 Response keys come from client-controlled GraphQL aliases. Projecting a selection set into a plain object made `result['__proto__']` resolve to `Object.prototype`, and the merge branch then assigned attacker-controlled fields onto it - polluting the global prototype for the lifetime of the gateway process.
 
-```graphql
-{
-  field1 {
-    __proto__: field2 {
-      poc: echo(input: "pwned")
-    }
-  }
-}
-```
-
 Projected objects are now created with a `null` prototype, so `__proto__` is treated as an ordinary response key.

--- a/packages/router-runtime/src/executor.ts
+++ b/packages/router-runtime/src/executor.ts
@@ -1546,7 +1546,9 @@ function projectSelectionSet(
       return null;
     }
   }
-  const result: Record<string, any> = {};
+  // null proto because response keys come from client-controlled aliases, `__proto__` would
+  // otherwise hit Object.prototype on read and merge attacker data into it
+  const result: Record<string, any> = Object.create(null);
   selectionLoop: for (const selection of selectionSet.selections) {
     if (selection.directives?.length) {
       for (const directiveNode of selection.directives) {

--- a/packages/router-runtime/tests/projectSelectionSet.spec.ts
+++ b/packages/router-runtime/tests/projectSelectionSet.spec.ts
@@ -1,0 +1,57 @@
+import { createGatewayTester } from '@graphql-hive/gateway-testing';
+import { assertSingleExecutionValue } from '@internal/testing';
+import { afterEach, expect, it } from 'vitest';
+import { unifiedGraphHandler } from '../src/index';
+
+afterEach(() => {
+  // clean up in case the pollution actually happened, otherwise every other test gets weird
+  delete (Object.prototype as any).poc;
+});
+
+it('does not pollute Object.prototype through a __proto__ alias', async () => {
+  await using gw = createGatewayTester({
+    unifiedGraphHandler,
+    subgraphs: [
+      {
+        name: 'echo',
+        schema: {
+          typeDefs: /* GraphQL */ `
+            type Query {
+              field1: Field1
+            }
+            type Field1 {
+              field2: Field2
+            }
+            type Field2 {
+              echo(input: String!): String!
+            }
+          `,
+          resolvers: {
+            Query: {
+              field1: () => ({ field2: {} }),
+            },
+            Field2: {
+              echo: (_: unknown, { input }: { input: string }) => input,
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  const res = await gw.execute({
+    query: /* GraphQL */ `
+      {
+        field1 {
+          __proto__: field2 {
+            poc: echo(input: "pwned")
+          }
+        }
+      }
+    `,
+  });
+  assertSingleExecutionValue(res);
+
+  expect(Object.hasOwn(Object.prototype, 'poc')).toBe(false);
+  expect(res.errors).toBeUndefined();
+});

--- a/packages/router-runtime/tests/projectSelectionSet.spec.ts
+++ b/packages/router-runtime/tests/projectSelectionSet.spec.ts
@@ -44,7 +44,7 @@ it('does not pollute Object.prototype through a __proto__ alias', async () => {
       {
         field1 {
           __proto__: field2 {
-            poc: echo(input: "pwned")
+            poc: echo(input: "go")
           }
         }
       }


### PR DESCRIPTION
Response keys come from client-controlled GraphQL aliases. Projecting a selection set into a plain object made `result['__proto__']` resolve to `Object.prototype`, and the merge branch then assigned attacker-controlled fields onto it - polluting the global prototype for the lifetime of the gateway process.

Projected objects are now created with a `null` prototype, so `__proto__` is treated as an ordinary response key.
