### PR TITLE
Drop prototype polluting keys from subgraph results before merging them

### DIFF
--- a/.changeset/shiny-berries-divide.md
+++ b/.changeset/shiny-berries-divide.md
@@ -1,0 +1,10 @@
+---
+'@graphql-tools/federation': patch
+'@graphql-tools/delegate': patch
+---
+
+Drop prototype polluting keys from subgraph results before merging them
+
+Response keys named `__proto__`, `constructor` or `prototype`, which a client can produce with a field alias, were only filtered at the top level of a merged result. Nested occurrences were passed to `mergeDeep`, which walks the prototype chain and could end up writing to `Object.prototype` or `Function.prototype`.
+
+Such keys are now removed at every depth of a subgraph result before it takes part in a merge, and `projectDataSelectionSet` no longer treats an inherited property as an already projected field.

--- a/packages/delegate/src/isPrototypePollutingKey.ts
+++ b/packages/delegate/src/isPrototypePollutingKey.ts
@@ -12,3 +12,28 @@ export function isPrototypePollutingKey(
   // @ts-expect-error - typings are incorrect
   return prototypePollutingKeys.includes(key);
 }
+
+/**
+ * Removes prototype polluting keys from the given value, in place and at every depth.
+ *
+ * Response data coming from a subgraph can contain keys such as `__proto__` or
+ * `constructor` when the client aliases a field to one of those names. Deep merging
+ * such data walks the prototype chain and can end up writing to `Object.prototype` or
+ * `Function.prototype`, so the keys are dropped before any merge happens.
+ */
+export function removePrototypePollutingKeys<T>(value: T): T {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      removePrototypePollutingKeys(item);
+    }
+  } else if (value && typeof value === 'object' && !(value instanceof Error)) {
+    for (const key of Object.keys(value)) {
+      if (isPrototypePollutingKey(key)) {
+        delete (value as Record<string, unknown>)[key];
+      } else {
+        removePrototypePollutingKeys((value as Record<string, unknown>)[key]);
+      }
+    }
+  }
+  return value;
+}

--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -22,7 +22,10 @@ import {
   SelectionSetNode,
 } from 'graphql';
 import { getCoercedVariableValues } from './getCoercedVariableValues.js';
-import { isPrototypePollutingKey } from './isPrototypePollutingKey.js';
+import {
+  isPrototypePollutingKey,
+  removePrototypePollutingKeys,
+} from './isPrototypePollutingKey.js';
 import { leftOverByDelegationPlan, PLAN_LEFT_OVER } from './leftOver.js';
 import { Subschema } from './Subschema.js';
 import {
@@ -187,7 +190,10 @@ export function handleResolverResult(
       continue;
     }
     const existingPropValue = object[responseKey];
-    const sourcePropValue = resolverResult[responseKey];
+    // nested keys are dangerous too, the merges below recurse into them
+    const sourcePropValue = removePrototypePollutingKeys(
+      resolverResult[responseKey],
+    );
     if (
       responseKey === '__typename' &&
       existingPropValue !== sourcePropValue &&

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -9,6 +9,7 @@ import {
   MergedFieldConfig,
   MergedTypeConfig,
   OBJECT_SUBSCHEMA_SYMBOL,
+  removePrototypePollutingKeys,
   SubschemaConfig,
   subtractSelectionSets,
   Transform,
@@ -2472,7 +2473,7 @@ function mergeResults(results: unknown[], getFieldNames: () => Set<string>) {
     } else if (result instanceof Error) {
       errors.push(result);
     } else if (result != null) {
-      datas.push(result);
+      datas.push(removePrototypePollutingKeys(result));
     }
   }
   if (datas.length) {

--- a/packages/federation/src/utils.ts
+++ b/packages/federation/src/utils.ts
@@ -53,7 +53,10 @@ export function projectDataSelectionSet(
           data[responseKey],
           selection.selectionSet,
         );
-        if (projectedData[fieldName]) {
+        if (
+          Object.prototype.hasOwnProperty.call(projectedData, fieldName) &&
+          projectedData[fieldName]
+        ) {
           if (
             projectedKeyData != null &&
             !(projectedKeyData instanceof Error)

--- a/packages/federation/tests/shared-root.test.ts
+++ b/packages/federation/tests/shared-root.test.ts
@@ -646,4 +646,200 @@ describe('Shared Root Fields', () => {
       ],
     });
   });
+
+  it('Aliased shared root fields named after object built-ins', async () => {
+    const subgraphA = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollo.dev/federation/v2.3"
+            import: ["@key", "@shareable"]
+          )
+
+        type Query {
+          shared: Shared @shareable
+        }
+
+        type Shared @key(fields: "id") {
+          id: ID!
+          fieldA: String
+        }
+      `),
+      resolvers: {
+        Query: {
+          shared: () => ({ id: '1', fieldA: 'from subgraph A' }),
+        },
+      },
+    });
+
+    const subgraphB = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollo.dev/federation/v2.3"
+            import: ["@key", "@shareable"]
+          )
+
+        type Query {
+          shared: Shared @shareable
+        }
+
+        type Shared @key(fields: "id") {
+          id: ID!
+          fieldB: Child1
+        }
+
+        type Child1 {
+          child: Child2
+        }
+
+        type Child2 {
+          value: String
+        }
+      `),
+      resolvers: {
+        Query: {
+          shared: () => ({
+            id: '1',
+            fieldB: { child: { value: 'from subgraph B' } },
+          }),
+        },
+      },
+    });
+
+    const gatewaySchema = await getStitchedSchemaFromLocalSchemas({
+      localSchemas: { a: subgraphA, b: subgraphB },
+    });
+
+    const result = await normalizedExecutor({
+      schema: gatewaySchema,
+      document: parse(/* GraphQL */ `
+        {
+          shared {
+            fieldA
+            constructor: fieldB {
+              __proto__: child {
+                call: value
+              }
+            }
+          }
+        }
+      `),
+    });
+
+    // the aliased dangerous keys are dropped, the rest of the response is intact
+    expect(result).toEqual({
+      data: {
+        shared: {
+          fieldA: 'from subgraph A',
+          constructor: null,
+        },
+      },
+    });
+    expect(({} as any).call).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty('call');
+    expect(typeof Function.prototype.call).toBe('function');
+    expect(() => (() => 'still works').call(null)).not.toThrow();
+  });
+
+  it('Aliased entity fields named after object built-ins', async () => {
+    const subgraphA = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollo.dev/federation/v2.3"
+            import: ["@key", "@shareable"]
+          )
+
+        type Query {
+          user: User
+        }
+
+        type User @key(fields: "id") {
+          id: ID!
+          profile: Profile @shareable
+        }
+
+        type Profile @shareable {
+          name: String
+        }
+      `),
+      resolvers: {
+        Query: {
+          user: () => ({ id: '1', profile: { name: 'from subgraph A' } }),
+        },
+      },
+    });
+
+    const subgraphB = buildSubgraphSchema({
+      typeDefs: parse(/* GraphQL */ `
+        extend schema
+          @link(
+            url: "https://specs.apollo.dev/federation/v2.3"
+            import: ["@key", "@shareable"]
+          )
+
+        type User @key(fields: "id") {
+          id: ID!
+          profile: Profile @shareable
+        }
+
+        type Profile @shareable {
+          deep: Deep
+        }
+
+        type Deep {
+          inner: Inner
+        }
+
+        type Inner {
+          value: String
+        }
+      `),
+      resolvers: {
+        User: {
+          __resolveReference: (ref: { id: string }) => ({
+            id: ref.id,
+            profile: { deep: { inner: { value: 'from subgraph B' } } },
+          }),
+        },
+      },
+    });
+
+    const gatewaySchema = await getStitchedSchemaFromLocalSchemas({
+      localSchemas: { a: subgraphA, b: subgraphB },
+    });
+
+    const result = await normalizedExecutor({
+      schema: gatewaySchema,
+      document: parse(/* GraphQL */ `
+        {
+          user {
+            profile {
+              name
+              constructor: deep {
+                __proto__: inner {
+                  call: value
+                }
+              }
+            }
+          }
+        }
+      `),
+    });
+
+    expect(result).toEqual({
+      data: {
+        user: {
+          profile: {
+            name: 'from subgraph A',
+            constructor: null,
+          },
+        },
+      },
+    });
+    expect(({} as any).call).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty('call');
+    expect(typeof Function.prototype.call).toBe('function');
+  });
 });


### PR DESCRIPTION
Basically mitigation for https://github.com/ardatan/graphql-tools/pull/8423.

Response keys named `__proto__`, `constructor` or `prototype`, which a client can produce with a field alias, were only filtered at the top level of a merged result. Nested occurrences were passed to `mergeDeep`, which walks the prototype chain and could end up writing to `Object.prototype` or `Function.prototype`.

Such keys are now removed at every depth of a subgraph result before it takes part in a merge, and `projectDataSelectionSet` no longer treats an inherited property as an already projected field.